### PR TITLE
Fix release license metadata

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -92,7 +92,7 @@ nfpms:
     description: |-
       Festival Methodology CLI suite.
       AI-native project planning with fest and camp.
-    license: "BUSL-1.1"
+    license: "FSL-1.1-ALv2"
     formats:
       - deb
       - rpm
@@ -121,7 +121,7 @@ aurs:
     description: "Festival Methodology CLI suite (fest + camp) - AI-native project planning"
     maintainers:
       - "Obedience Corp <contact@obediencecorp.com>"
-    license: "BUSL-1.1"
+    license: "FSL-1.1-ALv2"
     private_key: "{{ .Env.AUR_SSH_KEY }}"
     git_url: "ssh://aur@aur.archlinux.org/festival-bin.git"
     skip_upload: auto
@@ -151,7 +151,7 @@ aurs:
 #       token: "{{ .Env.SCOOP_GITHUB_TOKEN }}"
 #     homepage: "https://fest.build"
 #     description: "Festival Methodology CLI suite (fest + camp) - AI-native project planning"
-#     license: "BUSL-1.1"
+#     license: "FSL-1.1-ALv2"
 
 checksum:
   name_template: 'checksums.txt'
@@ -179,7 +179,7 @@ homebrew_casks:
       - festival-suite
     homepage: "https://github.com/Obedience-Corp/festival"
     description: "Festival Methodology CLI suite (fest + camp)"
-    license: "BUSL-1.1"
+    license: "FSL-1.1-ALv2"
     skip_upload: auto
     directory: Casks
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/Obedience-Corp/festival/issues"
   },
-  "license": "BUSL-1.1",
+  "license": "FSL-1.1-ALv2",
   "bin": {
     "camp": "bin/camp",
     "fest": "bin/fest"

--- a/themes/festival/theme.toml
+++ b/themes/festival/theme.toml
@@ -1,5 +1,5 @@
 name = "Festival"
-license = "BSL-1.1"
+license = "FSL-1.1-ALv2"
 description = "Custom theme for Festival documentation matching the festui design system"
 min_version = "0.100.0"
 


### PR DESCRIPTION
## Summary
- update npm package metadata from BUSL-1.1 to FSL-1.1-ALv2
- update GoReleaser package metadata for nfpm, AUR, Homebrew, and the disabled Scoop block
- update the Hugo theme metadata license to FSL-1.1-ALv2

## Root Cause
The repository LICENSE and README already use FSL-1.1-ALv2, but release packaging metadata still had stale BUSL/BSL values. npm reads the license from npm/package.json at publish time, which is why @obedience-corp/festival@0.2.4 shows BUSL-1.1 on the registry.

## Validation
- rg -n "BUSL|BSL"
- npm pkg get license from npm/
- git diff --check
- just release npm-publish-dry-run 0.2.4 stable

## Follow-up
Because npm package version metadata is immutable after publish, 0.2.4 cannot be corrected in place. After this lands, publish a 0.2.5 patch release so latest points at a version with FSL metadata, then consider deprecating 0.2.4 with a short message about incorrect license metadata.