### PR TITLE
fix festival release readiness checks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,8 +83,8 @@ jobs:
       - name: Verify tagged camp/fest pins
         run: just test release-pins "${{ steps.release_channel.outputs.mode }}"
 
-      - name: Check mirrored docs
-        run: just test doc-sync
+      - name: Check bundled submodule module resolution
+        run: just test bundled-module-resolution
 
       - name: Check docs profile
         run: just test docs-profile

--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -45,19 +45,19 @@ preflight mode="stable":
 [confirm("This will create a dev festival release from the latest dev tags in camp and fest. Continue?")]
 dev:
     just test release-operator
-    go -C tools/release-operator run . bundle dev --repo-root ../..
+    go -C tools/release-operator run . bundle --repo-root ../.. dev
 
 [no-cd]
 [confirm("This will create an RC festival release from the latest rc tags in camp and fest. Continue?")]
 rc:
     just test release-operator
-    go -C tools/release-operator run . bundle rc --repo-root ../..
+    go -C tools/release-operator run . bundle --repo-root ../.. rc
 
 [no-cd]
 [confirm("This will create a stable festival release from the latest stable tags in camp and fest. Continue?")]
 stable:
     just test release-operator
-    go -C tools/release-operator run . bundle stable --repo-root ../..
+    go -C tools/release-operator run . bundle --repo-root ../.. stable
 
 # Run GoReleaser dry run (no publish)
 [no-cd]

--- a/.justfiles/test.just
+++ b/.justfiles/test.just
@@ -15,6 +15,12 @@ all: fest camp release-operator release-notes
 doc-sync:
     bash scripts/check-doc-sync.sh
 
+# Verify bundled camp/fest submodules resolve from a clean module cache rather
+# than inheriting whatever happens to already be installed on the host.
+[no-cd]
+bundled-module-resolution:
+    go -C tools/release-operator run . check-bundled-modules --repo-root ../..
+
 # Verify stable/dev CLI doc generation uses the intended command surface
 [no-cd]
 docs-profile:

--- a/tools/release-operator/commands.go
+++ b/tools/release-operator/commands.go
@@ -100,6 +100,39 @@ func (r *repoContext) runDocs(mode releaseMode) error {
 	return r.justEnv(mode.DocsEnv, "docs", "all")
 }
 
+func (r *repoContext) checkBundledModuleResolution(name string) error {
+	tag, err := r.exactTag(name)
+	if err != nil {
+		return err
+	}
+	if tag == "" {
+		tag = "HEAD"
+	}
+
+	modCacheDir, err := os.MkdirTemp("", "festival-"+name+"-gomodcache-")
+	if err != nil {
+		return fmt.Errorf("create %s module cache: %w", name, err)
+	}
+	defer os.RemoveAll(modCacheDir)
+
+	goCacheDir, err := os.MkdirTemp("", "festival-"+name+"-gocache-")
+	if err != nil {
+		return fmt.Errorf("create %s build cache: %w", name, err)
+	}
+	defer os.RemoveAll(goCacheDir)
+
+	env := map[string]string{
+		"GOWORK":     "off",
+		"GOMODCACHE": modCacheDir,
+		"GOCACHE":    goCacheDir,
+	}
+	if _, err := cmdOutput(r.submodulePath(name), env, "go", "mod", "download"); err != nil {
+		return fmt.Errorf("%s %s module graph does not resolve from a clean cache: %w", name, tag, err)
+	}
+
+	return nil
+}
+
 func (r *repoContext) exactTag(name string) (string, error) {
 	out, err := cmdOutput(r.submodulePath(name), nil, "git", "describe", "--tags", "--exact-match", "HEAD")
 	if err != nil {
@@ -339,6 +372,19 @@ func runStatus(ctx *repoContext) error {
 	return nil
 }
 
+func runCheckBundledModules(ctx *repoContext) error {
+	fmt.Println("Checking bundled submodule module resolution:")
+	for _, sub := range submodules {
+		fmt.Printf("  %s: ", sub)
+		if err := ctx.checkBundledModuleResolution(sub); err != nil {
+			fmt.Println("failed")
+			return err
+		}
+		fmt.Println("ok")
+	}
+	return nil
+}
+
 func runPreflight(ctx *repoContext, mode releaseMode) error {
 	fmt.Println("=== Release Preflight ===")
 	fmt.Println()
@@ -383,8 +429,8 @@ func runPreflight(ctx *repoContext, mode releaseMode) error {
 	}
 	fmt.Println()
 
-	fmt.Println("Checking mirrored docs:")
-	if err := ctx.just("test", "doc-sync"); err != nil {
+	fmt.Println("Checking bundled submodule module resolution:")
+	if err := ctx.just("test", "bundled-module-resolution"); err != nil {
 		return err
 	}
 	fmt.Println()

--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -31,15 +31,11 @@ func run(args []string) error {
 		printHelp(os.Stdout)
 		return nil
 	case "bundle":
-		fs := commandFlags("bundle")
-		repoRoot := fs.String("repo-root", ".", "festival repo root")
-		if err := fs.Parse(args[1:]); err != nil {
+		repoRoot, channel, err := parseBundleArgs(args[1:])
+		if err != nil {
 			return err
 		}
-		if fs.NArg() != 1 {
-			return errors.New("usage: release-operator bundle <dev|rc|stable> [--repo-root PATH]")
-		}
-		return runBundleWithRoot(*repoRoot, fs.Arg(0))
+		return runBundleWithRoot(repoRoot, channel)
 	case "pin":
 		fs := commandFlags("pin")
 		repoRoot := fs.String("repo-root", ".", "festival repo root")
@@ -176,6 +172,18 @@ func commandFlags(name string) *flag.FlagSet {
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	return fs
+}
+
+func parseBundleArgs(args []string) (repoRoot string, channel string, err error) {
+	fs := commandFlags("bundle")
+	repoRootFlag := fs.String("repo-root", ".", "festival repo root")
+	if err := fs.Parse(args); err != nil {
+		return "", "", err
+	}
+	if fs.NArg() != 1 {
+		return "", "", errors.New("usage: release-operator bundle <dev|rc|stable> [--repo-root PATH]")
+	}
+	return *repoRootFlag, fs.Arg(0), nil
 }
 
 func repoContextFromArgs(name string, args []string) (*repoContext, error) {

--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -80,6 +80,12 @@ func run(args []string) error {
 			return err
 		}
 		return runRequireStablePublishCredentials(ctx)
+	case "check-bundled-modules":
+		ctx, err := repoContextFromArgs("check-bundled-modules", args[1:])
+		if err != nil {
+			return err
+		}
+		return runCheckBundledModules(ctx)
 	case "draft-from-latest":
 		fs := commandFlags("draft-from-latest")
 		repoRoot := fs.String("repo-root", ".", "festival repo root")
@@ -195,6 +201,7 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "Support:")
 	fmt.Fprintln(out, "  just release status")
 	fmt.Fprintln(out, "  just release preflight [stable|rc|dev]")
+	fmt.Fprintln(out, "  just test bundled-module-resolution")
 	fmt.Fprintln(out, "  just release dry-run")
 	fmt.Fprintln(out, "  just release cleanup <tag>")
 }

--- a/tools/release-operator/main_test.go
+++ b/tools/release-operator/main_test.go
@@ -7,6 +7,20 @@ import (
 	"testing"
 )
 
+func TestParseBundleArgsAcceptsRepoRootBeforeChannel(t *testing.T) {
+	repoRoot, channel, err := parseBundleArgs([]string{"--repo-root", "/tmp/festival", "dev"})
+	if err != nil {
+		t.Fatalf("parseBundleArgs returned error: %v", err)
+	}
+
+	if got, want := repoRoot, "/tmp/festival"; got != want {
+		t.Fatalf("repoRoot = %q, want %q", got, want)
+	}
+	if got, want := channel, "dev"; got != want {
+		t.Fatalf("channel = %q, want %q", got, want)
+	}
+}
+
 func TestLatestReachableTagForModeIgnoresOffBranchTags(t *testing.T) {
 	repo := initTestRepo(t)
 


### PR DESCRIPTION
## Summary
- remove workspace-only `doc-sync` from the release workflow and release preflight path
- add a clean-cache bundled module resolution check for the pinned `fest` and `camp` submodules
- fail early with the real bundled dependency error instead of relying on whatever happens to already be cached locally

## Why
`festival` should not report a local campaign workspace doc drift as the primary release blocker. The release path should fail on actual bundled release problems.

Right now the real blocker is upstream and unchanged by this PR: bundled `fest v0.2.1` still requires `github.com/Obedience-Corp/camp v0.2.0-dev.1`, and that tag does not exist. This PR makes that failure explicit during `just release preflight stable` and in the tag-triggered release workflow.

## Validation
- `go -C tools/release-operator test ./...`
- `goreleaser check`
- `just test bundled-module-resolution` (expected to fail on `fest v0.2.1 -> camp v0.2.0-dev.1`)
- `just release preflight stable` (expected to fail on the same bundled module resolution error)
