### PR TITLE
fix(release): prefer newest exact channel tag

### DIFF
--- a/tools/release-operator/commands.go
+++ b/tools/release-operator/commands.go
@@ -137,12 +137,12 @@ func (r *repoContext) exactTag(name string) (string, error) {
 	return exactTagAt(r.submodulePath(name))
 }
 
-func (r *repoContext) exactComponentTags() (string, string, error) {
-	festTag, err := r.exactTag("fest")
+func (r *repoContext) exactComponentTags(modeName string) (string, string, error) {
+	festTag, err := exactTagAtForMode(r.submodulePath("fest"), modeName)
 	if err != nil {
 		return "", "", err
 	}
-	campTag, err := r.exactTag("camp")
+	campTag, err := exactTagAtForMode(r.submodulePath("camp"), modeName)
 	if err != nil {
 		return "", "", err
 	}
@@ -515,7 +515,7 @@ func runDraftFromLatest(ctx *repoContext, version string, mode releaseMode, iter
 		return err
 	}
 
-	festTag, campTag, err := ctx.exactComponentTags()
+	festTag, campTag, err := ctx.exactComponentTags(mode.Name)
 	if err != nil {
 		return err
 	}

--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -321,11 +321,11 @@ func collectState(repoRoot, channel, festSelector, campSelector string) (operato
 		return operator.BundleInput{}, err
 	}
 
-	currentFestTag, err := exactTagAt(filepath.Join(repoRoot, "fest"))
+	currentFestTag, err := exactTagAtForMode(filepath.Join(repoRoot, "fest"), channel)
 	if err != nil {
 		return operator.BundleInput{}, err
 	}
-	currentCampTag, err := exactTagAt(filepath.Join(repoRoot, "camp"))
+	currentCampTag, err := exactTagAtForMode(filepath.Join(repoRoot, "camp"), channel)
 	if err != nil {
 		return operator.BundleInput{}, err
 	}
@@ -390,21 +390,36 @@ func collectState(repoRoot, channel, festSelector, campSelector string) (operato
 	return state, nil
 }
 
-// exactTagAt returns the tag pointing at HEAD in dir, or "" if HEAD is untagged.
-// Uses `git tag --points-at HEAD` because it exits 0 with empty stdout for the
-// untagged-HEAD case, avoiding locale- and version-dependent stderr parsing that
-// `git describe --exact-match` would require. If multiple tags point at HEAD,
-// the first line (sorted lexicographically by git) is returned.
+// exactTagAt returns the newest tag pointing at HEAD in dir, or "" if HEAD is
+// untagged. Uses `git tag --points-at HEAD` because it exits 0 with empty
+// stdout for the untagged-HEAD case, avoiding locale- and version-dependent
+// stderr parsing that `git describe --exact-match` would require.
 func exactTagAt(dir string) (string, error) {
-	out, err := gitOutput(dir, "tag", "--points-at", "HEAD")
+	tags, err := exactTagsAt(dir)
 	if err != nil {
 		return "", err
 	}
-	if out == "" {
+	if len(tags) == 0 {
 		return "", nil
 	}
-	first, _, _ := strings.Cut(out, "\n")
-	return first, nil
+	return tags[0], nil
+}
+
+func exactTagAtForMode(dir, mode string) (string, error) {
+	tags, err := exactTagsAt(dir)
+	if err != nil {
+		return "", err
+	}
+	for _, tag := range tags {
+		if operator.TagMatchesMode(tag, mode) {
+			return tag, nil
+		}
+	}
+	return "", nil
+}
+
+func exactTagsAt(dir string) ([]string, error) {
+	return gitLines(dir, "tag", "--points-at", "HEAD", "--sort=-v:refname")
 }
 
 func resolveSelectedTag(dir, mode, selector string) (string, error) {
@@ -418,7 +433,7 @@ func resolveSelectedTag(dir, mode, selector string) (string, error) {
 		}
 		return tag, nil
 	case "keep":
-		tag, err := exactTagAt(dir)
+		tag, err := exactTagAtForMode(dir, mode)
 		if err != nil {
 			return "", err
 		}

--- a/tools/release-operator/main_test.go
+++ b/tools/release-operator/main_test.go
@@ -169,16 +169,18 @@ func TestResolveSelectedTag(t *testing.T) {
 		runGit(t, repo, "add", "CHANGELOG.md")
 		runGit(t, repo, "commit", "-m", "stable release")
 		runGit(t, repo, "tag", "v0.2.0")
+		runGit(t, repo, "tag", "v0.2.1")
+		runGit(t, repo, "tag", "v0.2.2-dev.1")
 
 		if got, err := resolveSelectedTag(repo, "stable", "latest"); err != nil {
 			t.Fatalf("resolveSelectedTag(latest) error = %v", err)
-		} else if want := "v0.2.0"; got != want {
+		} else if want := "v0.2.1"; got != want {
 			t.Fatalf("resolveSelectedTag(latest) = %q, want %q", got, want)
 		}
 
 		if got, err := resolveSelectedTag(repo, "stable", "keep"); err != nil {
 			t.Fatalf("resolveSelectedTag(keep) error = %v", err)
-		} else if want := "v0.2.0"; got != want {
+		} else if want := "v0.2.1"; got != want {
 			t.Fatalf("resolveSelectedTag(keep) = %q, want %q", got, want)
 		}
 
@@ -231,17 +233,43 @@ func TestExactTagAt(t *testing.T) {
 
 	t.Run("returns a single tag when HEAD has multiple", func(t *testing.T) {
 		repo := initTestRepo(t)
-		runGit(t, repo, "tag", "v0.1.0-alias")
+		runGit(t, repo, "tag", "v0.1.1")
 
 		got, err := exactTagAt(repo)
 		if err != nil {
 			t.Fatalf("exactTagAt returned error: %v", err)
 		}
-		if got == "" {
-			t.Fatal("exactTagAt returned empty string, want one of the HEAD tags")
+		if want := "v0.1.1"; got != want {
+			t.Fatalf("exactTagAt = %q, want newest exact tag %q", got, want)
 		}
-		if got != "v0.1.0" && got != "v0.1.0-alias" {
-			t.Fatalf("exactTagAt = %q, want one of v0.1.0 or v0.1.0-alias", got)
+	})
+
+	t.Run("returns newest exact tag for requested mode", func(t *testing.T) {
+		repo := initTestRepo(t)
+		runGit(t, repo, "tag", "v0.2.7")
+		runGit(t, repo, "tag", "v0.2.8")
+		runGit(t, repo, "tag", "v0.3.0-dev.1")
+		runGit(t, repo, "tag", "v0.3.0-rc.1")
+
+		tests := []struct {
+			mode string
+			want string
+		}{
+			{mode: "stable", want: "v0.2.8"},
+			{mode: "dev", want: "v0.3.0-dev.1"},
+			{mode: "rc", want: "v0.3.0-rc.1"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.mode, func(t *testing.T) {
+				got, err := exactTagAtForMode(repo, tt.mode)
+				if err != nil {
+					t.Fatalf("exactTagAtForMode returned error: %v", err)
+				}
+				if got != tt.want {
+					t.Fatalf("exactTagAtForMode(%q) = %q, want %q", tt.mode, got, tt.want)
+				}
+			})
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fix the release operator exact-tag selection when multiple release tags point at the same component commit.

This happened after `fest` published both `v0.2.7` and `v0.2.8` at commit `7ea9f0d`: release status/plan paths could report the current pin as `v0.2.7` even though the stable refresh intended `v0.2.8`.

Changes:
- Sort exact HEAD tags by version before selecting a default tag.
- Make release-channel paths (`keep`, current pinned tags, post-pin component validation) choose the newest exact tag that matches the requested channel.
- Add regression coverage for multiple exact tags on one commit.

## Test plan

- [x] `go -C tools/release-operator test ./...`
- [x] `just test release-operator`
- [x] `just release status` reports `fest: 7ea9f0d (v0.2.8)` and `camp: cf9cbc3 (v0.2.6)`

## Release note

After this merges, rerun the release command from `main` with both bundled components selected from latest stable tags:

```bash
just release stable fest=latest camp=latest
```

That should create/push the Festival `v0.2.5` tag and trigger the release workflow. This release is intended to carry `fest v0.2.8` and `camp v0.2.6`.