### PR TITLE
Fix key-value festival release args

### DIFF
--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -45,9 +45,9 @@ func run(args []string) error {
 	case "pin":
 		fs := commandFlags("pin")
 		repoRoot := fs.String("repo-root", ".", "festival repo root")
-		modeName := fs.String("mode", "stable", "release mode: stable, rc, or dev")
-		festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag")
-		campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag")
+		modeName := fs.String("mode", "stable", "release mode: stable, rc, or dev (a mode=... prefix is also accepted)")
+		festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag (a fest=... prefix is also accepted)")
+		campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag (a camp=... prefix is also accepted)")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
@@ -69,7 +69,7 @@ func run(args []string) error {
 	case "preflight":
 		fs := commandFlags("preflight")
 		repoRoot := fs.String("repo-root", ".", "festival repo root")
-		modeName := fs.String("mode", "stable", "release mode: stable, rc, or dev")
+		modeName := fs.String("mode", "stable", "release mode: stable, rc, or dev (a mode=... prefix is also accepted)")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
@@ -98,10 +98,10 @@ func run(args []string) error {
 		fs := commandFlags("draft-from-latest")
 		repoRoot := fs.String("repo-root", ".", "festival repo root")
 		version := fs.String("version", "", "festival release version without leading v")
-		modeName := fs.String("mode", "stable", "release mode: stable, rc, or dev")
+		modeName := fs.String("mode", "stable", "release mode: stable, rc, or dev (a mode=... prefix is also accepted)")
 		iteration := fs.Int("n", 1, "prerelease iteration for rc/dev flows")
-		festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag")
-		campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag")
+		festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag (a fest=... prefix is also accepted)")
+		campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag (a camp=... prefix is also accepted)")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
@@ -221,8 +221,8 @@ type planOptions struct {
 func parseBundleArgs(args []string) (bundleOptions, error) {
 	fs := commandFlags("bundle")
 	repoRootFlag := fs.String("repo-root", ".", "festival repo root")
-	festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag")
-	campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag")
+	festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag (a fest=... prefix is also accepted)")
+	campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag (a camp=... prefix is also accepted)")
 	if err := fs.Parse(args); err != nil {
 		return bundleOptions{}, err
 	}
@@ -240,9 +240,9 @@ func parseBundleArgs(args []string) (bundleOptions, error) {
 func parsePlanArgs(args []string) (planOptions, error) {
 	fs := commandFlags("plan")
 	repoRootFlag := fs.String("repo-root", ".", "festival repo root")
-	modeName := fs.String("mode", "stable", "release mode: stable, rc, or dev")
-	festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag")
-	campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag")
+	modeName := fs.String("mode", "stable", "release mode: stable, rc, or dev (a mode=... prefix is also accepted)")
+	festTag := fs.String("fest-tag", "latest", "fest tag selector: latest, keep, or an explicit tag (a fest=... prefix is also accepted)")
+	campTag := fs.String("camp-tag", "latest", "camp tag selector: latest, keep, or an explicit tag (a camp=... prefix is also accepted)")
 	if err := fs.Parse(args); err != nil {
 		return planOptions{}, err
 	}

--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -55,7 +55,11 @@ func run(args []string) error {
 		if err != nil {
 			return err
 		}
-		return ctx.pinFromLatest(*modeName, *festTag, *campTag)
+		return ctx.pinFromLatest(
+			normalizeOptionalAssignment(*modeName, "mode"),
+			normalizeOptionalAssignment(*festTag, "fest"),
+			normalizeOptionalAssignment(*campTag, "camp"),
+		)
 	case "status":
 		ctx, err := repoContextFromArgs("status", args[1:])
 		if err != nil {
@@ -73,7 +77,7 @@ func run(args []string) error {
 		if err != nil {
 			return err
 		}
-		mode, err := modeConfig(*modeName)
+		mode, err := modeConfig(normalizeOptionalAssignment(*modeName, "mode"))
 		if err != nil {
 			return err
 		}
@@ -104,7 +108,10 @@ func run(args []string) error {
 		if *version == "" {
 			return errors.New("missing required --version")
 		}
-		mode, err := modeConfig(*modeName)
+		modeValue := normalizeOptionalAssignment(*modeName, "mode")
+		festValue := normalizeOptionalAssignment(*festTag, "fest")
+		campValue := normalizeOptionalAssignment(*campTag, "camp")
+		mode, err := modeConfig(modeValue)
 		if err != nil {
 			return err
 		}
@@ -112,11 +119,11 @@ func run(args []string) error {
 		if err != nil {
 			return err
 		}
-		state, err := collectState(ctx.Root, mode.Name, *festTag, *campTag)
+		state, err := collectState(ctx.Root, mode.Name, festValue, campValue)
 		if err != nil {
 			return err
 		}
-		return runDraftFromLatest(ctx, *version, mode, *iteration, *festTag, *campTag, state.CurrentPinnedFestTag, state.CurrentPinnedCampTag)
+		return runDraftFromLatest(ctx, *version, mode, *iteration, festValue, campValue, state.CurrentPinnedFestTag, state.CurrentPinnedCampTag)
 	case "draft-bootstrap":
 		fs := commandFlags("draft-bootstrap")
 		repoRoot := fs.String("repo-root", ".", "festival repo root")
@@ -188,6 +195,15 @@ func commandFlags(name string) *flag.FlagSet {
 	return fs
 }
 
+func normalizeOptionalAssignment(value, key string) string {
+	value = strings.TrimSpace(value)
+	prefix := key + "="
+	if strings.HasPrefix(value, prefix) {
+		return strings.TrimSpace(strings.TrimPrefix(value, prefix))
+	}
+	return value
+}
+
 type bundleOptions struct {
 	RepoRoot     string
 	Channel      string
@@ -216,8 +232,8 @@ func parseBundleArgs(args []string) (bundleOptions, error) {
 	return bundleOptions{
 		RepoRoot:     *repoRootFlag,
 		Channel:      fs.Arg(0),
-		FestSelector: *festTag,
-		CampSelector: *campTag,
+		FestSelector: normalizeOptionalAssignment(*festTag, "fest"),
+		CampSelector: normalizeOptionalAssignment(*campTag, "camp"),
 	}, nil
 }
 
@@ -235,9 +251,9 @@ func parsePlanArgs(args []string) (planOptions, error) {
 	}
 	return planOptions{
 		RepoRoot:     *repoRootFlag,
-		Channel:      *modeName,
-		FestSelector: *festTag,
-		CampSelector: *campTag,
+		Channel:      normalizeOptionalAssignment(*modeName, "mode"),
+		FestSelector: normalizeOptionalAssignment(*festTag, "fest"),
+		CampSelector: normalizeOptionalAssignment(*campTag, "camp"),
 	}, nil
 }
 

--- a/tools/release-operator/main_test.go
+++ b/tools/release-operator/main_test.go
@@ -27,6 +27,23 @@ func TestParseBundleArgsAcceptsRepoRootBeforeChannel(t *testing.T) {
 	}
 }
 
+func TestParseBundleArgsNormalizesKeyValueSelectors(t *testing.T) {
+	opts, err := parseBundleArgs([]string{"--fest-tag", "fest=latest", "--camp-tag", "camp=keep", "stable"})
+	if err != nil {
+		t.Fatalf("parseBundleArgs returned error: %v", err)
+	}
+
+	if got, want := opts.Channel, "stable"; got != want {
+		t.Fatalf("channel = %q, want %q", got, want)
+	}
+	if got, want := opts.FestSelector, "latest"; got != want {
+		t.Fatalf("fest selector = %q, want %q", got, want)
+	}
+	if got, want := opts.CampSelector, "keep"; got != want {
+		t.Fatalf("camp selector = %q, want %q", got, want)
+	}
+}
+
 func TestParsePlanArgsAcceptsSelectors(t *testing.T) {
 	opts, err := parsePlanArgs([]string{"--mode", "stable", "--fest-tag", "v0.2.4", "--camp-tag", "keep"})
 	if err != nil {
@@ -41,6 +58,59 @@ func TestParsePlanArgsAcceptsSelectors(t *testing.T) {
 	}
 	if got, want := opts.CampSelector, "keep"; got != want {
 		t.Fatalf("camp selector = %q, want %q", got, want)
+	}
+}
+
+func TestParsePlanArgsNormalizesKeyValueInputs(t *testing.T) {
+	opts, err := parsePlanArgs([]string{"--mode", "mode=stable", "--fest-tag", "fest=latest", "--camp-tag", "camp=keep"})
+	if err != nil {
+		t.Fatalf("parsePlanArgs returned error: %v", err)
+	}
+
+	if got, want := opts.Channel, "stable"; got != want {
+		t.Fatalf("channel = %q, want %q", got, want)
+	}
+	if got, want := opts.FestSelector, "latest"; got != want {
+		t.Fatalf("fest selector = %q, want %q", got, want)
+	}
+	if got, want := opts.CampSelector, "keep"; got != want {
+		t.Fatalf("camp selector = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeOptionalAssignment(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		key   string
+		want  string
+	}{
+		{
+			name:  "strips matching key prefix",
+			value: "fest=latest",
+			key:   "fest",
+			want:  "latest",
+		},
+		{
+			name:  "preserves plain value",
+			value: "keep",
+			key:   "camp",
+			want:  "keep",
+		},
+		{
+			name:  "ignores non-matching prefix",
+			value: "camp=keep",
+			key:   "fest",
+			want:  "camp=keep",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeOptionalAssignment(tt.value, tt.key); got != tt.want {
+				t.Fatalf("normalizeOptionalAssignment(%q, %q) = %q, want %q", tt.value, tt.key, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What changed

This fixes the follow-up bug in `festival`'s new release command surface where the intended key-value invocation style did not actually work through the `just` wrapper.

The broken case was:

- `just release stable fest=latest camp=keep`
- `just release plan mode=stable fest=latest camp=keep`

`just` was passing `fest=latest`, `camp=keep`, and `mode=stable` through as literal recipe argument values, and the release operator treated them as literal selector strings. That led to errors like:

- `fest tag fest=latest does not match stable mode`

This PR normalizes optional `key=value` assignments at the release-operator boundary, so the public `just` surface now accepts both forms:

- positional: `just release stable latest keep`
- key-value: `just release stable fest=latest camp=keep`

## Why

The whole point of the previous release-flow PR was to make `festival` releases easy to drive from `just`. The advertised command shape needs to work exactly as written, otherwise the command surface is lying to the operator.

This fix keeps the scope small and corrects the parser where the bug actually occurs: between the `just` wrapper and the Go release operator.

## Validation

- `just test release-operator`
- `just release plan mode=stable fest=latest camp=keep`
  - now gets past selector parsing and only stops on the expected branch/dirty-worktree guards while run from the feature branch
