### PR TITLE
Update Claude Code plugin for v0.2.4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,12 +4,29 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Festival version to publish to npm, without leading v (example: 0.2.4)'
+        required: true
+        type: string
+      release_mode:
+        description: 'npm dist-tag channel'
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - rc
+          - dev
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -58,15 +75,6 @@ jobs:
               exit 1
               ;;
           esac
-
-      - name: Validate npm publish credentials
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "${NPM_TOKEN:-}" ]; then
-            echo "::error::Missing required secret NPM_TOKEN"
-            exit 1
-          fi
 
       - name: Validate stable publish credentials
         if: steps.release_channel.outputs.mode == 'stable'
@@ -150,30 +158,38 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish npm package
-        working-directory: npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_MODE: ${{ steps.release_channel.outputs.mode }}
-        run: |
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "::error::Missing required secret NPM_TOKEN"
-            exit 1
-          fi
+        run: scripts/publish_npm_package.sh
 
-          version="${GITHUB_REF_NAME#v}"
-          case "${RELEASE_MODE}" in
-            stable) npm_tag="latest" ;;
-            rc) npm_tag="rc" ;;
-            dev) npm_tag="dev" ;;
-            *)
-              echo "::error::Unsupported release mode ${RELEASE_MODE}"
-              exit 1
-              ;;
-          esac
+  npm-publish:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout workflow scripts
+        uses: actions/checkout@v4
 
-          npm version "${version}" --no-git-tag-version
-          npm publish --access public --tag "${npm_tag}"
+      - name: Checkout release source
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }}
+          path: release-source
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish npm package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_PACKAGE_DIR: release-source/npm
+          NPM_PACKAGE_VERSION: ${{ inputs.version }}
+          RELEASE_MODE: ${{ inputs.release_mode }}
+        run: scripts/publish_npm_package.sh

--- a/.justfiles/plugin.just
+++ b/.justfiles/plugin.just
@@ -8,8 +8,8 @@ default:
 # Check plugin commands match installed CLI
 check:
     #!/usr/bin/env bash
-    PLUGIN="$(cd "$(dirname "{{source_file()}}")/.." && pwd)/claude-plugin"
-    bash "$PLUGIN/hooks/scripts/sync-check.sh"
+    ROOT="$(cd "$(dirname "{{source_file()}}")/.." && pwd)"
+    bash "$ROOT/scripts/test_claude_plugin.sh"
 
 # List all plugin components
 list:

--- a/.justfiles/test.just
+++ b/.justfiles/test.just
@@ -55,3 +55,8 @@ release-operator:
 [no-cd]
 release-notes:
     cd tools/release-notes && go test ./...
+
+# Test the Claude Code plugin bundle and hooks
+[no-cd]
+plugin:
+    just plugin check

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "festival",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Festival Methodology for Claude Code — goal-oriented project management for human-AI development workflows. Provides fest and camp CLI integration, automatic installation, and methodology guidance.",
   "author": {
     "name": "Obedience Corp",

--- a/claude-plugin/hooks/scripts/ensure-festival.sh
+++ b/claude-plugin/hooks/scripts/ensure-festival.sh
@@ -1,13 +1,37 @@
 #!/usr/bin/env bash
 # Ensures fest and camp are installed and up-to-date. Runs on SessionStart.
-# - If missing: downloads and installs from GitHub releases.
+# - If missing: downloads and installs from GitHub releases with checksum verification.
 # - If installed: checks for newer version and offers update notification.
 
 set -euo pipefail
 
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 REPO="Obedience-Corp/festival"
-CHECK_FILE="${HOME}/.cache/festival/last-update-check"
+CACHE_DIR="${FESTIVAL_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/festival}"
+CHECK_FILE="${FESTIVAL_CHECK_FILE:-$CACHE_DIR/last-update-check}"
+DOWNLOAD_TIMEOUT_SECONDS="${FESTIVAL_DOWNLOAD_TIMEOUT_SECONDS:-120}"
+
+info() {
+    echo "$*" >&2
+}
+
+fail() {
+    echo "$*" >&2
+    exit 1
+}
+
+require_command() {
+    local name="$1"
+    command -v "$name" >/dev/null 2>&1 || fail "Required command not found: $name"
+}
+
+require_checksum_command() {
+    if command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1; then
+        return 0
+    fi
+
+    fail "Required command not found: shasum or sha256sum"
+}
 
 check_installed() {
     command -v fest >/dev/null 2>&1 && command -v camp >/dev/null 2>&1
@@ -49,7 +73,7 @@ detect_platform() {
 }
 
 fetch_release() {
-    curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null
+    curl -fsSL --connect-timeout 10 --max-time "$DOWNLOAD_TIMEOUT_SECONDS" "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null
 }
 
 find_archive_url() {
@@ -70,44 +94,119 @@ extract_tag() {
     echo "$1" | grep '"tag_name"' | head -1 | sed -E 's/.*"([^"]+)".*/\1/'
 }
 
-download_and_install() {
+download_file() {
+    local url="$1"
+    local dest="$2"
+    local tmp="${dest}.tmp"
+
+    rm -f "$tmp"
+    curl -fsSL --connect-timeout 10 --max-time "$DOWNLOAD_TIMEOUT_SECONDS" "$url" -o "$tmp" || {
+        rm -f "$tmp"
+        return 1
+    }
+    mv "$tmp" "$dest"
+}
+
+checksum_url_for_archive() {
     local archive_url="$1"
+    echo "${archive_url%/*}/checksums.txt"
+}
 
-    TMP_DIR=$(mktemp -d)
-    trap 'rm -rf "$TMP_DIR"' EXIT
+sha256_file() {
+    local file="$1"
 
-    curl -fsSL "$archive_url" -o "${TMP_DIR}/archive.tar.gz" 2>/dev/null || {
-        echo "Download failed. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash" >&2
-        exit 1
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$file" | awk '{print $1}'
+        return 0
+    fi
+
+    sha256sum "$file" | awk '{print $1}'
+}
+
+expected_checksum() {
+    local checksums_file="$1"
+    local archive_name="$2"
+
+    awk -v name="$archive_name" '$2 == name {print $1; found=1} END {exit found ? 0 : 1}' "$checksums_file"
+}
+
+verify_checksum() {
+    local archive_path="$1"
+    local checksums_path="$2"
+    local archive_name="$3"
+    local expected actual
+
+    expected="$(expected_checksum "$checksums_path" "$archive_name")" || {
+        echo "Checksum for ${archive_name} not found in checksums.txt" >&2
+        return 1
     }
 
-    tar -xzf "${TMP_DIR}/archive.tar.gz" -C "$TMP_DIR"
+    actual="$(sha256_file "$archive_path")"
+    if [ "$actual" != "$expected" ]; then
+        echo "Checksum mismatch for ${archive_name}" >&2
+        echo "expected: ${expected}" >&2
+        echo "actual:   ${actual}" >&2
+        return 1
+    fi
+}
+
+download_and_install() {
+    local archive_url="$1"
+    local archive_name checksums_url archive_path checksums_path
+
+    archive_name="$(basename "$archive_url")"
+    checksums_url="$(checksum_url_for_archive "$archive_url")"
+    TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/festival-plugin.XXXXXX")
+    trap 'rm -rf "$TMP_DIR"' EXIT
+    archive_path="${TMP_DIR}/${archive_name}"
+    checksums_path="${TMP_DIR}/checksums.txt"
+
+    download_file "$archive_url" "$archive_path" ||
+        fail "Download failed. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+
+    download_file "$checksums_url" "$checksums_path" ||
+        fail "Checksum download failed. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+
+    verify_checksum "$archive_path" "$checksums_path" "$archive_name" ||
+        fail "Checksum verification failed. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+
+    tar -xzf "$archive_path" -C "$TMP_DIR"
 
     mkdir -p "$INSTALL_DIR"
     for binary in fest camp; do
-        if [ -f "${TMP_DIR}/${binary}" ]; then
-            cp "${TMP_DIR}/${binary}" "${INSTALL_DIR}/${binary}"
-            chmod +x "${INSTALL_DIR}/${binary}"
+        extracted_path="$(find "$TMP_DIR" -type f -name "$binary" | head -1)"
+        if [ -n "$extracted_path" ]; then
+            install -m 0755 "$extracted_path" "${INSTALL_DIR}/${binary}"
+        else
+            fail "${binary} not found in ${archive_name}"
         fi
     done
 }
 
 # --- Main ---
 
+require_command curl
+require_command tar
+require_command grep
+require_command sed
+require_command awk
+require_command find
+require_command install
+require_checksum_command
 detect_platform
 
 if ! check_installed; then
     # Fresh install
-    echo "Festival CLI not found. Installing fest and camp..." >&2
+    info "Festival CLI not found. Installing fest and camp..."
 
     RELEASE_JSON=$(fetch_release) || {
-        echo "Could not fetch release info. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash" >&2
+        info "Could not fetch release info. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
         exit 1
     }
 
     ARCHIVE_URL=$(find_archive_url "$RELEASE_JSON")
     if [ -z "$ARCHIVE_URL" ]; then
-        echo "No compatible archive found for ${OS}/${ARCH}. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash" >&2
+        info "No compatible archive found for ${OS}/${ARCH}. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
         exit 1
     fi
 
@@ -115,9 +214,9 @@ if ! check_installed; then
     record_check
 
     if command -v fest >/dev/null 2>&1; then
-        echo "Festival installed successfully: $(fest version 2>/dev/null || echo 'fest ready')" >&2
+        info "Festival installed successfully: $(fest version 2>/dev/null || echo 'fest ready')"
     else
-        echo "Installed to ${INSTALL_DIR}. You may need to add it to your PATH: export PATH=\"${INSTALL_DIR}:\$PATH\"" >&2
+        info "Installed to ${INSTALL_DIR}. You may need to add it to your PATH: export PATH=\"${INSTALL_DIR}:\$PATH\""
     fi
     exit 0
 fi
@@ -146,5 +245,5 @@ LATEST_CLEAN="${LATEST_TAG#v}"
 record_check
 
 if [ "$CURRENT_CLEAN" != "$LATEST_CLEAN" ]; then
-    echo "Festival update available: ${CURRENT_VERSION} -> ${LATEST_TAG}. Run: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash" >&2
+    info "Festival update available: ${CURRENT_VERSION} -> ${LATEST_TAG}. Run: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
 fi

--- a/claude-plugin/hooks/scripts/sync-check.sh
+++ b/claude-plugin/hooks/scripts/sync-check.sh
@@ -62,17 +62,50 @@ check_command() {
     fi
 }
 
+known_reference() {
+    case "$1:$2" in
+        fest:next|fest:validate|fest:commit|fest:status|fest:list|fest:show|fest:create|fest:task|fest:workflow|fest:link|fest:promote|fest:understand|fest:deps|fest:progress|fest:shell-init|fest:completion|fest:types|fest:links|fest:unlink|fest:scaffold)
+            return 0
+            ;;
+        camp:init|camp:intent|camp:project|camp:go|camp:status|camp:shell-init|camp:p|camp:refs-sync|camp:pull|camp:push|camp:dungeon|camp:flow)
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+check_markdown_references() {
+    local file line cmd subcmd
+
+    while IFS= read -r file; do
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^[[:space:]]*(fest|camp)[[:space:]]+([a-z][a-z-]*) ]]; then
+                cmd="${BASH_REMATCH[1]}"
+                subcmd="${BASH_REMATCH[2]}"
+
+                if ! known_reference "$cmd" "$subcmd"; then
+                    echo "WARNING: $file references '$cmd $subcmd' but sync-check.sh does not validate it" >&2
+                    ERRORS=$((ERRORS + 1))
+                fi
+            fi
+        done < "$file"
+    done < <(find "$PLUGIN_DIR" -type f -name '*.md' | sort)
+}
+
 echo "Checking plugin commands against installed CLI..."
 
 # fest commands referenced in plugin
-for subcmd in next validate commit status list show create task workflow link promote understand; do
+for subcmd in next validate commit status list show create task workflow link promote understand deps progress shell-init completion types links unlink scaffold; do
     check_command fest "$subcmd"
 done
 
 # camp commands referenced in plugin
-for subcmd in init intent project go status; do
+for subcmd in init intent project go status shell-init p refs-sync pull push dungeon flow; do
     check_command camp "$subcmd"
 done
+
+check_markdown_references
 
 if [ "$ERRORS" -gt 0 ]; then
     echo ""

--- a/scripts/publish_npm_package.sh
+++ b/scripts/publish_npm_package.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Publish the npm wrapper package for an existing Festival release.
+
+set -euo pipefail
+
+PACKAGE_DIR="${NPM_PACKAGE_DIR:-npm}"
+PACKAGE_NAME="${NPM_PACKAGE_NAME:-@obedience-corp/festival}"
+RELEASE_MODE="${RELEASE_MODE:-stable}"
+
+if [ -n "${NPM_PACKAGE_VERSION:-}" ]; then
+    VERSION="$NPM_PACKAGE_VERSION"
+elif [ -n "${GITHUB_REF_NAME:-}" ]; then
+    VERSION="${GITHUB_REF_NAME#v}"
+else
+    echo "::error::NPM_PACKAGE_VERSION or GITHUB_REF_NAME is required" >&2
+    exit 1
+fi
+
+case "$RELEASE_MODE" in
+    stable) NPM_DIST_TAG="${NPM_DIST_TAG:-latest}" ;;
+    rc) NPM_DIST_TAG="${NPM_DIST_TAG:-rc}" ;;
+    dev) NPM_DIST_TAG="${NPM_DIST_TAG:-dev}" ;;
+    *)
+        echo "::error::Unsupported release mode ${RELEASE_MODE}" >&2
+        exit 1
+        ;;
+esac
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+    echo "::error::Invalid npm package version: ${VERSION}" >&2
+    exit 1
+fi
+
+if [ ! -d "$PACKAGE_DIR" ]; then
+    echo "::error::npm package directory not found: ${PACKAGE_DIR}" >&2
+    exit 1
+fi
+
+echo "Node: $(node --version)"
+echo "npm: $(npm --version)"
+echo "Package: ${PACKAGE_NAME}@${VERSION}"
+echo "Dist tag: ${NPM_DIST_TAG}"
+echo "Package directory: ${PACKAGE_DIR}"
+
+if [ "${NPM_SKIP_EXISTING_CHECK:-false}" != "true" ] && npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
+    echo "${PACKAGE_NAME}@${VERSION} is already published; leaving registry unchanged."
+    exit 0
+fi
+
+pushd "$PACKAGE_DIR" >/dev/null
+npm version "$VERSION" --no-git-tag-version
+
+set +e
+publish_args=(publish --access public --tag "$NPM_DIST_TAG")
+if [ "${NPM_PUBLISH_DRY_RUN:-false}" = "true" ]; then
+    publish_args+=(--dry-run)
+fi
+publish_output="$(npm "${publish_args[@]}" 2>&1)"
+publish_status=$?
+set -e
+printf '%s\n' "$publish_output"
+
+if [ "$publish_status" -ne 0 ]; then
+    if printf '%s\n' "$publish_output" | grep -q 'EOTP'; then
+        echo "::error::npm publish requires OTP. Configure npm trusted publishing for .github/workflows/release.yaml or replace NPM_TOKEN with a granular token that has bypass 2FA enabled." >&2
+    fi
+    exit "$publish_status"
+fi
+
+popd >/dev/null

--- a/scripts/test_claude_plugin.sh
+++ b/scripts/test_claude_plugin.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Smoke-test the Claude Code plugin bundle and its session hooks.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+plugin_dir="$repo_root/claude-plugin"
+
+require_command() {
+    local name="$1"
+    command -v "$name" >/dev/null 2>&1 || {
+        echo "Required command not found: $name" >&2
+        exit 1
+    }
+}
+
+json_check() {
+    local file="$1"
+    node -e "JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'))" "$file"
+}
+
+plugin_version_check() {
+    node -e '
+const fs = require("fs");
+const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (!/^[0-9]+\.[0-9]+\.[0-9]+$/.test(manifest.version)) {
+  throw new Error(`plugin version must be semver: ${manifest.version}`);
+}
+if (!manifest.name || !manifest.description || !manifest.repository) {
+  throw new Error("plugin manifest is missing required metadata");
+}
+' "$plugin_dir/.claude-plugin/plugin.json"
+}
+
+target_for_host() {
+    local os arch
+
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    case "$os" in
+        darwin) os="macOS" ;;
+        linux) os="linux" ;;
+        *) echo "unsupported" && return 0 ;;
+    esac
+
+    arch="$(uname -m)"
+    case "$arch" in
+        x86_64|amd64) arch="x86_64" ;;
+        arm64|aarch64) arch="arm64" ;;
+        *) echo "unsupported" && return 0 ;;
+    esac
+
+    if [ "$os" = "macOS" ]; then
+        echo "macOS-all"
+    else
+        echo "${os}-${arch}"
+    fi
+}
+
+write_stub_binary() {
+    local path="$1"
+    local name="$2"
+
+    cat > "$path" <<EOF_STUB
+#!/usr/bin/env bash
+case "\${1:-}" in
+  version|--version) echo "${name} v9.8.7" ;;
+  *) echo "${name} stub" ;;
+esac
+EOF_STUB
+    chmod +x "$path"
+}
+
+write_fake_curl() {
+    local path="$1"
+
+    cat > "$path" <<'EOF_CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            out="$2"
+            shift 2
+            ;;
+        -*)
+            shift
+            ;;
+        *)
+            url="$1"
+            shift
+            ;;
+    esac
+done
+
+fixture="${FESTIVAL_PLUGIN_TEST_FIXTURE_DIR:?}"
+case "$url" in
+    *"/releases/latest")
+        src="$fixture/release.json"
+        ;;
+    *"/checksums.txt")
+        src="$fixture/checksums.txt"
+        ;;
+    *".tar.gz")
+        src="$fixture/archive.tar.gz"
+        ;;
+    *)
+        echo "unexpected URL: $url" >&2
+        exit 22
+        ;;
+esac
+
+if [ -n "$out" ]; then
+    cp "$src" "$out"
+else
+    cat "$src"
+fi
+EOF_CURL
+    chmod +x "$path"
+}
+
+smoke_install_hook() {
+    local target archive_name tmp fixture payload fakebin home install_dir
+
+    target="$(target_for_host)"
+    if [ "$target" = "unsupported" ]; then
+        echo "Skipping install hook smoke on unsupported host platform"
+        return 0
+    fi
+
+    tmp="$(mktemp -d "${TMPDIR:-/tmp}/festival-plugin-test.XXXXXX")"
+    trap 'rm -rf "$tmp"' RETURN
+    fixture="$tmp/fixture"
+    payload="$tmp/payload"
+    fakebin="$tmp/fakebin"
+    home="$tmp/home"
+    install_dir="$tmp/install"
+    mkdir -p "$fixture" "$payload" "$fakebin" "$home" "$install_dir"
+
+    write_stub_binary "$payload/fest" "fest"
+    write_stub_binary "$payload/camp" "camp"
+
+    archive_name="festival-9.8.7-${target}.tar.gz"
+    (cd "$payload" && tar -czf "$fixture/archive.tar.gz" fest camp)
+    if command -v shasum >/dev/null 2>&1; then
+        checksum="$(shasum -a 256 "$fixture/archive.tar.gz" | awk '{print $1}')"
+    else
+        checksum="$(sha256sum "$fixture/archive.tar.gz" | awk '{print $1}')"
+    fi
+    printf '%s  %s\n' "$checksum" "$archive_name" > "$fixture/checksums.txt"
+
+    cat > "$fixture/release.json" <<EOF_JSON
+{
+  "tag_name": "v9.8.7",
+  "assets": [
+    {
+      "browser_download_url": "https://example.test/${archive_name}"
+    }
+  ]
+}
+EOF_JSON
+
+    write_fake_curl "$fakebin/curl"
+
+    if ! FESTIVAL_PLUGIN_TEST_FIXTURE_DIR="$fixture" \
+        HOME="$home" \
+        INSTALL_DIR="$install_dir" \
+        PATH="$fakebin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash "$plugin_dir/hooks/scripts/ensure-festival.sh" >"$tmp/install.log" 2>&1; then
+        cat "$tmp/install.log" >&2
+        return 1
+    fi
+
+    test -x "$install_dir/fest"
+    test -x "$install_dir/camp"
+
+    if ! FESTIVAL_PLUGIN_TEST_FIXTURE_DIR="$fixture" \
+        HOME="$home" \
+        INSTALL_DIR="$install_dir" \
+        PATH="$install_dir:$fakebin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash "$plugin_dir/hooks/scripts/ensure-festival.sh" >"$tmp/update-check.log" 2>&1; then
+        cat "$tmp/update-check.log" >&2
+        return 1
+    fi
+}
+
+require_command node
+require_command tar
+require_command bash
+
+json_check "$plugin_dir/.claude-plugin/plugin.json"
+json_check "$plugin_dir/hooks/hooks.json"
+plugin_version_check
+bash -n "$plugin_dir/hooks/scripts/ensure-festival.sh" "$plugin_dir/hooks/scripts/sync-check.sh"
+
+if [ -x "$repo_root/fest/bin/fest" ] && [ -x "$repo_root/camp/bin/camp" ]; then
+    FEST_BIN="$repo_root/fest/bin/fest" CAMP_BIN="$repo_root/camp/bin/camp" \
+        bash "$plugin_dir/hooks/scripts/sync-check.sh"
+else
+    bash "$plugin_dir/hooks/scripts/sync-check.sh"
+fi
+
+smoke_install_hook
+
+echo "Claude plugin smoke passed"


### PR DESCRIPTION
## Summary
- Bump the Claude Code plugin manifest to `1.0.1`.
- Harden the Claude plugin install hook with dependency checks, timeout-bounded downloads, checksum verification, nested archive lookup, and XDG-aware cache path support.
- Expand plugin sync validation so command references in plugin markdown must be covered by the CLI check.
- Add `scripts/test_claude_plugin.sh` and expose it as `just test plugin` / `just plugin check`; the test validates JSON manifests, shell syntax, command sync, and a no-network install-hook smoke test.
- Add a reusable npm publish script and a manual `release.yaml` workflow dispatch path to retry npm-only publishes for existing release tags without rerunning GoReleaser.
- Update the tag release workflow to Node 24 and `id-token: write` so future npm publishing can use trusted publishing once npm is configured for `.github/workflows/release.yaml`, while still supporting `NPM_TOKEN`.

## Validation
- `just test plugin`
- `tmp=$(mktemp -d); cp -R npm "$tmp/npm"; NPM_PACKAGE_DIR="$tmp/npm" NPM_PACKAGE_VERSION=0.2.4 RELEASE_MODE=stable NPM_SKIP_EXISTING_CHECK=true NPM_PUBLISH_DRY_RUN=true scripts/publish_npm_package.sh; rm -rf "$tmp"`
- `bash -n claude-plugin/hooks/scripts/ensure-festival.sh claude-plugin/hooks/scripts/sync-check.sh scripts/test_claude_plugin.sh scripts/publish_npm_package.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yaml"); puts "release-yaml-ok"'`\n- `git diff --check`\n\n## npm v0.2.4 recovery\nThe `v0.2.4` release failed only at npm with `EOTP`. After replacing `NPM_TOKEN` with a granular token that has bypass 2FA enabled, run the `Release` workflow manually with `version=0.2.4` and `release_mode=stable`. This uses the `npm-publish` job and does not rerun GoReleaser or re-upload release assets.\n\nTrusted publishing should be configured after the first npm publish exists: npm package `@obedience-corp/festival`, GitHub org/user `Obedience-Corp`, repository `festival`, workflow filename `release.yaml`.\n