### PR TITLE
Prompt for npm OTP during manual publish

### DIFF
--- a/scripts/publish_npm_package.sh
+++ b/scripts/publish_npm_package.sh
@@ -42,6 +42,30 @@ echo "Package: ${PACKAGE_NAME}@${VERSION}"
 echo "Dist tag: ${NPM_DIST_TAG}"
 echo "Package directory: ${PACKAGE_DIR}"
 
+can_prompt_for_otp() {
+    [ "${NPM_OTP_PROMPT:-auto}" != "never" ] &&
+        [ "${CI:-}" != "true" ] &&
+        [ -r /dev/tty ] &&
+        [ -w /dev/tty ]
+}
+
+prompt_for_otp() {
+    local otp
+
+    printf 'npm OTP: ' >/dev/tty
+    stty -echo </dev/tty
+    IFS= read -r otp </dev/tty
+    stty echo </dev/tty
+    printf '\n' >/dev/tty
+
+    if [ -z "$otp" ]; then
+        echo "::error::npm OTP was empty" >&2
+        return 1
+    fi
+
+    NPM_CONFIG_OTP="$otp" npm "${publish_args[@]}"
+}
+
 if [ "${NPM_SKIP_EXISTING_CHECK:-false}" != "true" ] && npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
     echo "${PACKAGE_NAME}@${VERSION} is already published; leaving registry unchanged."
     exit 0
@@ -62,7 +86,13 @@ printf '%s\n' "$publish_output"
 
 if [ "$publish_status" -ne 0 ]; then
     if printf '%s\n' "$publish_output" | grep -q 'EOTP'; then
-        echo "::error::npm publish requires OTP. Configure npm trusted publishing for .github/workflows/release.yaml or replace NPM_TOKEN with a granular token that has bypass 2FA enabled." >&2
+        if can_prompt_for_otp; then
+            echo "npm publish requires a one-time password."
+            prompt_for_otp
+            exit $?
+        fi
+
+        echo "::error::npm publish requires OTP. Re-run locally with an authenticator code, configure npm trusted publishing for .github/workflows/release.yaml, or replace NPM_TOKEN with a granular token that has bypass 2FA enabled." >&2
     fi
     exit "$publish_status"
 fi


### PR DESCRIPTION
## Summary

- retry npm publish after `EOTP` by prompting for an OTP when running from an interactive terminal
- keep CI non-interactive by failing fast when `CI=true` or no `/dev/tty` is available
- preserve the existing trusted-publishing/token guidance for pipeline failures

## Validation

- `bash -n scripts/publish_npm_package.sh`
- fake npm CI-mode EOTP test confirms no prompt/hang
- fake npm interactive EOTP test confirms prompt + retry succeeds
- `just --yes release npm-publish-dry-run 0.2.4 stable`