### PR TITLE
Add npm package distribution for Festival

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,15 @@ jobs:
               ;;
           esac
 
+      - name: Validate npm publish credentials
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "::error::Missing required secret NPM_TOKEN"
+            exit 1
+          fi
+
       - name: Validate stable publish credentials
         if: steps.release_channel.outputs.mode == 'stable'
         env:
@@ -137,3 +146,34 @@ jobs:
             --notes-file "${RUNNER_TEMP}/festival-release-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish npm package
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_MODE: ${{ steps.release_channel.outputs.mode }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::Missing required secret NPM_TOKEN"
+            exit 1
+          fi
+
+          version="${GITHUB_REF_NAME#v}"
+          case "${RELEASE_MODE}" in
+            stable) npm_tag="latest" ;;
+            rc) npm_tag="rc" ;;
+            dev) npm_tag="dev" ;;
+            *)
+              echo "::error::Unsupported release mode ${RELEASE_MODE}"
+              exit 1
+              ;;
+          esac
+
+          npm version "${version}" --no-git-tag-version
+          npm publish --access public --tag "${npm_tag}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -234,6 +234,7 @@ release:
 
     | Platform | Command |
     |----------|---------|
+    | npm / pnpm / bun | `npm install -g @obedience-corp/festival` |
     | macOS | `brew install --cask Obedience-Corp/tap/festival` |
     | Arch Linux | `yay -S festival-bin` |
     | Debian/Ubuntu | Download `.deb` from assets below |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ graph TD
 
 ## Install
 
+**npm / pnpm / bun:**
+
+```bash
+npm install -g @obedience-corp/festival
+```
+
 **macOS:**
 
 ```bash
@@ -44,6 +50,26 @@ For now, use WSL2 and the Linux install method above.
 
 - `git` is required. `camp` and `fest` use git internally for campaign init, project management, template sync, and commit-aware workflows.
 - `scc` is recommended but optional. Without it, `camp leverage` features will not work.
+
+## Updating Templates After Upgrades
+
+Festival releases may include updated methodology files, agents, examples, and templates. Upgrading the `fest` binary does not automatically rewrite those files because users often customize their `.festival/` methodology directory and template files.
+
+When a release includes template changes, update in two explicit steps:
+
+```bash
+# Refresh the local system template cache
+fest system sync
+
+# Preview campaign methodology/template changes before applying them
+fest system update --dry-run
+
+# Apply interactively, or create backups before updating
+fest system update
+fest system update --backup
+```
+
+Use `fest system update --force` only when you intentionally want to overwrite local changes. The manual update flow protects customized templates from accidental replacement.
 
 ## Quick Start
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,6 +12,16 @@ Festival includes two CLI tools: **fest** (festival planning) and **camp** (camp
 - `git` is required. Festival depends on it for campaign init, project management, template sync, and commit-aware workflows.
 - `scc` is recommended but optional. Without it, `camp leverage` features will not work.
 
+## npm / pnpm / bun
+
+```bash
+npm install -g @obedience-corp/festival
+```
+
+The npm package downloads the matching Festival GitHub release archive for your
+platform, verifies it against the release checksums, and exposes both `fest` and
+`camp`.
+
 {{< tabs names="macOS, Linux, Windows (Temporarily Paused)" >}}
 
 ### Homebrew (Recommended)

--- a/docs/install.md
+++ b/docs/install.md
@@ -13,6 +13,12 @@ title: "Install Festival"
 The fastest way to install:
 
 ```bash
+npm install -g @obedience-corp/festival
+```
+
+Or use Homebrew:
+
+```bash
 brew install --cask Obedience-Corp/tap/festival
 ```
 
@@ -25,6 +31,12 @@ Or download the latest macOS release directly:
 <div id="install-linux" class="install-platform" style="display:none">
 
 ## Linux
+
+The npm package works on x64 and arm64 Linux:
+
+```bash
+npm install -g @obedience-corp/festival
+```
 
 Choose your distribution's package format:
 

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,5 @@
+*.tar.gz
+.tmp-extract/
+bin/*-bin
+bin/*.exe
+

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,51 @@
+# @obedience-corp/festival
+
+NPM installer for the Festival CLI suite.
+
+Festival includes two commands:
+
+- `fest` - Festival planning and execution workflow CLI
+- `camp` - Campaign workspace management CLI
+
+## Install
+
+```bash
+npm install -g @obedience-corp/festival
+```
+
+You can also use another npm-compatible package manager:
+
+```bash
+pnpm add -g @obedience-corp/festival
+bun add -g @obedience-corp/festival
+```
+
+## Verify
+
+```bash
+fest version
+camp version
+```
+
+## Supported Platforms
+
+- macOS: Intel and Apple Silicon, distributed as a universal archive
+- Linux: x64 and arm64
+
+Windows npm installation is paused until the Festival Windows release artifacts
+are re-enabled.
+
+## How It Works
+
+This package downloads the matching Festival GitHub release archive for your
+platform, verifies it against the release `checksums.txt`, and exposes `fest`
+and `camp` on your PATH.
+
+## Maintainer Notes
+
+The npm package intentionally exposes the same binary set as the Festival release
+archive. If a future release adds or removes CLI binaries, update `BINARIES` in
+`install.js`, the `bin` map in `package.json`, the wrapper files in `bin/`, and
+the GoReleaser archive `ids:` in `../.goreleaser.yaml` together.
+
+See <https://fest.build> for docs and the full installation guide.

--- a/npm/bin/camp
+++ b/npm/bin/camp
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { runBinary } = require("../lib/run");
+
+runBinary("camp").catch((err) => {
+  console.error(`Failed to run camp: ${err.message}`);
+  process.exit(1);
+});
+

--- a/npm/bin/fest
+++ b/npm/bin/fest
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { runBinary } = require("../lib/run");
+
+runBinary("fest").catch((err) => {
+  console.error(`Failed to run fest: ${err.message}`);
+  process.exit(1);
+});
+

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+const crypto = require("crypto");
+const fs = require("fs");
+const https = require("https");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const REPO = "Obedience-Corp/festival";
+const BINARIES = ["fest", "camp"];
+const DOWNLOAD_ATTEMPTS = 3;
+const DOWNLOAD_TIMEOUT_MS = 60_000;
+const RETRY_BASE_DELAY_MS = 750;
+
+const PLATFORM_MAP = {
+  darwin: "macOS",
+  linux: "linux",
+};
+
+const ARCH_MAP = {
+  x64: "x86_64",
+  arm64: "arm64",
+};
+
+function packageVersion() {
+  const packageJSON = require("./package.json");
+  return packageJSON.version;
+}
+
+function releaseTag(version = packageVersion()) {
+  return `v${version}`;
+}
+
+function targetForCurrentPlatform() {
+  const platform = PLATFORM_MAP[process.platform];
+  const arch = ARCH_MAP[process.arch];
+
+  if (!platform || !arch) {
+    throw new Error(
+      `Unsupported platform: ${process.platform}/${process.arch}. Festival npm install currently supports macOS and Linux on x64/arm64.`,
+    );
+  }
+
+  if (platform === "macOS") {
+    return "macOS-all";
+  }
+
+  return `${platform}-${arch}`;
+}
+
+function archiveName(version = packageVersion()) {
+  return `festival-${version}-${targetForCurrentPlatform()}.tar.gz`;
+}
+
+function releaseURL(asset, version = packageVersion()) {
+  return `https://github.com/${REPO}/releases/download/${releaseTag(version)}/${asset}`;
+}
+
+function binaryPath(name) {
+  const binaryName = process.platform === "win32" ? `${name}.exe` : `${name}-bin`;
+  return path.join(__dirname, "bin", binaryName);
+}
+
+function haveBinaries() {
+  return BINARIES.every((name) => fs.existsSync(binaryPath(name)));
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function downloadOnce(url, dest) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const fail = (err) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      fs.rmSync(dest, { force: true });
+      reject(err);
+    };
+
+    const done = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve();
+    };
+
+    const follow = (nextURL, redirects = 0) => {
+      if (redirects > 10) {
+        fail(new Error("too many redirects"));
+        return;
+      }
+
+      const request = https
+        .get(nextURL, (response) => {
+          if (
+            response.statusCode >= 300 &&
+            response.statusCode < 400 &&
+            response.headers.location
+          ) {
+            response.resume();
+            follow(response.headers.location, redirects + 1);
+            return;
+          }
+
+          if (response.statusCode !== 200) {
+            response.resume();
+            fail(new Error(`failed to download ${url}: HTTP ${response.statusCode}`));
+            return;
+          }
+
+          const file = fs.createWriteStream(dest);
+          response.pipe(file);
+          file.on("finish", () => {
+            file.close(done);
+          });
+          file.on("error", fail);
+        })
+        .on("error", fail);
+
+      request.setTimeout(DOWNLOAD_TIMEOUT_MS, () => {
+        request.destroy(new Error(`download timeout after ${DOWNLOAD_TIMEOUT_MS / 1000}s`));
+      });
+    };
+
+    follow(url);
+  });
+}
+
+async function download(url, dest, attempts = DOWNLOAD_ATTEMPTS) {
+  let lastErr;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      await downloadOnce(url, dest);
+      return;
+    } catch (err) {
+      lastErr = err;
+
+      if (attempt === attempts) {
+        break;
+      }
+
+      const delay = RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+      console.warn(
+        `Download failed (${attempt}/${attempts}) for ${path.basename(dest)}: ${err.message}. Retrying in ${delay}ms...`,
+      );
+      await sleep(delay);
+    }
+  }
+
+  throw lastErr;
+}
+
+function sha256(filePath) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+function expectedChecksum(checksumsPath, filename) {
+  const checksums = fs.readFileSync(checksumsPath, "utf8").split(/\r?\n/);
+
+  for (const line of checksums) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length >= 2 && parts[1] === filename) {
+      return parts[0];
+    }
+  }
+
+  throw new Error(`checksum for ${filename} not found in checksums.txt`);
+}
+
+function verifyChecksum(archivePath, checksumsPath, filename) {
+  const expected = expectedChecksum(checksumsPath, filename);
+  const actual = sha256(archivePath);
+
+  if (actual !== expected) {
+    throw new Error(`checksum mismatch for ${filename}: expected ${expected}, got ${actual}`);
+  }
+}
+
+function extractArchive(archivePath, destDir) {
+  const result = spawnSync("tar", ["-xzf", archivePath, "-C", destDir], {
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`tar exited with status ${result.status}`);
+  }
+}
+
+async function install(options = {}) {
+  const force = options.force === true;
+
+  if (!force && haveBinaries()) {
+    return;
+  }
+
+  const version = packageVersion();
+  const filename = archiveName(version);
+  const binDir = path.join(__dirname, "bin");
+  const tempDir = path.join(__dirname, ".tmp-extract");
+  const archivePath = path.join(__dirname, filename);
+  const checksumsPath = path.join(__dirname, "checksums.txt");
+
+  console.log(`Installing Festival ${version} (${targetForCurrentPlatform()})...`);
+
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.mkdirSync(tempDir, { recursive: true });
+
+  try {
+    await download(releaseURL(filename, version), archivePath);
+    await download(releaseURL("checksums.txt", version), checksumsPath);
+    verifyChecksum(archivePath, checksumsPath, filename);
+    extractArchive(archivePath, tempDir);
+
+    for (const name of BINARIES) {
+      const extractedPath = path.join(tempDir, name);
+      const targetPath = binaryPath(name);
+
+      if (!fs.existsSync(extractedPath)) {
+        throw new Error(`${name} not found in ${filename}`);
+      }
+
+      fs.renameSync(extractedPath, targetPath);
+      if (process.platform !== "win32") {
+        fs.chmodSync(targetPath, 0o755);
+      }
+    }
+
+    console.log("Installed Festival successfully");
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(archivePath, { force: true });
+    fs.rmSync(checksumsPath, { force: true });
+  }
+}
+
+async function main() {
+  try {
+    await install({ force: false });
+  } catch (err) {
+    console.error(`Failed to install Festival: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  archiveName,
+  binaryPath,
+  install,
+  targetForCurrentPlatform,
+};

--- a/npm/lib/run.js
+++ b/npm/lib/run.js
@@ -1,0 +1,28 @@
+const fs = require("fs");
+const { spawnSync } = require("child_process");
+
+const { binaryPath, install } = require("../install");
+
+async function runBinary(name) {
+  const target = binaryPath(name);
+
+  if (!fs.existsSync(target)) {
+    await install();
+  }
+
+  const result = spawnSync(target, process.argv.slice(2), {
+    stdio: "inherit",
+    shell: false,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  process.exit(result.status ?? 1);
+}
+
+module.exports = {
+  runBinary,
+};
+

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@obedience-corp/festival",
+  "version": "0.0.0",
+  "description": "Festival Methodology CLI suite: fest and camp",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Obedience-Corp/festival.git"
+  },
+  "homepage": "https://fest.build",
+  "bugs": {
+    "url": "https://github.com/Obedience-Corp/festival/issues"
+  },
+  "license": "BUSL-1.1",
+  "bin": {
+    "camp": "bin/camp",
+    "fest": "bin/fest"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "files": [
+    "README.md",
+    "bin",
+    "install.js",
+    "lib"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "keywords": [
+    "ai",
+    "ai-agents",
+    "camp",
+    "cli",
+    "developer-tools",
+    "fest",
+    "festival",
+    "festival-methodology",
+    "workflow"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds npm distribution for the Festival CLI suite under `@obedience-corp/festival`.

The package exposes both commands:

```bash
npm install -g @obedience-corp/festival
fest version
camp version
```

## What Changed

- Added `npm/package.json` for the scoped npm package.
- Added Node wrapper bins for `fest` and `camp`.
- Added an installer that downloads the matching GitHub release archive, verifies it against `checksums.txt`, extracts `fest` and `camp`, and stores them as package-local binaries.
- Wired npm publishing into the release workflow after GoReleaser succeeds.
- Added npm install instructions to README, docs, and GoReleaser release notes.

## Notes

- The package intentionally supports macOS and Linux only, matching the current stable Festival release artifacts.
- The npm scope `@obedience-corp` and `NPM_TOKEN` secret need to be configured before the first release that publishes this package.
- Stable releases publish with npm dist-tag `latest`; rc/dev tags publish with `rc` and `dev` respectively.

## Validation

- `node --check npm/install.js`
- `node --check npm/lib/run.js`
- `node --check npm/bin/fest`
- `node --check npm/bin/camp`
- `npm pack --dry-run` from `npm/`
- temp install test against Festival `v0.2.3`, then `fest --version` and `camp --version`
- `goreleaser check`
- `just test docs-profile`
- `git diff --check`
