### PR TITLE
docs(install): document upgrade paths for Homebrew and other installers

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -123,6 +123,50 @@ fest --version
 camp --version
 ```
 
+## Upgrading
+
+How you upgrade depends on how you installed Festival.
+
+### Homebrew
+
+```bash
+brew update
+brew upgrade --cask festival
+```
+
+`brew outdated --cask` will surface a new festival release when one is available.
+
+### npm / pnpm / bun
+
+```bash
+npm install -g @obedience-corp/festival@latest
+```
+
+### Debian / Ubuntu, Fedora / RHEL, Alpine
+
+Download the latest package from [GitHub Releases](https://github.com/Obedience-Corp/festival/releases/latest) and reinstall using the same `dpkg -i`, `rpm -i`, or `apk add` command from the install steps above.
+
+### Arch Linux (AUR)
+
+```bash
+yay -Syu festival-bin
+```
+
+### Shell Script
+
+Re-run the installer. It will replace the binaries in `~/.local/bin` with the latest release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Obedience-Corp/festival/main/install.sh | bash
+```
+
+### From Source
+
+```bash
+go install github.com/Obedience-Corp/fest/cmd/fest@latest
+go install github.com/Obedience-Corp/camp/cmd/camp@latest
+```
+
 ## Shell Integration
 
 Enable navigation features by adding to your `~/.zshrc` or `~/.bashrc`:

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,6 +22,13 @@ Or use Homebrew:
 brew install --cask Obedience-Corp/tap/festival
 ```
 
+To upgrade an existing Homebrew install:
+
+```bash
+brew update
+brew upgrade --cask festival
+```
+
 Or download the latest macOS release directly:
 
 <a href="https://github.com/Obedience-Corp/festival/releases/latest" class="btn btn--primary">Download for macOS</a>


### PR DESCRIPTION
## Summary

- Adds an explicit Homebrew upgrade snippet (`brew update && brew upgrade --cask festival`) to the short install page (`docs/install.md`).
- Adds a full **Upgrading** section to `docs/getting-started/installation.md` covering every supported install method: Homebrew, npm/pnpm/bun, Debian/Ubuntu, Fedora/RHEL, Alpine, Arch (AUR), the install.sh shell script, and `go install` from source.

## Why

The install docs tell users how to install via Homebrew but never tell them how to upgrade. Since festival ships as a versioned Homebrew **cask** via GoReleaser, `brew upgrade --cask festival` works out of the box, but users had no in-docs signal for it. This closes the gap for brew users and documents the upgrade path for every other installer at the same time.

## Test plan

- [ ] Visual review of rendered Hugo pages for `/install/` and `/getting-started/installation/`.
- [ ] Confirm no broken anchors or tabs in `installation.md` (the new section sits between Verify Installation and Shell Integration, outside the macOS/Linux/Windows tab block).