### PR TITLE
Site: support ?theme=dark URL param override

### DIFF
--- a/themes/festival/layouts/_default/baseof.html
+++ b/themes/festival/layouts/_default/baseof.html
@@ -57,8 +57,14 @@
   <script>
   // Theme toggle
   (function() {
+    var urlTheme = null;
+    try {
+      urlTheme = new URLSearchParams(window.location.search).get('theme');
+    } catch (e) {}
     var defaultTheme = {{ if .IsHome }}"light"{{ else }}"dark"{{ end }};
-    var theme = localStorage.getItem('theme') || defaultTheme;
+    var theme = (urlTheme === 'dark' || urlTheme === 'light')
+      ? urlTheme
+      : (localStorage.getItem('theme') || defaultTheme);
     document.documentElement.setAttribute('data-theme', theme);
   })();
 


### PR DESCRIPTION
## Summary

Lets embeds/previews of fest.build force a theme via URL. When the `theme` query param is `dark` or `light`, it takes precedence over the existing `localStorage` value and the home/non-home default. Without the param, behavior is unchanged.

Motivation: the corp-site `/work` page embeds the fest.build landing in an iframe. Without this, the iframe ignores the surrounding dark theme and renders light-mode by default. Paired PR in corp-site already passes `?theme=dark` to the iframe.

## Change
`themes/festival/layouts/_default/baseof.html` — inline theme-init script now reads `URLSearchParams` first and falls back to localStorage + the home/non-home default as before.

## Deploy note
The live site is rebuilt by `.github/workflows/pages.yaml` on `v*` tag pushes (or manual `workflow_dispatch`). The embedded iframe at corp-site `/work` will keep showing light mode until a new deploy picks up this template change.

## Test plan
- [ ] `just docs build && just docs serve` locally; visit `/?theme=dark` and confirm dark theme applies on the home page (which normally defaults to light).
- [ ] Visit `/` with no query param and confirm home still defaults to light.
- [ ] Visit any non-home page with `?theme=light` and confirm it renders light despite the non-home default being dark.
- [ ] Confirm the manual theme toggle still works after load (updates `data-theme` and localStorage).