### PR TITLE
Simplify stable festival bundle releases

### DIFF
--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -50,19 +50,19 @@ plan mode="stable" fest="latest" camp="latest":
 # - keep: keep the currently pinned exact tag for that submodule
 # - vX.Y.Z: pin a specific release tag
 [no-cd]
-[confirm("This will create a dev festival release from the latest dev tags in camp and fest. Continue?")]
+[confirm("This will create a dev festival release using the selected fest/camp tags. Run 'just release plan mode=dev fest=... camp=...' first if you want to see the exact tags. Continue?")]
 dev fest="latest" camp="latest":
     just test release-operator
     go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" dev
 
 [no-cd]
-[confirm("This will create an RC festival release from the latest rc tags in camp and fest. Continue?")]
+[confirm("This will create an RC festival release using the selected fest/camp tags. Run 'just release plan mode=rc fest=... camp=...' first if you want to see the exact tags. Continue?")]
 rc fest="latest" camp="latest":
     just test release-operator
     go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" rc
 
 [no-cd]
-[confirm("This will create a stable festival release from selected stable camp/fest tags on main. Continue?")]
+[confirm("This will create a stable festival release on main using the selected fest/camp tags. Run 'just release plan mode=stable fest=... camp=...' first if you want to see the exact tags. Continue?")]
 stable fest="latest" camp="latest":
     just test release-operator
     go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" stable

--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -39,25 +39,33 @@ status:
 preflight mode="stable":
     go -C tools/release-operator run . preflight --repo-root ../.. --mode "{{mode}}"
 
-# One-command bundled release from the latest already-created camp/fest tags.
-# This does not create camp/fest tags. Those repos own their own versions.
+# Preview the next bundled release without mutating submodule refs, docs, or tags.
+[no-cd]
+plan mode="stable" fest="latest" camp="latest":
+    go -C tools/release-operator run . plan --repo-root ../.. --mode "{{mode}}" --fest-tag "{{fest}}" --camp-tag "{{camp}}"
+
+# One-command bundled release from already-created camp/fest tags.
+# Selectors:
+# - latest: use the newest tag for the requested release channel
+# - keep: keep the currently pinned exact tag for that submodule
+# - vX.Y.Z: pin a specific release tag
 [no-cd]
 [confirm("This will create a dev festival release from the latest dev tags in camp and fest. Continue?")]
-dev:
+dev fest="latest" camp="latest":
     just test release-operator
-    go -C tools/release-operator run . bundle --repo-root ../.. dev
+    go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" dev
 
 [no-cd]
 [confirm("This will create an RC festival release from the latest rc tags in camp and fest. Continue?")]
-rc:
+rc fest="latest" camp="latest":
     just test release-operator
-    go -C tools/release-operator run . bundle --repo-root ../.. rc
+    go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" rc
 
 [no-cd]
-[confirm("This will create a stable festival release from the latest stable tags in camp and fest. Continue?")]
-stable:
+[confirm("This will create a stable festival release from selected stable camp/fest tags on main. Continue?")]
+stable fest="latest" camp="latest":
     just test release-operator
-    go -C tools/release-operator run . bundle --repo-root ../.. stable
+    go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" stable
 
 # Run GoReleaser dry run (no publish)
 [no-cd]

--- a/tools/release-operator/commands.go
+++ b/tools/release-operator/commands.go
@@ -134,11 +134,7 @@ func (r *repoContext) checkBundledModuleResolution(name string) error {
 }
 
 func (r *repoContext) exactTag(name string) (string, error) {
-	out, err := cmdOutput(r.submodulePath(name), nil, "git", "describe", "--tags", "--exact-match", "HEAD")
-	if err != nil {
-		return "", nil
-	}
-	return strings.TrimSpace(out), nil
+	return exactTagAt(r.submodulePath(name))
 }
 
 func (r *repoContext) exactComponentTags() (string, string, error) {

--- a/tools/release-operator/commands.go
+++ b/tools/release-operator/commands.go
@@ -170,7 +170,23 @@ func (r *repoContext) cachedDiffExists(paths ...string) (bool, error) {
 	return false, nil
 }
 
-func (r *repoContext) commitPinnedArtifacts(festTag, campTag string) error {
+func releaseCommitMessage(currentFestTag, currentCampTag, festTag, campTag string) string {
+	festChanged := currentFestTag != festTag
+	campChanged := currentCampTag != campTag
+
+	switch {
+	case festChanged && campChanged:
+		return fmt.Sprintf("Release: pin fest %s and camp %s", festTag, campTag)
+	case festChanged:
+		return fmt.Sprintf("Release: pin fest %s", festTag)
+	case campChanged:
+		return fmt.Sprintf("Release: pin camp %s", campTag)
+	default:
+		return fmt.Sprintf("Release: refresh bundled docs for fest %s and camp %s", festTag, campTag)
+	}
+}
+
+func (r *repoContext) commitPinnedArtifacts(currentFestTag, currentCampTag, festTag, campTag string) error {
 	hasDiff, err := r.cachedDiffExists("fest", "camp", "docs/cli-reference")
 	if err != nil {
 		return err
@@ -179,7 +195,7 @@ func (r *repoContext) commitPinnedArtifacts(festTag, campTag string) error {
 		fmt.Printf("Submodule pointers and docs already at fest=%s, camp=%s; no release commit needed.\n", festTag, campTag)
 		return nil
 	}
-	if err := r.runGit("commit", "-m", fmt.Sprintf("Release: pin fest %s and camp %s", festTag, campTag)); err != nil {
+	if err := r.runGit("commit", "-m", releaseCommitMessage(currentFestTag, currentCampTag, festTag, campTag)); err != nil {
 		return err
 	}
 	return r.runGit("push", "origin", "HEAD")
@@ -231,7 +247,7 @@ func (r *repoContext) checkoutSubmoduleTag(name, tag string) error {
 	return r.runGitSubmodule(name, "checkout", "--detach", tag)
 }
 
-func (r *repoContext) pinFromLatest(modeName string) error {
+func (r *repoContext) pinFromLatest(modeName, festSelector, campSelector string) error {
 	mode, err := modeConfig(modeName)
 	if err != nil {
 		return err
@@ -243,8 +259,14 @@ func (r *repoContext) pinFromLatest(modeName string) error {
 		return err
 	}
 
-	festTag := latestTagForMode(r.submodulePath("fest"), mode.Name)
-	campTag := latestTagForMode(r.submodulePath("camp"), mode.Name)
+	festTag, err := resolveSelectedTag(r.submodulePath("fest"), mode.Name, festSelector)
+	if err != nil {
+		return err
+	}
+	campTag, err := resolveSelectedTag(r.submodulePath("camp"), mode.Name, campSelector)
+	if err != nil {
+		return err
+	}
 	if festTag == "" || campTag == "" {
 		fmt.Printf("ERROR: Missing %s tags.\n", mode.Name)
 		fmt.Printf("fest latest %s: %s\n", mode.Name, valueOrNone(festTag))
@@ -476,17 +498,18 @@ func runPreflight(ctx *repoContext, mode releaseMode) error {
 	}
 	fmt.Println()
 	fmt.Println("Preflight complete.")
-	fmt.Println("  One-command: just release dev | just release rc | just release stable")
+	fmt.Println("  One-command: just release stable fest=latest camp=keep")
+	fmt.Println("  Planner:     just release plan mode=stable fest=latest camp=keep")
 	fmt.Println("  Manual:      just release draft <version> | draft-rc <version> <n> | draft-dev <version> <n>")
 	return nil
 }
 
-func runDraftFromLatest(ctx *repoContext, version string, mode releaseMode, iteration int) error {
+func runDraftFromLatest(ctx *repoContext, version string, mode releaseMode, iteration int, festSelector, campSelector, currentFestTag, currentCampTag string) error {
 	releaseTag := releaseTagFor(mode, version, iteration)
 	if err := ctx.ensureTagAbsent(releaseTag); err != nil {
 		return err
 	}
-	if err := ctx.pinFromLatest(mode.Name); err != nil {
+	if err := ctx.pinFromLatest(mode.Name, festSelector, campSelector); err != nil {
 		return err
 	}
 	if err := ctx.runDocs(mode); err != nil {
@@ -504,7 +527,7 @@ func runDraftFromLatest(ctx *repoContext, version string, mode releaseMode, iter
 		return fmt.Errorf("submodules are not pinned to exact %s tags after refresh", mode.Name)
 	}
 
-	if err := ctx.commitPinnedArtifacts(festTag, campTag); err != nil {
+	if err := ctx.commitPinnedArtifacts(currentFestTag, currentCampTag, festTag, campTag); err != nil {
 		return err
 	}
 	if err := runPreflight(ctx, mode); err != nil {
@@ -595,7 +618,7 @@ func runDraftBootstrap(ctx *repoContext, festivalVersion, festVersion, campVersi
 	if err := ctx.stageReleaseArtifacts(); err != nil {
 		return err
 	}
-	if err := ctx.commitPinnedArtifacts(festTag, campTag); err != nil {
+	if err := ctx.commitPinnedArtifacts("", "", festTag, campTag); err != nil {
 		return err
 	}
 
@@ -619,13 +642,49 @@ func runDraftBootstrap(ctx *repoContext, festivalVersion, festVersion, campVersi
 	return nil
 }
 
-func runBundleWithRoot(repoRoot, channel string) error {
-	ctx, err := newRepoContext(repoRoot)
+func runPlanWithRoot(opts planOptions) error {
+	ctx, err := newRepoContext(opts.RepoRoot)
 	if err != nil {
 		return err
 	}
 
-	state, err := collectState(ctx.Root, channel)
+	state, err := collectState(ctx.Root, opts.Channel, opts.FestSelector, opts.CampSelector)
+	if err != nil {
+		return err
+	}
+
+	plan, err := operator.DeriveBundlePlan(state)
+	if err != nil {
+		return err
+	}
+	mode, err := modeConfig(plan.Channel)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println("== Release Plan ==")
+	fmt.Printf("  channel: %s\n", opts.Channel)
+	fmt.Printf("  festival branch: %s\n", state.CurrentBranch)
+	fmt.Printf("  planned release tag: %s\n", plan.ReleaseTag)
+	fmt.Printf("  fest: %s -> %s (%s)\n", valueOrNone(state.CurrentPinnedFestTag), state.FestTag, opts.FestSelector)
+	fmt.Printf("  camp: %s -> %s (%s)\n", valueOrNone(state.CurrentPinnedCampTag), state.CampTag, opts.CampSelector)
+	fmt.Printf("  docs profile: %s\n", mode.BuildProfile)
+	fmt.Printf("  commit message: %s\n", releaseCommitMessage(state.CurrentPinnedFestTag, state.CurrentPinnedCampTag, state.FestTag, state.CampTag))
+	fmt.Println()
+	fmt.Println(plan.Description)
+	fmt.Printf("Command: just release %s fest=%s camp=%s\n", opts.Channel, opts.FestSelector, opts.CampSelector)
+	fmt.Println()
+	return nil
+}
+
+func runBundleWithRoot(opts bundleOptions) error {
+	ctx, err := newRepoContext(opts.RepoRoot)
+	if err != nil {
+		return err
+	}
+
+	state, err := collectState(ctx.Root, opts.Channel, opts.FestSelector, opts.CampSelector)
 	if err != nil {
 		return err
 	}
@@ -642,15 +701,15 @@ func runBundleWithRoot(repoRoot, channel string) error {
 	fmt.Println()
 	fmt.Println("== Current State ==")
 	fmt.Printf("  festival branch: %s\n", state.CurrentBranch)
-	fmt.Printf("  fest tag: %s\n", state.FestTag)
-	fmt.Printf("  camp tag: %s\n", state.CampTag)
+	fmt.Printf("  fest: %s -> %s (%s)\n", valueOrNone(state.CurrentPinnedFestTag), state.FestTag, opts.FestSelector)
+	fmt.Printf("  camp: %s -> %s (%s)\n", valueOrNone(state.CurrentPinnedCampTag), state.CampTag, opts.CampSelector)
 	fmt.Println()
-	fmt.Printf("== %s Bundle Release ==\n", strings.ToUpper(channel))
+	fmt.Printf("== %s Bundle Release ==\n", strings.ToUpper(opts.Channel))
 	fmt.Println(plan.Description)
-	fmt.Printf("Using latest already-created %s tags from camp and fest.\n", channel)
+	fmt.Printf("Using selected %s tags for camp and fest.\n", opts.Channel)
 	fmt.Println()
 
-	return runDraftFromLatest(ctx, plan.Version, mode, plan.Iteration)
+	return runDraftFromLatest(ctx, plan.Version, mode, plan.Iteration, opts.FestSelector, opts.CampSelector, state.CurrentPinnedFestTag, state.CurrentPinnedCampTag)
 }
 
 func runCleanup(ctx *repoContext, tag string) error {

--- a/tools/release-operator/internal/operator/plan.go
+++ b/tools/release-operator/internal/operator/plan.go
@@ -55,16 +55,19 @@ type ParsedPrerelease struct {
 }
 
 type BundleInput struct {
-	Channel                      string
-	CurrentBranch                string
-	FestTag                      string
-	CampTag                      string
-	LatestFestivalDev            string
-	LatestFestivalPromotableRC   string
-	LatestFestivalStable         string
-	LatestFestivalVersionRC      string
-	CurrentCommitTaggedLatestDev bool
-	CurrentCommitTaggedVersionRC bool
+	Channel                         string
+	CurrentBranch                   string
+	FestTag                         string
+	CampTag                         string
+	CurrentPinnedFestTag            string
+	CurrentPinnedCampTag            string
+	LatestFestivalDev               string
+	LatestFestivalPromotableRC      string
+	LatestFestivalStable            string
+	LatestFestivalVersionRC         string
+	CurrentCommitTaggedLatestDev    bool
+	CurrentCommitTaggedLatestStable bool
+	CurrentCommitTaggedVersionRC    bool
 }
 
 type BundlePlan struct {
@@ -169,33 +172,28 @@ func planStable(in BundleInput) (BundlePlan, error) {
 	if in.CurrentBranch != "main" {
 		return BundlePlan{}, fmt.Errorf("stable releases must be created from the main branch")
 	}
-	if in.LatestFestivalPromotableRC == "" {
-		return BundlePlan{}, fmt.Errorf("main does not contain a festival rc to promote")
+	if in.LatestFestivalStable == "" {
+		return BundlePlan{}, fmt.Errorf("main does not contain a prior festival stable release; use draft-bootstrap or draft --version")
 	}
 
-	rc, err := ParseRCTag(in.LatestFestivalPromotableRC)
+	stable, err := ParseStableTag(in.LatestFestivalStable)
 	if err != nil {
 		return BundlePlan{}, err
 	}
-
-	if in.LatestFestivalStable != "" {
-		stable, err := ParseStableTag(in.LatestFestivalStable)
-		if err != nil {
-			return BundlePlan{}, err
-		}
-		if stable.Compare(rc.Version) >= 0 {
-			return BundlePlan{}, fmt.Errorf("there is no newer festival rc line to promote")
-		}
+	if in.CurrentCommitTaggedLatestStable &&
+		in.FestTag == in.CurrentPinnedFestTag &&
+		in.CampTag == in.CurrentPinnedCampTag {
+		return BundlePlan{}, fmt.Errorf("latest festival stable release already bundles the selected component tags on the current commit")
 	}
 
-	version := rc.Version.String()
+	version := stable.BumpPatch().String()
 	return BundlePlan{
 		Channel:     "stable",
 		Version:     version,
 		ReleaseTag:  "v" + version,
 		DraftRecipe: "draft-stable-from-latest",
 		DraftArgs:   []string{version},
-		Description: fmt.Sprintf("Festival version line: v%s (promoting %s on main)", version, in.LatestFestivalPromotableRC),
+		Description: fmt.Sprintf("Festival version line: v%s (patch bump from %s on main)", version, in.LatestFestivalStable),
 	}, nil
 }
 

--- a/tools/release-operator/internal/operator/plan_test.go
+++ b/tools/release-operator/internal/operator/plan_test.go
@@ -49,25 +49,26 @@ func TestDeriveBundlePlanRCFromReleaseBranch(t *testing.T) {
 	}
 }
 
-func TestDeriveBundlePlanStablePromotesLatestRC(t *testing.T) {
+func TestDeriveBundlePlanStableBumpsLatestStablePatch(t *testing.T) {
 	plan, err := DeriveBundlePlan(BundleInput{
-		Channel:                    "stable",
-		CurrentBranch:              "main",
-		FestTag:                    "v0.2.0",
-		CampTag:                    "v0.2.1",
-		LatestFestivalPromotableRC: "v0.2.0-rc.3",
-		LatestFestivalStable:       "v0.1.1",
+		Channel:              "stable",
+		CurrentBranch:        "main",
+		FestTag:              "v0.2.0",
+		CampTag:              "v0.2.1",
+		CurrentPinnedFestTag: "v0.1.9",
+		CurrentPinnedCampTag: "v0.2.1",
+		LatestFestivalStable: "v0.1.1",
 	})
 	if err != nil {
 		t.Fatalf("DeriveBundlePlan returned error: %v", err)
 	}
 
-	if got, want := plan.ReleaseTag, "v0.2.0"; got != want {
+	if got, want := plan.ReleaseTag, "v0.1.2"; got != want {
 		t.Fatalf("ReleaseTag = %q, want %q", got, want)
 	}
 }
 
-func TestDeriveBundlePlanStableRejectsWhenMainHasNoPromotableRC(t *testing.T) {
+func TestDeriveBundlePlanStableRejectsWhenMainHasNoStableHistory(t *testing.T) {
 	_, err := DeriveBundlePlan(BundleInput{
 		Channel:       "stable",
 		CurrentBranch: "main",
@@ -79,14 +80,16 @@ func TestDeriveBundlePlanStableRejectsWhenMainHasNoPromotableRC(t *testing.T) {
 	}
 }
 
-func TestDeriveBundlePlanStableRejectsWhenStableAlreadyCaughtUp(t *testing.T) {
+func TestDeriveBundlePlanStableRejectsWhenCurrentCommitAlreadyBundlesSelectedTags(t *testing.T) {
 	_, err := DeriveBundlePlan(BundleInput{
-		Channel:                    "stable",
-		CurrentBranch:              "main",
-		FestTag:                    "v0.2.0",
-		CampTag:                    "v0.2.1",
-		LatestFestivalPromotableRC: "v0.2.0-rc.3",
-		LatestFestivalStable:       "v0.2.0",
+		Channel:                         "stable",
+		CurrentBranch:                   "main",
+		FestTag:                         "v0.2.0",
+		CampTag:                         "v0.2.1",
+		CurrentPinnedFestTag:            "v0.2.0",
+		CurrentPinnedCampTag:            "v0.2.1",
+		LatestFestivalStable:            "v0.2.0",
+		CurrentCommitTaggedLatestStable: true,
 	})
 	if err == nil {
 		t.Fatal("expected error")

--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -374,15 +374,21 @@ func collectState(repoRoot, channel, festSelector, campSelector string) (operato
 	return state, nil
 }
 
+// exactTagAt returns the tag pointing at HEAD in dir, or "" if HEAD is untagged.
+// Uses `git tag --points-at HEAD` because it exits 0 with empty stdout for the
+// untagged-HEAD case, avoiding locale- and version-dependent stderr parsing that
+// `git describe --exact-match` would require. If multiple tags point at HEAD,
+// the first line (sorted lexicographically by git) is returned.
 func exactTagAt(dir string) (string, error) {
-	out, err := cmdOutput(dir, nil, "git", "describe", "--tags", "--exact-match", "HEAD")
+	out, err := gitOutput(dir, "tag", "--points-at", "HEAD")
 	if err != nil {
-		if strings.Contains(err.Error(), "no tag exactly matches") || strings.Contains(err.Error(), "cannot describe") {
-			return "", nil
-		}
-		return "", fmt.Errorf("git describe --tags --exact-match HEAD: %w", err)
+		return "", err
 	}
-	return strings.TrimSpace(out), nil
+	if out == "" {
+		return "", nil
+	}
+	first, _, _ := strings.Cut(out, "\n")
+	return first, nil
 }
 
 func resolveSelectedTag(dir, mode, selector string) (string, error) {

--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -31,15 +31,23 @@ func run(args []string) error {
 		printHelp(os.Stdout)
 		return nil
 	case "bundle":
-		repoRoot, channel, err := parseBundleArgs(args[1:])
+		opts, err := parseBundleArgs(args[1:])
 		if err != nil {
 			return err
 		}
-		return runBundleWithRoot(repoRoot, channel)
+		return runBundleWithRoot(opts)
+	case "plan":
+		opts, err := parsePlanArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		return runPlanWithRoot(opts)
 	case "pin":
 		fs := commandFlags("pin")
 		repoRoot := fs.String("repo-root", ".", "festival repo root")
 		modeName := fs.String("mode", "stable", "release mode: stable, rc, or dev")
+		festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag")
+		campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
@@ -47,7 +55,7 @@ func run(args []string) error {
 		if err != nil {
 			return err
 		}
-		return ctx.pinFromLatest(*modeName)
+		return ctx.pinFromLatest(*modeName, *festTag, *campTag)
 	case "status":
 		ctx, err := repoContextFromArgs("status", args[1:])
 		if err != nil {
@@ -88,6 +96,8 @@ func run(args []string) error {
 		version := fs.String("version", "", "festival release version without leading v")
 		modeName := fs.String("mode", "stable", "release mode: stable, rc, or dev")
 		iteration := fs.Int("n", 1, "prerelease iteration for rc/dev flows")
+		festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag")
+		campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
@@ -102,7 +112,11 @@ func run(args []string) error {
 		if err != nil {
 			return err
 		}
-		return runDraftFromLatest(ctx, *version, mode, *iteration)
+		state, err := collectState(ctx.Root, mode.Name, *festTag, *campTag)
+		if err != nil {
+			return err
+		}
+		return runDraftFromLatest(ctx, *version, mode, *iteration, *festTag, *campTag, state.CurrentPinnedFestTag, state.CurrentPinnedCampTag)
 	case "draft-bootstrap":
 		fs := commandFlags("draft-bootstrap")
 		repoRoot := fs.String("repo-root", ".", "festival repo root")
@@ -174,16 +188,57 @@ func commandFlags(name string) *flag.FlagSet {
 	return fs
 }
 
-func parseBundleArgs(args []string) (repoRoot string, channel string, err error) {
+type bundleOptions struct {
+	RepoRoot     string
+	Channel      string
+	FestSelector string
+	CampSelector string
+}
+
+type planOptions struct {
+	RepoRoot     string
+	Channel      string
+	FestSelector string
+	CampSelector string
+}
+
+func parseBundleArgs(args []string) (bundleOptions, error) {
 	fs := commandFlags("bundle")
 	repoRootFlag := fs.String("repo-root", ".", "festival repo root")
+	festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag")
+	campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag")
 	if err := fs.Parse(args); err != nil {
-		return "", "", err
+		return bundleOptions{}, err
 	}
 	if fs.NArg() != 1 {
-		return "", "", errors.New("usage: release-operator bundle <dev|rc|stable> [--repo-root PATH]")
+		return bundleOptions{}, errors.New("usage: release-operator bundle <dev|rc|stable> [--repo-root PATH] [--fest-tag latest|keep|vX.Y.Z] [--camp-tag latest|keep|vX.Y.Z]")
 	}
-	return *repoRootFlag, fs.Arg(0), nil
+	return bundleOptions{
+		RepoRoot:     *repoRootFlag,
+		Channel:      fs.Arg(0),
+		FestSelector: *festTag,
+		CampSelector: *campTag,
+	}, nil
+}
+
+func parsePlanArgs(args []string) (planOptions, error) {
+	fs := commandFlags("plan")
+	repoRootFlag := fs.String("repo-root", ".", "festival repo root")
+	modeName := fs.String("mode", "stable", "release mode: stable, rc, or dev")
+	festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag")
+	campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag")
+	if err := fs.Parse(args); err != nil {
+		return planOptions{}, err
+	}
+	if fs.NArg() != 0 {
+		return planOptions{}, errors.New("usage: release-operator plan [--mode stable|rc|dev] [--repo-root PATH] [--fest-tag latest|keep|vX.Y.Z] [--camp-tag latest|keep|vX.Y.Z]")
+	}
+	return planOptions{
+		RepoRoot:     *repoRootFlag,
+		Channel:      *modeName,
+		FestSelector: *festTag,
+		CampSelector: *campTag,
+	}, nil
 }
 
 func repoContextFromArgs(name string, args []string) (*repoContext, error) {
@@ -202,9 +257,10 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "festival release commands")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Primary:")
-	fmt.Fprintln(out, "  just release dev")
-	fmt.Fprintln(out, "  just release rc")
-	fmt.Fprintln(out, "  just release stable")
+	fmt.Fprintln(out, "  just release plan [mode=stable] [fest=latest|keep|vX.Y.Z] [camp=latest|keep|vX.Y.Z]")
+	fmt.Fprintln(out, "  just release dev [fest=latest|keep|vX.Y.Z] [camp=latest|keep|vX.Y.Z]")
+	fmt.Fprintln(out, "  just release rc [fest=latest|keep|vX.Y.Z] [camp=latest|keep|vX.Y.Z]")
+	fmt.Fprintln(out, "  just release stable [fest=latest|keep|vX.Y.Z] [camp=latest|keep|vX.Y.Z]")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Support:")
 	fmt.Fprintln(out, "  just release status")
@@ -214,7 +270,7 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "  just release cleanup <tag>")
 }
 
-func collectState(repoRoot, channel string) (operator.BundleInput, error) {
+func collectState(repoRoot, channel, festSelector, campSelector string) (operator.BundleInput, error) {
 	if channel != "dev" && channel != "rc" && channel != "stable" {
 		return operator.BundleInput{}, fmt.Errorf("channel must be dev, rc, or stable (got %q)", channel)
 	}
@@ -249,11 +305,31 @@ func collectState(repoRoot, channel string) (operator.BundleInput, error) {
 		return operator.BundleInput{}, err
 	}
 
+	currentFestTag, err := exactTagAt(filepath.Join(repoRoot, "fest"))
+	if err != nil {
+		return operator.BundleInput{}, err
+	}
+	currentCampTag, err := exactTagAt(filepath.Join(repoRoot, "camp"))
+	if err != nil {
+		return operator.BundleInput{}, err
+	}
+
+	selectedFestTag, err := resolveSelectedTag(filepath.Join(repoRoot, "fest"), channel, festSelector)
+	if err != nil {
+		return operator.BundleInput{}, err
+	}
+	selectedCampTag, err := resolveSelectedTag(filepath.Join(repoRoot, "camp"), channel, campSelector)
+	if err != nil {
+		return operator.BundleInput{}, err
+	}
+
 	state := operator.BundleInput{
-		Channel:       channel,
-		CurrentBranch: branch,
-		FestTag:       latestTagForMode(filepath.Join(repoRoot, "fest"), channel),
-		CampTag:       latestTagForMode(filepath.Join(repoRoot, "camp"), channel),
+		Channel:              channel,
+		CurrentBranch:        branch,
+		FestTag:              selectedFestTag,
+		CampTag:              selectedCampTag,
+		CurrentPinnedFestTag: currentFestTag,
+		CurrentPinnedCampTag: currentCampTag,
 	}
 	state.LatestFestivalDev, err = latestReachableTagForMode(repoRoot, "dev")
 	if err != nil {
@@ -275,6 +351,13 @@ func collectState(repoRoot, channel string) (operator.BundleInput, error) {
 		}
 		state.CurrentCommitTaggedLatestDev = match
 	}
+	if state.LatestFestivalStable != "" {
+		match, err := headMatchesTag(repoRoot, state.LatestFestivalStable)
+		if err != nil {
+			return operator.BundleInput{}, err
+		}
+		state.CurrentCommitTaggedLatestStable = match
+	}
 
 	if state.CurrentBranch != "" && strings.HasPrefix(state.CurrentBranch, "release/v") {
 		version := strings.TrimPrefix(state.CurrentBranch, "release/v")
@@ -289,6 +372,54 @@ func collectState(repoRoot, channel string) (operator.BundleInput, error) {
 	}
 
 	return state, nil
+}
+
+func exactTagAt(dir string) (string, error) {
+	out, err := cmdOutput(dir, nil, "git", "describe", "--tags", "--exact-match", "HEAD")
+	if err != nil {
+		if strings.Contains(err.Error(), "no tag exactly matches") || strings.Contains(err.Error(), "cannot describe") {
+			return "", nil
+		}
+		return "", fmt.Errorf("git describe --tags --exact-match HEAD: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func resolveSelectedTag(dir, mode, selector string) (string, error) {
+	name := filepath.Base(dir)
+
+	switch selector {
+	case "", "latest":
+		tag := latestTagForMode(dir, mode)
+		if tag == "" {
+			return "", fmt.Errorf("%s has no %s tag to select", name, mode)
+		}
+		return tag, nil
+	case "keep":
+		tag, err := exactTagAt(dir)
+		if err != nil {
+			return "", err
+		}
+		if tag == "" {
+			return "", fmt.Errorf("%s is not pinned to an exact tag, so keep cannot be used", name)
+		}
+		if !operator.TagMatchesMode(tag, mode) {
+			return "", fmt.Errorf("%s keep tag %s does not match %s mode", name, tag, mode)
+		}
+		return tag, nil
+	default:
+		if !operator.TagMatchesMode(selector, mode) {
+			return "", fmt.Errorf("%s tag %s does not match %s mode", name, selector, mode)
+		}
+		out, err := gitOutput(dir, "tag", "-l", selector)
+		if err != nil {
+			return "", err
+		}
+		if strings.TrimSpace(out) == "" {
+			return "", fmt.Errorf("%s tag %s was not found", name, selector)
+		}
+		return selector, nil
+	}
 }
 
 func worktreeDirty(dir string) (bool, error) {

--- a/tools/release-operator/main_test.go
+++ b/tools/release-operator/main_test.go
@@ -8,16 +8,39 @@ import (
 )
 
 func TestParseBundleArgsAcceptsRepoRootBeforeChannel(t *testing.T) {
-	repoRoot, channel, err := parseBundleArgs([]string{"--repo-root", "/tmp/festival", "dev"})
+	opts, err := parseBundleArgs([]string{"--repo-root", "/tmp/festival", "--fest-tag", "keep", "dev"})
 	if err != nil {
 		t.Fatalf("parseBundleArgs returned error: %v", err)
 	}
 
-	if got, want := repoRoot, "/tmp/festival"; got != want {
+	if got, want := opts.RepoRoot, "/tmp/festival"; got != want {
 		t.Fatalf("repoRoot = %q, want %q", got, want)
 	}
-	if got, want := channel, "dev"; got != want {
+	if got, want := opts.Channel, "dev"; got != want {
 		t.Fatalf("channel = %q, want %q", got, want)
+	}
+	if got, want := opts.FestSelector, "keep"; got != want {
+		t.Fatalf("fest selector = %q, want %q", got, want)
+	}
+	if got, want := opts.CampSelector, "latest"; got != want {
+		t.Fatalf("camp selector = %q, want %q", got, want)
+	}
+}
+
+func TestParsePlanArgsAcceptsSelectors(t *testing.T) {
+	opts, err := parsePlanArgs([]string{"--mode", "stable", "--fest-tag", "v0.2.4", "--camp-tag", "keep"})
+	if err != nil {
+		t.Fatalf("parsePlanArgs returned error: %v", err)
+	}
+
+	if got, want := opts.Channel, "stable"; got != want {
+		t.Fatalf("channel = %q, want %q", got, want)
+	}
+	if got, want := opts.FestSelector, "v0.2.4"; got != want {
+		t.Fatalf("fest selector = %q, want %q", got, want)
+	}
+	if got, want := opts.CampSelector, "keep"; got != want {
+		t.Fatalf("camp selector = %q, want %q", got, want)
 	}
 }
 
@@ -66,6 +89,47 @@ func TestLatestReachableTagForModeIgnoresOffBranchTags(t *testing.T) {
 	if got, want := latestTagForMode(repo, "stable"), "v0.2.0"; got != want {
 		t.Fatalf("latestTagForMode(stable) = %q, want %q", got, want)
 	}
+}
+
+func TestResolveSelectedTag(t *testing.T) {
+	t.Run("selects latest keep and explicit tags", func(t *testing.T) {
+		repo := initTestRepo(t)
+
+		writeFile(t, filepath.Join(repo, "CHANGELOG.md"), "stable\n")
+		runGit(t, repo, "add", "CHANGELOG.md")
+		runGit(t, repo, "commit", "-m", "stable release")
+		runGit(t, repo, "tag", "v0.2.0")
+
+		if got, err := resolveSelectedTag(repo, "stable", "latest"); err != nil {
+			t.Fatalf("resolveSelectedTag(latest) error = %v", err)
+		} else if want := "v0.2.0"; got != want {
+			t.Fatalf("resolveSelectedTag(latest) = %q, want %q", got, want)
+		}
+
+		if got, err := resolveSelectedTag(repo, "stable", "keep"); err != nil {
+			t.Fatalf("resolveSelectedTag(keep) error = %v", err)
+		} else if want := "v0.2.0"; got != want {
+			t.Fatalf("resolveSelectedTag(keep) = %q, want %q", got, want)
+		}
+
+		if got, err := resolveSelectedTag(repo, "stable", "v0.1.0"); err != nil {
+			t.Fatalf("resolveSelectedTag(explicit) error = %v", err)
+		} else if want := "v0.1.0"; got != want {
+			t.Fatalf("resolveSelectedTag(explicit) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("keep rejects untagged head", func(t *testing.T) {
+		repo := initTestRepo(t)
+
+		writeFile(t, filepath.Join(repo, "UNTAGGED.md"), "untagged\n")
+		runGit(t, repo, "add", "UNTAGGED.md")
+		runGit(t, repo, "commit", "-m", "untagged commit")
+
+		if _, err := resolveSelectedTag(repo, "stable", "keep"); err == nil {
+			t.Fatal("expected keep selection to fail on untagged HEAD")
+		}
+	})
 }
 
 func initTestRepo(t *testing.T) string {

--- a/tools/release-operator/main_test.go
+++ b/tools/release-operator/main_test.go
@@ -132,6 +132,50 @@ func TestResolveSelectedTag(t *testing.T) {
 	})
 }
 
+func TestExactTagAt(t *testing.T) {
+	t.Run("returns empty for untagged HEAD without error", func(t *testing.T) {
+		repo := initTestRepo(t)
+		writeFile(t, filepath.Join(repo, "untagged.md"), "untagged\n")
+		runGit(t, repo, "add", "untagged.md")
+		runGit(t, repo, "commit", "-m", "untagged")
+
+		got, err := exactTagAt(repo)
+		if err != nil {
+			t.Fatalf("exactTagAt returned error for untagged HEAD: %v", err)
+		}
+		if got != "" {
+			t.Fatalf("exactTagAt = %q, want empty string", got)
+		}
+	})
+
+	t.Run("returns a tag when HEAD is tagged", func(t *testing.T) {
+		repo := initTestRepo(t)
+		got, err := exactTagAt(repo)
+		if err != nil {
+			t.Fatalf("exactTagAt returned error: %v", err)
+		}
+		if want := "v0.1.0"; got != want {
+			t.Fatalf("exactTagAt = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns a single tag when HEAD has multiple", func(t *testing.T) {
+		repo := initTestRepo(t)
+		runGit(t, repo, "tag", "v0.1.0-alias")
+
+		got, err := exactTagAt(repo)
+		if err != nil {
+			t.Fatalf("exactTagAt returned error: %v", err)
+		}
+		if got == "" {
+			t.Fatal("exactTagAt returned empty string, want one of the HEAD tags")
+		}
+		if got != "v0.1.0" && got != "v0.1.0-alias" {
+			t.Fatalf("exactTagAt = %q, want one of v0.1.0 or v0.1.0-alias", got)
+		}
+	})
+}
+
 func initTestRepo(t *testing.T) string {
 	t.Helper()
 


### PR DESCRIPTION
## What changed

This simplifies `festival` release drafting around the path we actually use most often: creating a new stable `festival` release from already-tagged `fest` and `camp` versions on `main`.

The changes are:

- `just release stable` no longer depends on a promotable RC line in `festival`
- stable release planning now bumps the next `festival` patch from the latest stable `festival` tag on `main`
- `just release stable`, `just release rc`, and `just release dev` now accept explicit component selectors:
  - `latest`
  - `keep`
  - an explicit tag like `v0.2.4`
- a new public `just release plan` command shows the selected `fest`/`camp` tags, the planned `festival` tag, and the release commit message before anything mutates git
- release commits are now more specific when only one bundled component changes

## Why

The existing public `festival` release surface pushed operators toward an RC-first workflow even though the codebase already had most of the machinery needed to:

- pin submodules to chosen tags
- regenerate docs
- commit the pin/docs update
- create the `festival` release tag

That useful path was effectively hidden behind private commands, while the visible `stable` flow still required an RC promotion step. That made common releases harder than they needed to be, especially when only one bundled binary changed.

This PR makes the common case direct:

- inspect the release with `just release plan mode=stable fest=latest camp=keep`
- create it with `just release stable fest=latest camp=keep`

## Operator impact

This keeps the existing release-operator model, but changes the stable planner to match current release practice:

- stable releases come from `main`
- they use already-created stable component tags
- they do not require a prior `festival` RC

RC and dev flows remain available.

## Validation

- `just test release-operator`
- `just release`
- `go -C tools/release-operator run . help`
