### PR TITLE
chore(refs): refresh submodules to camp v0.2.6 / fest v0.2.8

### DIFF
--- a/docs/cli-reference/camp/camp.md
+++ b/docs/cli-reference/camp/camp.md
@@ -49,13 +49,16 @@ camp [flags]
 
 ### SEE ALSO
 
+* [camp attach](../camp_attach/)	 - Attach an external directory to a campaign
 * [camp cache](../camp_cache/)	 - Manage the navigation index cache
 * [camp clone](../camp_clone/)	 - Clone a campaign with full submodule setup
 * [camp commit](../camp_commit/)	 - Commit changes in the campaign root
 * [camp completion](../camp_completion/)	 - Generate the autocompletion script for the specified shell
 * [camp concepts](../camp_concepts/)	 - List configured concepts
 * [camp copy](../camp_copy/)	 - Copy a file or directory within the campaign
+* [camp create](../camp_create/)	 - Create a new campaign at the default campaigns directory
 * [camp date](../camp_date/)	 - Append date suffix to file or directory name
+* [camp detach](../camp_detach/)	 - Remove the attachment marker from a directory
 * [camp doctor](../camp_doctor/)	 - Diagnose and fix campaign health issues
 * [camp dungeon](../camp_dungeon/)	 - Manage the campaign dungeon
 * [camp fresh](../camp_fresh/)	 - Post-merge branch cycling: sync to default branch and optionally create a new working branch
@@ -83,6 +86,7 @@ camp [flags]
 * [camp shell-init](../camp_shell-init/)	 - Output shell initialization code
 * [camp shortcuts](../camp_shortcuts/)	 - List all available shortcuts
 * [camp skills](../camp_skills/)	 - Manage campaign skill directory links
+* [camp stage](../camp_stage/)	 - Stage changes in the campaign root
 * [camp status](../camp_status/)	 - Show git status of the campaign
 * [camp switch](../camp_switch/)	 - Switch to a different campaign
 * [camp sync](../camp_sync/)	 - Safely synchronize submodules
@@ -90,3 +94,4 @@ camp [flags]
 * [camp unpin](../camp_unpin/)	 - Remove a saved pin
 * [camp unregister](../camp_unregister/)	 - Remove campaign from registry
 * [camp version](../camp_version/)	 - Show version information
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_attach.md
+++ b/docs/cli-reference/camp/camp_attach.md
@@ -1,0 +1,56 @@
+---
+title: "camp attach"
+linkTitle: "camp attach"
+description: "Attach an external directory to a campaign"
+---
+
+## camp attach
+
+Attach an external directory to a campaign
+
+### Synopsis
+
+Attach a non-project directory to a campaign by writing a .camp marker.
+
+The user manages the symlink (if any). camp attach only writes the marker at
+the resolved target so commands run from inside that directory know which
+campaign owns it.
+
+If the target is reached through a symlink, camp follows it once and writes
+the marker at the final directory.
+
+Campaign selection:
+  - inside a campaign, omit --campaign to attach to the current campaign
+  - outside a campaign in an interactive terminal, omit --campaign to pick
+  - use a bare --campaign to force the picker even inside a campaign
+  - use --campaign <name-or-id> for scripts or to skip the picker
+
+Examples:
+  camp attach ai_docs/examples/external-repo
+  camp attach ~/scratch/notes-link
+  camp attach ~/scratch/notes-link --campaign
+  camp attach /abs/path/to/dir --campaign platform
+
+```
+camp attach <path> [flags]
+```
+
+### Options
+
+```
+  -c, --campaign string   Target campaign by name or ID; omit value to pick interactively
+      --force             Overwrite an existing attachment marker
+  -h, --help              help for attach
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces

--- a/docs/cli-reference/camp/camp_commit.md
+++ b/docs/cli-reference/camp/camp_commit.md
@@ -39,9 +39,10 @@ camp commit [flags]
 ```
   -a, --all              Stage all changes before committing (default true)
       --amend            Amend the previous commit
+      --auto-write       Run configured commit message writer
   -h, --help             help for commit
       --include-refs     Include submodule ref changes when staging at campaign root
-  -m, --message string   Commit message (required)
+  -m, --message string   Commit message (required unless --auto-write)
   -p, --project string   Operate on a specific project/submodule path
       --sub              Operate on the submodule detected from current directory
 ```

--- a/docs/cli-reference/camp/camp_create.md
+++ b/docs/cli-reference/camp/camp_create.md
@@ -1,0 +1,51 @@
+---
+title: "camp create"
+linkTitle: "camp create"
+description: "Create a new campaign at the default campaigns directory"
+---
+
+## camp create
+
+Create a new campaign at the default campaigns directory
+
+### Synopsis
+
+Create a new campaign at <campaigns_dir>/<name>/, using the same scaffolding as 'camp init'. The default campaigns directory is ~/campaigns/ and can be configured via 'camp settings' or by editing the campaigns_dir field in ~/.obey/campaign/config.json.
+
+```
+camp create <name> [flags]
+```
+
+### Examples
+
+```
+  camp create my-project
+  camp create my-project -d "Description" -m "Mission"
+  camp create my-project --path ~/Dev/sandbox
+  camp create my-project --dry-run
+```
+
+### Options
+
+```
+  -d, --description string   Campaign description
+      --dry-run              Show what would be done without creating anything
+  -h, --help                 help for create
+  -m, --mission string       Campaign mission statement
+  -n, --name string          Campaign display name (defaults to <name> positional)
+      --no-git               Skip git repository initialization
+      --path string          Override the base campaigns directory (campaign created at <path>/<name>/)
+  -t, --type string          Campaign type (product, research, tools, personal) (default "product")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces

--- a/docs/cli-reference/camp/camp_detach.md
+++ b/docs/cli-reference/camp/camp_detach.md
@@ -1,0 +1,42 @@
+---
+title: "camp detach"
+linkTitle: "camp detach"
+description: "Remove the attachment marker from a directory"
+---
+
+## camp detach
+
+Remove the attachment marker from a directory
+
+### Synopsis
+
+Remove the .camp attachment marker from the target directory.
+
+Refuses on linked-project markers; use 'camp project unlink' for those.
+The user-managed symlink (if any) is not modified.
+
+Examples:
+  camp detach ai_docs/examples/external-repo
+  camp detach ~/scratch/notes-link
+
+```
+camp detach <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for detach
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces

--- a/docs/cli-reference/camp/camp_dungeon_move.md
+++ b/docs/cli-reference/camp/camp_dungeon_move.md
@@ -15,6 +15,7 @@ Move items within the dungeon or from the parent directory into the dungeon.
 Without --triage, moves an item already in the dungeon root to a status directory.
 With --triage, moves an item from the parent directory into the dungeon.
 With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
+Moves are always auto-committed so dungeon history remains auditable.
 
 Statuses: completed, archived, someday
 
@@ -33,7 +34,6 @@ camp dungeon move <item> [status] [flags]
 
 ```
   -h, --help             help for move
-      --no-commit        Don't create a git commit
       --to-docs string   Route triage item into an existing campaign-root docs/<subdir> (requires --triage)
       --triage           Move from parent directory (not from dungeon root)
 ```

--- a/docs/cli-reference/camp/camp_init.md
+++ b/docs/cli-reference/camp/camp_init.md
@@ -61,7 +61,6 @@ camp init [path] [flags]
       --no-git               Skip git repository initialization
       --no-register          Don't add to global registry
       --repair               Add missing files to existing campaign
-      --skip-fest            Skip automatic Festival Methodology initialization
   -t, --type string          Campaign type (product, research, tools, personal) (default "product")
       --yes                  Skip repair confirmation prompt (for scripting)
 ```

--- a/docs/cli-reference/camp/camp_intent.md
+++ b/docs/cli-reference/camp/camp_intent.md
@@ -61,6 +61,7 @@ camp intent [flags]
 * [camp intent add](../camp_intent_add/)	 - Create a new intent
 * [camp intent archive](../camp_intent_archive/)	 - Archive an intent
 * [camp intent count](../camp_intent_count/)	 - Count intents by status directory
+* [camp intent crawl](../camp_intent_crawl/)	 - Interactive intent triage
 * [camp intent edit](../camp_intent_edit/)	 - Edit an existing intent
 * [camp intent explore](../camp_intent_explore/)	 - Interactive intent explorer
 * [camp intent find](../camp_intent_find/)	 - Search for intents by title or content

--- a/docs/cli-reference/camp/camp_intent_crawl.md
+++ b/docs/cli-reference/camp/camp_intent_crawl.md
@@ -1,0 +1,52 @@
+---
+title: "camp intent crawl"
+linkTitle: "camp intent crawl"
+description: "Interactive intent triage"
+---
+
+## camp intent crawl
+
+Interactive intent triage
+
+### Synopsis
+
+Walk live intents one at a time and decide their fate.
+
+Default scope is the working set: inbox, ready, and active. Each candidate is
+shown with a compact preview. For each one you can keep, move to another
+status, skip, or quit. Moves to dungeon statuses require a reason.
+
+Existing dungeon intents are not crawl candidates. Use 'camp intent move' to
+restore them explicitly.
+
+Examples:
+  camp intent crawl
+  camp intent crawl --status inbox --limit 25
+  camp intent crawl --status ready --status active --sort priority
+  camp intent crawl --no-commit
+
+```
+camp intent crawl [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for crawl
+      --limit int        Stop after N candidates (0 = no limit)
+      --no-commit        Apply moves and logs but do not auto-commit
+      --sort string      Sort mode: stale, updated, created, priority, title (default "stale")
+      --status strings   Restrict to live statuses (repeatable: inbox, ready, active)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp intent](../camp_intent/)	 - Manage campaign intents

--- a/docs/cli-reference/camp/camp_project.md
+++ b/docs/cli-reference/camp/camp_project.md
@@ -55,5 +55,6 @@ camp project [flags]
 * [camp project remote](../camp_project_remote/)	 - Manage remotes for a project
 * [camp project remove](../camp_project_remove/)	 - Remove a project from campaign
 * [camp project run](../camp_project_run/)	 - Run a command inside a project directory
+* [camp project stage](../camp_project_stage/)	 - Stage changes in a project submodule
 * [camp project unlink](../camp_project_unlink/)	 - Unlink a linked project from a campaign
 * [camp project worktree](../camp_project_worktree/)	 - Manage worktrees for a project

--- a/docs/cli-reference/camp/camp_project_commit.md
+++ b/docs/cli-reference/camp/camp_project_commit.md
@@ -32,8 +32,9 @@ camp project commit [flags]
 ```
   -a, --all              Stage all changes (default true)
       --amend            Amend the previous commit
+      --auto-write       Run configured commit message writer
   -h, --help             help for commit
-  -m, --message string   Commit message (required)
+  -m, --message string   Commit message (required unless --auto-write)
   -p, --project string   Project name (auto-detected from cwd if not specified)
       --sync             Sync submodule ref at campaign root after commit (opt-in)
 ```

--- a/docs/cli-reference/camp/camp_project_stage.md
+++ b/docs/cli-reference/camp/camp_project_stage.md
@@ -1,0 +1,51 @@
+---
+title: "camp project stage"
+linkTitle: "camp project stage"
+description: "Stage changes in a project submodule"
+---
+
+## camp project stage
+
+Stage changes in a project submodule
+
+### Synopsis
+
+Stage changes within a project submodule without committing.
+
+Runs the same auto-staging logic as 'camp project commit' (including
+stale lock file cleanup) but stops before creating a commit, so you can
+use a different commit strategy.
+
+Auto-detects the current project from your working directory,
+or use --project to specify a project by name.
+
+Examples:
+  # From within a project directory
+  cd projects/my-api
+  camp project stage
+
+  # Specify project by name
+  camp project stage --project my-api
+
+```
+camp project stage [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for stage
+  -p, --project string   Project name (auto-detected from cwd if not specified)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp project](../camp_project/)	 - Manage campaign projects

--- a/docs/cli-reference/camp/camp_stage.md
+++ b/docs/cli-reference/camp/camp_stage.md
@@ -1,0 +1,56 @@
+---
+title: "camp stage"
+linkTitle: "camp stage"
+description: "Stage changes in the campaign root"
+---
+
+## camp stage
+
+Stage changes in the campaign root
+
+### Synopsis
+
+Stage changes in the campaign root directory without committing.
+
+Runs the same auto-staging logic as 'camp commit' (including stale lock
+file cleanup) but stops before creating a commit, so you can use a
+different commit strategy (interactive 'git commit --patch', a GUI
+client, signing flow, etc.).
+
+At the campaign root, submodule ref changes (projects/*) are excluded
+from staging by default to prevent accidental ref conflicts across
+machines. Use --include-refs to stage them explicitly.
+
+Use --sub to stage in the submodule detected from your current directory.
+Use -p/--project to stage in a specific project (e.g., -p projects/camp).
+
+Examples:
+  camp stage
+  camp stage --include-refs
+  camp stage --sub
+  camp stage -p projects/camp
+
+```
+camp stage [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for stage
+      --include-refs     Include submodule ref changes when staging at campaign root
+  -p, --project string   Operate on a specific project/submodule path
+      --sub              Operate on the submodule detected from current directory
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces

--- a/docs/cli-reference/camp/camp_workitem.md
+++ b/docs/cli-reference/camp/camp_workitem.md
@@ -1,0 +1,53 @@
+---
+title: "camp workitem"
+linkTitle: "camp workitem"
+description: "View active campaign work items"
+---
+
+## camp workitem
+
+View active campaign work items
+
+### Synopsis
+
+View active campaign work items across intents, designs, explore, and festivals.
+
+Default mode launches an interactive TUI dashboard. Use --json for machine-readable
+output or --print to select and print a path for shell integration.
+
+Examples:
+  camp workitem                              # interactive dashboard
+  camp workitem --json                       # JSON output for agents/scripts
+  camp workitem --json --type design         # filter by type
+  camp workitem --json --type intent --limit 5
+  camp workitem --print                      # select and print path
+
+```
+camp workitem [flags]
+```
+
+### Options
+
+```
+  -h, --help                help for workitem
+      --json                Output as JSON
+      --limit int           Maximum number of items to return
+      --print               Print path only (for shell integration)
+      --query string        Search query to filter items
+      --stage stringArray   Filter by lifecycle stage (inbox, active, ready, planning)
+      --type stringArray    Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp workitem adopt](../camp_workitem_adopt/)	 - Attach .workitem metadata to an existing directory
+* [camp workitem create](../camp_workitem_create/)	 - Create a new workitem with v1 minimum metadata

--- a/docs/cli-reference/camp/camp_workitem_adopt.md
+++ b/docs/cli-reference/camp/camp_workitem_adopt.md
@@ -1,0 +1,34 @@
+---
+title: "camp workitem adopt"
+linkTitle: "camp workitem adopt"
+description: "Attach .workitem metadata to an existing directory"
+---
+
+## camp workitem adopt
+
+Attach .workitem metadata to an existing directory
+
+```
+camp workitem adopt <dir> [flags]
+```
+
+### Options
+
+```
+  -h, --help           help for adopt
+      --id string      override the generated id
+      --title string   human-readable title
+      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_create.md
+++ b/docs/cli-reference/camp/camp_workitem_create.md
@@ -1,0 +1,35 @@
+---
+title: "camp workitem create"
+linkTitle: "camp workitem create"
+description: "Create a new workitem with v1 minimum metadata"
+---
+
+## camp workitem create
+
+Create a new workitem with v1 minimum metadata
+
+```
+camp workitem create <slug> [flags]
+```
+
+### Options
+
+```
+      --dir string     parent dir override (default: workflow/<type>)
+  -h, --help           help for create
+      --id string      override the generated id
+      --title string   human-readable title
+      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/fest/fest.md
+++ b/docs/cli-reference/fest/fest.md
@@ -96,5 +96,6 @@ Run 'fest understand' to learn the methodology before executing tasks.
 * [fest unlink](../fest_unlink/)	 - Remove festival-project link (context-aware)
 * [fest validate](../fest_validate/)	 - Check festival structure - find missing task files and issues
 * [fest version](../fest_version/)	 - Show version information
+* [fest watch](../fest_watch/)	 - Watch a festival's in-progress work
 * [fest wizard](../fest_wizard/)	 - Interactive guidance and assistance for festival creation
 * [fest workflow](../fest_workflow/)	 - Manage workflow-based phase execution

--- a/docs/cli-reference/fest/fest_commit.md
+++ b/docs/cli-reference/fest/fest_commit.md
@@ -57,6 +57,9 @@ Examples:
 
   fest commit --stage=false -m "Only commit staged"
   # Skip auto-staging, commit only what's already staged
+
+  fest commit --auto-write
+  # Run the configured campaign commit-message hook from the target repo
 ```
 
 ```
@@ -66,10 +69,11 @@ fest commit [flags]
 ### Options
 
 ```
+      --auto-write        run configured commit message writer
       --festival string   festival name or ID (overrides auto-detection)
   -h, --help              help for commit
       --json              output result as JSON
-  -m, --message string    commit message
+  -m, --message string    commit message (required unless --auto-write)
       --no-root           skip campaign root commit (project commit only)
       --no-tag            don't prepend task reference
       --stage             auto-stage all changes before commit (default true)

--- a/docs/cli-reference/fest/fest_create_workflow.md
+++ b/docs/cli-reference/fest/fest_create_workflow.md
@@ -38,10 +38,12 @@ fest create workflow [flags]
       --festival string     Festival root override
   -h, --help                help for workflow
       --json                Emit JSON output
+      --no-init             skip .workflow/ runtime init (standalone mode only)
       --path string         Phase directory path (default ".")
       --position string     Workflow position relative to sequences (before|after) (default "after")
       --steps string        Inline JSON with workflow definition
       --steps-file string   Path to JSON file with workflow definition
+      --type string         workflow type (standalone mode only) (default "task")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest/fest_watch.md
+++ b/docs/cli-reference/fest/fest_watch.md
@@ -1,0 +1,55 @@
+---
+title: "fest watch"
+linkTitle: "fest watch"
+description: "Watch a festival's in-progress work"
+---
+
+## fest watch
+
+Watch a festival's in-progress work
+
+### Synopsis
+
+Watch the in-progress state of a festival.
+
+With a selector, fest watch resolves a festival by directory name or logical ID.
+Without a selector, it watches the current festival when run from a festival
+directory, or the linked festival when run from a linked project directory.
+
+From a campaign or festivals workspace in an interactive terminal, fest watch
+opens a festival picker. Watch mode refreshes in place until you press Ctrl+C.
+It does not change your shell directory.
+
+```
+fest watch [festival-selector] [flags]
+```
+
+### Examples
+
+```
+  fest watch
+  fest watch my-festival
+  fest watch GS0001
+```
+
+### Options
+
+```
+      --collapsed   show collapsed tree with counters only
+      --goals       show goals for phases and sequences
+  -h, --help        help for watch
+      --summary     show aggregate summary instead of tree view
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.config/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest](../fest/)	 - Festival Methodology CLI - goal-oriented project management for AI agents

--- a/docs/cli-reference/fest/fest_workflow.md
+++ b/docs/cli-reference/fest/fest_workflow.md
@@ -76,8 +76,11 @@ Examples:
 * [fest](../fest/)	 - Festival Methodology CLI - goal-oriented project management for AI agents
 * [fest workflow advance](../fest_workflow_advance/)	 - Complete current step and move to next
 * [fest workflow approve](../fest_workflow_approve/)	 - Approve a blocking checkpoint
+* [fest workflow init](../fest_workflow_init/)	 - Initialize standalone workflow runtime
 * [fest workflow reject](../fest_workflow_reject/)	 - Reject checkpoint with feedback
 * [fest workflow reset](../fest_workflow_reset/)	 - Reset workflow to step 1
+* [fest workflow runs](../fest_workflow_runs/)	 - List runs of a standalone workflow
 * [fest workflow show](../fest_workflow_show/)	 - Display current step details
 * [fest workflow skip](../fest_workflow_skip/)	 - Operator override: mark workflow steps as skipped/completed
+* [fest workflow start](../fest_workflow_start/)	 - Start a new run for a standalone workflow
 * [fest workflow status](../fest_workflow_status/)	 - Show workflow progress

--- a/docs/cli-reference/fest/fest_workflow_init.md
+++ b/docs/cli-reference/fest/fest_workflow_init.md
@@ -1,0 +1,46 @@
+---
+title: "fest workflow init"
+linkTitle: "fest workflow init"
+description: "Initialize standalone workflow runtime"
+---
+
+## fest workflow init
+
+Initialize standalone workflow runtime
+
+### Synopsis
+
+Create .workflow/ next to an existing WORKFLOW.md.
+
+Run from the directory containing WORKFLOW.md. The command refuses to run
+inside a festival phase. Use --force to overwrite an existing
+.workflow/workflow.yaml.
+
+This command does not create .workitem; that file is owned by camp
+(see 'camp workitem create' and 'camp workitem adopt').
+
+```
+fest workflow init [flags]
+```
+
+### Options
+
+```
+      --force                overwrite existing .workflow/workflow.yaml
+  -h, --help                 help for init
+      --workflow-id string   workflow_id to write into manifest (defaults to wf-<basename>)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.config/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --phase string    specify phase directory (e.g., 001_INGEST)
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest workflow](../fest_workflow/)	 - Manage workflow-based phase execution

--- a/docs/cli-reference/fest/fest_workflow_runs.md
+++ b/docs/cli-reference/fest/fest_workflow_runs.md
@@ -1,0 +1,40 @@
+---
+title: "fest workflow runs"
+linkTitle: "fest workflow runs"
+description: "List runs of a standalone workflow"
+---
+
+## fest workflow runs
+
+List runs of a standalone workflow
+
+### Synopsis
+
+List runs recorded in .workflow/workflow.yaml.
+
+Each row shows run id, status, started time, and completed time.
+
+```
+fest workflow runs [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for runs
+      --json   emit JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.config/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --phase string    specify phase directory (e.g., 001_INGEST)
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest workflow](../fest_workflow/)	 - Manage workflow-based phase execution

--- a/docs/cli-reference/fest/fest_workflow_start.md
+++ b/docs/cli-reference/fest/fest_workflow_start.md
@@ -1,0 +1,39 @@
+---
+title: "fest workflow start"
+linkTitle: "fest workflow start"
+description: "Start a new run for a standalone workflow"
+---
+
+## fest workflow start
+
+Start a new run for a standalone workflow
+
+### Synopsis
+
+Create a new .workflow/runs/<run-id>/ directory and mark it active.
+
+Requires .workflow/workflow.yaml to exist (run fest workflow init first).
+
+```
+fest workflow start [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for start
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.config/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --phase string    specify phase directory (e.g., 001_INGEST)
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest workflow](../fest_workflow/)	 - Manage workflow-based phase execution


### PR DESCRIPTION
## Summary
- Pinned submodules to latest stable tags via `just refresh`
- camp: `v0.2.5` -> `v0.2.6`
- fest: `v0.2.5` -> `v0.2.8`
- Regenerated CLI reference docs (surfaces `camp workitem`, `fest workflow`, `fest watch`, and several new subcommands)

## Test plan
- [ ] CI green
- [ ] Spot check `docs/cli-reference/camp/camp_workitem.md` and `docs/cli-reference/fest/fest_watch.md` render correctly
- [ ] Confirm `just release verify` (or equivalent pin check) passes