### PR TITLE
fix(release): resolve plugin sync against bundled CLIs

### DIFF
--- a/claude-plugin/hooks/scripts/sync-check.sh
+++ b/claude-plugin/hooks/scripts/sync-check.sh
@@ -5,13 +5,58 @@
 set -euo pipefail
 
 PLUGIN_DIR="${1:-$(dirname "$0")/../..}"
+PLUGIN_DIR="$(cd "$PLUGIN_DIR" && pwd)"
+REPO_ROOT="$(cd "$PLUGIN_DIR/.." && pwd)"
 ERRORS=0
+
+resolve_cli() {
+    local name="$1"
+    local bundled=""
+
+    case "$name" in
+        fest) bundled="$REPO_ROOT/fest/bin/fest" ;;
+        camp) bundled="$REPO_ROOT/camp/bin/camp" ;;
+        *) return 1 ;;
+    esac
+
+    if [[ -x "$bundled" ]]; then
+        printf '%s\n' "$bundled"
+        return 0
+    fi
+
+    if command -v "$name" >/dev/null 2>&1; then
+        command -v "$name"
+        return 0
+    fi
+
+    return 1
+}
+
+FEST_BIN="${FEST_BIN:-$(resolve_cli fest || true)}"
+CAMP_BIN="${CAMP_BIN:-$(resolve_cli camp || true)}"
 
 check_command() {
     local cmd="$1"
     local subcmd="$2"
+    local cli=""
 
-    if ! $cmd help "$subcmd" >/dev/null 2>&1; then
+    case "$cmd" in
+        fest) cli="$FEST_BIN" ;;
+        camp) cli="$CAMP_BIN" ;;
+        *)
+            echo "WARNING: unsupported CLI '$cmd' in plugin sync check" >&2
+            ERRORS=$((ERRORS + 1))
+            return
+            ;;
+    esac
+
+    if [[ -z "$cli" ]]; then
+        echo "WARNING: '$cmd' executable not found for plugin sync check" >&2
+        ERRORS=$((ERRORS + 1))
+        return
+    fi
+
+    if ! "$cli" help "$subcmd" >/dev/null 2>&1; then
         echo "WARNING: '$cmd $subcmd' not found in CLI — plugin may reference a removed command" >&2
         ERRORS=$((ERRORS + 1))
     fi


### PR DESCRIPTION
## Summary
- resolve plugin sync checks against the bundled fest and camp binaries in this repo
- fall back to PATH only when bundled binaries are not present
- prevent tag releases from failing before GoReleaser runs

## Verification
- just plugin check
- env PATH="/usr/bin:/bin" bash claude-plugin/hooks/scripts/sync-check.sh claude-plugin