### PR TITLE
Add distribution metrics just recipes

### DIFF
--- a/.justfiles/metrics.just
+++ b/.justfiles/metrics.just
@@ -4,8 +4,6 @@
 npm_package := env("FESTIVAL_NPM_PACKAGE", "@obedience-corp/festival")
 homebrew_cask := env("FESTIVAL_HOMEBREW_CASK", "obedience-corp/tap/festival")
 github_repo := env("FESTIVAL_GITHUB_REPO", "Obedience-Corp/festival")
-compare_npm_package := env("COMPARE_NPM_PACKAGE", "@openparachute/vault")
-compare_github_repo := env("COMPARE_GITHUB_REPO", "ParachuteComputer/parachute-vault")
 
 [private]
 default:
@@ -113,49 +111,3 @@ github repo=github_repo:
     macos="$(jq '[.[] | .assets[]? | select(.name | test("macOS-all\\.tar\\.gz$")) | .download_count] | add // 0' <<<"$releases")"
     echo "release_asset_downloads: ${total}"
     echo "macos_archive_downloads: ${macos}"
-
-# Compare Festival npm/GitHub metrics against another package and repository
-[no-cd]
-compare package=compare_npm_package repo=compare_github_repo:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    command -v curl >/dev/null || { echo "curl is required" >&2; exit 1; }
-    command -v gh >/dev/null || { echo "gh is required" >&2; exit 1; }
-    command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
-
-    encode_package() {
-        local value="$1"
-        value="${value//@/%40}"
-        value="${value//\//%2F}"
-        printf '%s' "$value"
-    }
-
-    npm_downloads() {
-        local period="$1"
-        local package="$2"
-        local encoded
-        encoded="$(encode_package "$package")"
-        curl -fsSL "https://api.npmjs.org/downloads/point/${period}/${encoded}" 2>/dev/null |
-            jq -r '.downloads | tostring' 2>/dev/null || printf 'unavailable'
-    }
-
-    repo_stars() {
-        gh repo view "$1" --json stargazerCount --jq '.stargazerCount'
-    }
-
-    festival_package="{{npm_package}}"
-    festival_repo="{{github_repo}}"
-
-    echo "npm downloads"
-    printf "%-32s %12s %12s\n" "package" "last-week" "last-month"
-    printf "%-32s %12s %12s\n" "$festival_package" "$(npm_downloads last-week "$festival_package")" "$(npm_downloads last-month "$festival_package")"
-    printf "%-32s %12s %12s\n" "{{package}}" "$(npm_downloads last-week "{{package}}")" "$(npm_downloads last-month "{{package}}")"
-
-    echo ""
-    echo "GitHub stars"
-    printf "%-36s %8s\n" "repo" "stars"
-    printf "%-36s %8s\n" "$festival_repo" "$(repo_stars "$festival_repo")"
-    printf "%-36s %8s\n" "{{repo}}" "$(repo_stars "{{repo}}")"
-
-    echo ""
-    echo "Note: npm downloads are download events, not unique users. Homebrew cask analytics are not included here because they only apply when both projects ship comparable casks."

--- a/.justfiles/metrics.just
+++ b/.justfiles/metrics.just
@@ -1,0 +1,161 @@
+#!/usr/bin/env just --justfile
+# Distribution metrics
+
+npm_package := env("FESTIVAL_NPM_PACKAGE", "@obedience-corp/festival")
+homebrew_cask := env("FESTIVAL_HOMEBREW_CASK", "obedience-corp/tap/festival")
+github_repo := env("FESTIVAL_GITHUB_REPO", "Obedience-Corp/festival")
+compare_npm_package := env("COMPARE_NPM_PACKAGE", "@openparachute/vault")
+compare_github_repo := env("COMPARE_GITHUB_REPO", "ParachuteComputer/parachute-vault")
+
+[private]
+default:
+    @just --list --justfile {{source_file()}}
+
+# Show the main Festival distribution metrics
+[no-cd]
+summary:
+    @just --justfile {{source_file()}} homebrew
+    @echo ""
+    @just --justfile {{source_file()}} npm
+    @echo ""
+    @just --justfile {{source_file()}} github
+
+# Show Homebrew cask install analytics for Festival
+[no-cd]
+homebrew cask=homebrew_cask:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v curl >/dev/null || { echo "curl is required" >&2; exit 1; }
+    command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+    echo "Homebrew cask analytics: {{cask}}"
+    printf "%-8s %-12s %-12s %10s %8s\n" "window" "start" "end" "installs" "rank"
+    for days in 30 90 365; do
+        json="$(curl -fsSL "https://formulae.brew.sh/api/analytics/cask-install/${days}d.json")"
+        row="$(
+            jq -r --arg cask "{{cask}}" --arg days "${days}d" '
+                . as $root
+                | .items[]?
+                | select(.cask == $cask)
+                | [$days, $root.start_date, $root.end_date, .count, (.number | tostring)]
+                | @tsv
+            ' <<<"$json"
+        )"
+        if [ -n "$row" ]; then
+            printf "%-8s %-12s %-12s %10s %8s\n" $row
+        else
+            printf "%-8s %-12s %-12s %10s %8s\n" "${days}d" "-" "-" "0" "-"
+        fi
+    done
+
+# Show npm package metadata and download windows
+[no-cd]
+npm package=npm_package:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v curl >/dev/null || { echo "curl is required" >&2; exit 1; }
+    command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+    package="{{package}}"
+    encoded="${package//@/%40}"
+    encoded="${encoded//\//%2F}"
+
+    echo "npm package: ${package}"
+    if command -v npm >/dev/null && metadata="$(npm view "$package" version license dist-tags --json 2>/dev/null)"; then
+        jq -r '"version: " + (.version // "unknown"), "license: " + (.license // "unknown"), "dist-tags: " + ((."dist-tags" // {}) | tojson)' <<<"$metadata"
+    else
+        echo "metadata: unavailable"
+    fi
+
+    echo ""
+    printf "%-12s %10s %-12s %-12s\n" "window" "downloads" "start" "end"
+    for period in last-week last-month; do
+        if json="$(curl -fsSL "https://api.npmjs.org/downloads/point/${period}/${encoded}" 2>/dev/null)"; then
+            jq -r --arg period "$period" '[ $period, (.downloads | tostring), .start, .end ] | @tsv' <<<"$json" |
+                while IFS=$'\t' read -r window downloads start end; do
+                    printf "%-12s %10s %-12s %-12s\n" "$window" "$downloads" "$start" "$end"
+                done
+        else
+            printf "%-12s %10s %-12s %-12s\n" "$period" "unavailable" "-" "-"
+        fi
+    done
+
+    echo ""
+    echo "Last-month daily downloads grouped into 7-day buckets:"
+    if range_json="$(curl -fsSL "https://api.npmjs.org/downloads/range/last-month/${encoded}" 2>/dev/null)"; then
+        jq -r '.downloads[] | [.day, .downloads] | @tsv' <<<"$range_json" |
+            awk 'BEGIN { sum = 0; start = "" } { if (start == "") start = $1; sum += $2; if (NR % 7 == 0) { printf "%s to %s\t%d\n", start, $1, sum; sum = 0; start = "" } } END { if (start != "") printf "%s to %s\t%d\n", start, $1, sum }'
+    else
+        echo "unavailable"
+    fi
+
+# Show GitHub repository and release asset metrics
+[no-cd]
+github repo=github_repo:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v gh >/dev/null || { echo "gh is required" >&2; exit 1; }
+    command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+    repo="{{repo}}"
+    echo "GitHub repo: ${repo}"
+    gh repo view "$repo" --json nameWithOwner,stargazerCount,forkCount,watchers,pushedAt,url |
+        jq -r '
+            "url: " + .url,
+            "stars: " + (.stargazerCount | tostring),
+            "forks: " + (.forkCount | tostring),
+            "watchers: " + (.watchers.totalCount | tostring),
+            "pushed_at: " + .pushedAt
+        '
+
+    releases="$(gh api "repos/${repo}/releases")"
+    total="$(jq '[.[] | .assets[]? | .download_count] | add // 0' <<<"$releases")"
+    macos="$(jq '[.[] | .assets[]? | select(.name | test("macOS-all\\.tar\\.gz$")) | .download_count] | add // 0' <<<"$releases")"
+    echo "release_asset_downloads: ${total}"
+    echo "macos_archive_downloads: ${macos}"
+
+# Compare Festival npm/GitHub metrics against another package and repository
+[no-cd]
+compare package=compare_npm_package repo=compare_github_repo:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v curl >/dev/null || { echo "curl is required" >&2; exit 1; }
+    command -v gh >/dev/null || { echo "gh is required" >&2; exit 1; }
+    command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+    encode_package() {
+        local value="$1"
+        value="${value//@/%40}"
+        value="${value//\//%2F}"
+        printf '%s' "$value"
+    }
+
+    npm_downloads() {
+        local period="$1"
+        local package="$2"
+        local encoded
+        encoded="$(encode_package "$package")"
+        curl -fsSL "https://api.npmjs.org/downloads/point/${period}/${encoded}" 2>/dev/null |
+            jq -r '.downloads | tostring' 2>/dev/null || printf 'unavailable'
+    }
+
+    repo_stars() {
+        gh repo view "$1" --json stargazerCount --jq '.stargazerCount'
+    }
+
+    festival_package="{{npm_package}}"
+    festival_repo="{{github_repo}}"
+
+    echo "npm downloads"
+    printf "%-32s %12s %12s\n" "package" "last-week" "last-month"
+    printf "%-32s %12s %12s\n" "$festival_package" "$(npm_downloads last-week "$festival_package")" "$(npm_downloads last-month "$festival_package")"
+    printf "%-32s %12s %12s\n" "{{package}}" "$(npm_downloads last-week "{{package}}")" "$(npm_downloads last-month "{{package}}")"
+
+    echo ""
+    echo "GitHub stars"
+    printf "%-36s %8s\n" "repo" "stars"
+    printf "%-36s %8s\n" "$festival_repo" "$(repo_stars "$festival_repo")"
+    printf "%-36s %8s\n" "{{repo}}" "$(repo_stars "{{repo}}")"
+
+    echo ""
+    echo "Note: npm downloads are download events, not unique users. Homebrew cask analytics are not included here because they only apply when both projects ship comparable casks."

--- a/justfile
+++ b/justfile
@@ -16,6 +16,9 @@ mod docs '.justfiles/docs.just'
 [doc('Release management')]
 mod release '.justfiles/release.just'
 
+[doc('Distribution metrics')]
+mod metrics '.justfiles/metrics.just'
+
 [doc('Submodule management')]
 mod sub '.justfiles/sub.just'
 


### PR DESCRIPTION
## Summary
- add a `metrics` justfile module for first-party Festival distribution analytics
- expose Homebrew cask install analytics, npm package download windows, and GitHub repo/release asset metrics
- keep the recipes read-only and tolerant of unavailable npm download data for newly published packages

## Scope
This intentionally avoids competitor or cross-project comparison metrics. Those belong in the private campaign workspace when needed for one-off analysis or business tracking.

## Validation
- `just --list`
- `just metrics`
- `just metrics homebrew`
- `just metrics npm`
- `just metrics github`
- `just metrics summary`
- `git diff --check`