### PR TITLE
chore(docs): unify GA tag with festivalfrontend

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -3,7 +3,7 @@ title: Festival
 theme: festival
 contentDir: docs
 
-googleAnalytics: G-2CT5B4LDH2
+googleAnalytics: G-BBJ8SY37X5
 
 params:
   description: "Mission-based AI workspace management for developers using AI coding tools"


### PR DESCRIPTION
## Summary
- Replace docs site GA measurement ID `G-2CT5B4LDH2` with `G-BBJ8SY37X5` (the ID already in use by `festivalfrontend`)
- Both surfaces now report into a single GA property whose owning account is known to be accessible
- The orphaned `G-2CT5B4LDH2` ID is tracked as a campaign intent so ownership can be reclaimed later

## Why
The original tag was added to `hugo.yaml` in #56 but ties to an unknown Google account. Rather than block on rediscovering that account, switch to the festivalfrontend tag now so analytics data is captured in a property we control. We can revisit the unified-vs-separate question once both keys are accounted for.

## Test plan
- [ ] Hugo build succeeds: `just docs build` (or equivalent)
- [ ] Rendered HTML contains `G-BBJ8SY37X5` and not `G-2CT5B4LDH2`
- [ ] GA Realtime shows hits from the docs domain after deploy