### PR TITLE
chore(docs): add Google Analytics 4 to docs site

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -3,6 +3,8 @@ title: Festival
 theme: festival
 contentDir: docs
 
+googleAnalytics: G-2CT5B4LDH2
+
 params:
   description: "Mission-based AI workspace management for developers using AI coding tools"
   repo: "https://github.com/Obedience-Corp/festival"

--- a/themes/festival/layouts/_default/baseof.html
+++ b/themes/festival/layouts/_default/baseof.html
@@ -8,6 +8,7 @@
   {{ $css := resources.Get "css/main.css" | minify | fingerprint }}
   <link rel="stylesheet" href="{{ $css.RelPermalink }}">
   <link href="{{ "pagefind/pagefind-ui.css" | relURL }}" rel="stylesheet">
+  {{ template "_internal/google_analytics.html" . }}
 </head>
 <body class="{{ if .IsHome }}site-body--home{{ else }}site-body--docs{{ end }}">
   {{ partial "header.html" . }}


### PR DESCRIPTION
## Summary
- Add `googleAnalytics: G-2CT5B4LDH2` to `hugo.yaml`
- Render Hugo's built-in `_internal/google_analytics.html` template in the theme's `baseof.html` `<head>`

## Why
Docs site (`docs.fest.build`) had no analytics. Adds GA4 so we can see traffic, top pages, and search-referral terms across the docs.

## Behavior notes
- Hugo's internal GA4 template **auto-disables on `hugo server`** (local dev), so localhost runs do not send hits to the production property.
- GA only ships in production builds (i.e. the GitHub Pages release-tag deploy in `.github/workflows/pages.yaml`).
- No env var needed — the docs site is single-environment (one prod build per tag, deployed to GitHub Pages).

## Test plan
- [ ] `just docs build` produces output containing the gtag.js snippet with `G-2CT5B4LDH2`
- [ ] `hugo server` (dev) produces output WITHOUT the gtag.js snippet (sanity check on the auto-disable)
- [ ] After tagging a release and the Pages deploy completes, visit `https://docs.fest.build/` and confirm hits appear in GA Realtime