### PR TITLE
Use dynamic just help menus

### DIFF
--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -7,7 +7,7 @@
 [private]
 [no-cd]
 default:
-    @go -C tools/release-operator run . help
+    @just --list --justfile {{source_file()}}
 
 # Pin submodules to latest stable tags without creating a festival release
 [no-cd]
@@ -33,6 +33,11 @@ require-stable-publish-credentials:
 [no-cd]
 status:
     go -C tools/release-operator run . status --repo-root ../..
+
+# Show the release operator's detailed workflow help
+[no-cd]
+operator-help:
+    go -C tools/release-operator run . help
 
 # Pre-release checks: show submodule versions, dirty state, and build validation
 [no-cd]

--- a/justfile
+++ b/justfile
@@ -28,10 +28,7 @@ mod plugin '.justfiles/plugin.just'
 
 [private]
 default:
-    #!/usr/bin/env bash
-    echo "festival - Festival Methodology CLI Distribution"
-    echo ""
-    just --list --unsorted
+    @just --list --justfile {{source_file()}}
 
 # Pin submodules to latest stable tags and regenerate CLI docs
 refresh:


### PR DESCRIPTION
## Summary

- make root `just` render the built-in recipe list directly
- make `just release` list release recipes instead of delegating to the release operator help text

## Validation

- `just`
- `just release`
- `git diff --check`