### PR TITLE
Add manual npm publish backfill

### DIFF
--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -72,6 +72,18 @@ stable fest="latest" camp="latest":
 dry-run:
     goreleaser release --snapshot --clean --skip=publish,announce
 
+# Publish the npm wrapper for an already-created GitHub release.
+# This is a manual backfill path only; tag releases should normally publish npm from CI.
+[no-cd]
+[confirm("This will publish the npm wrapper for an existing Festival GitHub release. Already-published versions are skipped. Continue?")]
+npm-publish version="latest" mode="stable":
+    scripts/publish_existing_release_npm.sh "{{version}}" "{{mode}}"
+
+# Preview the manual npm backfill without publishing to the registry.
+[no-cd]
+npm-publish-dry-run version="latest" mode="stable":
+    NPM_PUBLISH_DRY_RUN=true scripts/publish_existing_release_npm.sh "{{version}}" "{{mode}}"
+
 # First stable release bootstrap:
 # - create/push fest + camp stable tags at their current HEAD
 # - pin festival submodules to those tags

--- a/scripts/publish_existing_release_npm.sh
+++ b/scripts/publish_existing_release_npm.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Publish the npm wrapper for an existing Festival GitHub release.
+
+set -euo pipefail
+
+VERSION_SELECTOR="${1:-latest}"
+RELEASE_MODE="${2:-stable}"
+REPO="${GITHUB_REPOSITORY:-Obedience-Corp/festival}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+case "$RELEASE_MODE" in
+    stable | rc | dev) ;;
+    *)
+        echo "::error::Unsupported release mode ${RELEASE_MODE}" >&2
+        exit 1
+        ;;
+esac
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "::error::gh is required to resolve and verify Festival GitHub releases" >&2
+    exit 1
+fi
+
+if ! command -v rsync >/dev/null 2>&1; then
+    echo "::error::rsync is required to stage the npm package without mutating the working tree" >&2
+    exit 1
+fi
+
+if [ "$VERSION_SELECTOR" = "latest" ]; then
+    TAG="$(gh release view --repo "$REPO" --json tagName --jq .tagName)"
+else
+    TAG="${VERSION_SELECTOR#v}"
+    TAG="v${TAG}"
+    gh release view "$TAG" --repo "$REPO" >/dev/null
+fi
+
+VERSION="${TAG#v}"
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+    echo "::error::Invalid Festival release tag ${TAG}" >&2
+    exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+rsync -a "$ROOT_DIR/npm/" "$TMP_DIR/"
+
+echo "Publishing npm wrapper for Festival ${TAG} from ${REPO}"
+echo "Staged package directory: ${TMP_DIR}"
+
+NPM_PACKAGE_DIR="$TMP_DIR" \
+NPM_PACKAGE_VERSION="$VERSION" \
+RELEASE_MODE="$RELEASE_MODE" \
+"$ROOT_DIR/scripts/publish_npm_package.sh"


### PR DESCRIPTION
## Summary

- add a manual `just release npm-publish` entrypoint for publishing the npm wrapper from an existing GitHub release
- stage the npm package in a temporary directory so the checked-in `0.0.0` version is never mutated
- reuse the existing idempotent publish script so already-published versions exit cleanly

## Validation

- `bash -n scripts/publish_existing_release_npm.sh`
- `bash -n scripts/publish_npm_package.sh`
- `just --justfile .justfiles/release.just --list --unsorted`
- `just release npm-publish-dry-run 0.2.4 stable`
- `just release npm-publish-dry-run latest stable`
- `NPM_PACKAGE_NAME=npm NPM_PACKAGE_VERSION=11.8.0 NPM_PACKAGE_DIR=npm RELEASE_MODE=stable scripts/publish_npm_package.sh`