### PR TITLE
docs: reframe positioning around the organizational layer for AI work

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Festival is the organizational layer for work done with AI. Instead of asking "w
 
 Festival ships two CLIs (`camp` and `fest`) that solve the three problems above.
 
-**`camp`** manages campaigns: isolated workspaces that hold all the projects, docs, research, and planning for a single mission. It gives you instant navigation across everything in the workspace, project lifecycle management, and shell shortcuts that make `cd` obsolete.
+**`camp`** manages campaigns: isolated workspaces that hold all the projects, docs, research, and planning for a single mission, a high-level purpose like your startup, your job, or a hobby. A mission grows over time, and the campaign grows with it. It gives you instant navigation across everything in the workspace, project lifecycle management, and shell shortcuts that make `cd` obsolete.
 
 **`fest`** manages festivals: structured plans that break work into phases, sequences, and tasks. The hierarchy is designed for AI agents to execute autonomously, pause, and resume without context loss. Run `fest next` and the agent gets its next task with full surrounding context. Run `fest commit` and every commit traces back to the plan.
 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,15 @@ After installing, see the [quick start guide](https://docs.fest.build/getting-st
 
 ## The Problem
 
-AI coding tools are fast. But speed without context and direction just means you burn tokens faster. Every new session starts from zero: no memory of the larger goal, no structure for multi-step work, no way to pick up where you left off. You end up re-explaining the same context, getting inconsistent results, and losing coherence across sessions.
+If you work on more than a few things at once, staying organized becomes a job of its own.
 
-Traditional tools don't solve this because they weren't designed for it. You need:
+Your work spreads across repositories, documents, chats, notes, bookmarks, and AI conversations. Finding where something belongs becomes work. Remembering what you were doing becomes work. Switching between efforts becomes work.
+
+AI makes this harder, not easier. It generates plans, code, research, and tasks faster than you can file them. The bottleneck moves from producing work to organizing it.
+
+So every new AI session starts from zero. No memory of the larger goal, no structure for multi-step work, no way to pick up where you left off. You re-explain the same context, get inconsistent results, and lose coherence across sessions.
+
+Festival is the organizational layer for work done with AI. Instead of asking "where should this go?" you put it in the campaign it belongs to. Instead of asking "what was I working on?" you resume the campaign. To turn that organization into outcomes, Festival gives every mission three things:
 
 1. **Context**: a workspace that holds all projects, docs, and planning for a mission in one place
 2. **Direction**: structured plans that AI agents can pick up, execute, and resume without losing the thread

--- a/docs/methodology/campaigns.md
+++ b/docs/methodology/campaigns.md
@@ -15,7 +15,7 @@ A campaign solves this by isolating one mission into a single, navigable workspa
 
 ## What is a Campaign?
 
-A campaign is an isolated workspace for a single mission. It groups all related projects as git submodules, all festival plans in a structured hierarchy, and all supporting materials - documentation, research, workflow configs, design artifacts - into a standard directory layout.
+A campaign is an isolated workspace for a single mission. It groups all related projects, as git submodules or as links to repositories already on your machine, all festival plans in a structured hierarchy, and all supporting materials - documentation, research, workflow configs, design artifacts - into a standard directory layout.
 
 The key property is **navigability**. Both humans and AI agents can enter a campaign and immediately understand its structure. Projects are in `projects/`. Plans are in `festivals/`. Docs are in `docs/`. There is no guessing, no project-specific convention to learn, no onboarding friction.
 
@@ -90,12 +90,55 @@ cgo w           # Jump to workflow/
 cgo p api       # Jump to projects/api-service/ (fuzzy match)
 ```
 
-### Project Management
+### Adding Projects
+
+A project can join a campaign two ways, depending on where the code already lives.
+
+**As a submodule.** If the project is a remote git repository, add it as a tracked
+submodule under `projects/`. Camp clones it and records the ref:
 
 ```bash
-camp project add git@github.com:org/repo.git    # Add a submodule
-camp project list                                # List all projects
-camp project remove old-project                  # Remove a submodule
+camp project add git@github.com:org/repo.git    # Clone a remote repo as a submodule
+camp project new my-service                      # Scaffold a brand-new project in the campaign
+```
+
+**As a linked workspace.** If the project already exists on your machine, link it
+instead of cloning a second copy. Camp creates a symlink at `projects/<name>` pointing
+at the real directory and writes a `.camp` marker so commands run from inside that
+directory know which campaign owns it. The original checkout is left exactly where it is:
+
+```bash
+camp project link ~/code/my-project              # Link an existing local directory
+camp project link                                # Link the current directory
+camp project link ~/code/api --name backend      # Override the project name
+```
+
+Linking is the right choice for repositories you already clone and work on outside any
+campaign. Your existing branches, remotes, and history stay in place; the campaign just
+gains a navigable reference to them. Both humans (`cgo p backend`) and AI agents treat a
+linked workspace exactly like a submodule project.
+
+To list, unlink, or remove projects:
+
+```bash
+camp project list                                # List all projects (submodules and links)
+camp project unlink my-project                   # Remove a link (leaves the external workspace intact)
+camp project remove old-service                  # Remove a submodule project
+```
+
+`unlink` removes only the symlink and the campaign marker. The external workspace and
+its git history are never touched. Use `remove` for submodule projects.
+
+### Attaching Other Directories
+
+Not every directory a campaign should own is a project. A notes folder, a scratch
+directory, or an external reference repo can be attached without becoming a project.
+`camp attach` writes a `.camp` marker at the target so commands run from inside it
+resolve to the right campaign. You manage the symlink, if any, yourself:
+
+```bash
+camp attach ~/scratch/research-notes             # Attach a non-project directory
+camp detach ~/scratch/research-notes             # Remove the attachment marker
 ```
 
 ### Health and Sync

--- a/docs/methodology/campaigns.md
+++ b/docs/methodology/campaigns.md
@@ -15,7 +15,7 @@ A campaign solves this by isolating one mission into a single, navigable workspa
 
 ## What is a Campaign?
 
-A campaign is an isolated workspace for a single mission. It groups all related projects, as git submodules or as links to repositories already on your machine, all festival plans in a structured hierarchy, and all supporting materials - documentation, research, workflow configs, design artifacts - into a standard directory layout.
+A campaign is an isolated workspace for a single mission, a high-level purpose such as a startup, a job, or an open-source project you maintain. A mission is broad and long-lived, so a campaign grows with it over months and years. It groups all related projects, as git submodules or as links to repositories already on your machine, all festival plans in a structured hierarchy, and all supporting materials - documentation, research, workflow configs, design artifacts - into a standard directory layout.
 
 The key property is **navigability**. Both humans and AI agents can enter a campaign and immediately understand its structure. Projects are in `projects/`. Plans are in `festivals/`. Docs are in `docs/`. There is no guessing, no project-specific convention to learn, no onboarding friction.
 

--- a/docs/methodology/why-festival.md
+++ b/docs/methodology/why-festival.md
@@ -1,0 +1,81 @@
+---
+title: "Why Festival"
+weight: 20
+---
+
+# Why Festival
+
+## The Organization Problem
+
+If you work on more than a few things at once, staying organized becomes a job of
+its own.
+
+Work ends up spread across repositories, documents, chats, notes, bookmarks, TODO
+lists, and AI conversations. Finding where something belongs becomes work.
+Remembering what you were doing becomes work. Switching contexts becomes work. The
+effort you spend keeping track of work starts to rival the effort of doing it.
+
+## AI Makes It Worse
+
+AI coding tools are genuinely fast. They write code, run research, draft plans, and
+break down tasks faster than most people can keep up with. That speed is real, and it
+is not the problem.
+
+The problem is what happens to all of that output. AI generates plans, code,
+research, and tasks faster than you can file them. The bottleneck moves from
+producing work to organizing it. Every new session starts from nothing: no memory of
+the larger goal, no structure for multi-step work, no thread to pick back up. You
+spend your time re-explaining context that an organized workspace would make obvious.
+
+## Campaigns: A Workspace for a Mission
+
+Festival is a workspace system built for that reality. It organizes work into
+campaigns.
+
+A campaign is a workspace for a single mission. Everything related to that mission
+lives in one place: projects, repositories, plans, documentation, research, and the
+work your AI agents produce.
+
+Instead of asking:
+
+> "Where should this go?"
+
+You put it in the campaign it belongs to.
+
+Instead of asking:
+
+> "What was I working on?"
+
+You resume the campaign.
+
+Both humans and AI agents can enter a campaign and immediately understand its
+structure, because every campaign uses the same predictable layout. See
+[Campaigns]({{< ref "/methodology/campaigns" >}}) for the full directory model.
+
+## From Organization to Outcomes
+
+Organization is the foundation, not the finish line. Once your work has a home,
+Festival gives every mission three things that turn structure into results:
+
+1. **Context** - a campaign workspace that holds all projects, docs, and research.
+2. **Direction** - structured plans that AI agents can execute, pause, and resume.
+3. **Verification** - work captured in reviewable files you can trace and audit.
+
+The planning model that supplies direction and verification is the Festival
+Methodology. Read the [Methodology Overview]({{< ref "/methodology/overview" >}}) to
+see how phases, sequences, and tasks turn a goal into work an agent can keep moving
+through.
+
+## Built to Scale
+
+This is not a system for one project. It is how the author of Festival manages 17
+campaigns and more than 150 projects without losing context between them.
+
+A campaign can be a side project with two or three repos, or a mission spanning
+dozens of projects and hundreds of plans. The structure scales in both directions,
+and switching between missions is a single command.
+
+## Get Started
+
+Create your first campaign and run your first festival in about five minutes:
+[Quick Start]({{< ref "/getting-started/quickstart" >}}).

--- a/docs/methodology/why-festival.md
+++ b/docs/methodology/why-festival.md
@@ -32,9 +32,11 @@ spend your time re-explaining context that an organized workspace would make obv
 Festival is a workspace system built for that reality. It organizes work into
 campaigns.
 
-A campaign is a workspace for a single mission. Everything related to that mission
-lives in one place: projects, repositories, plans, documentation, research, and the
-work your AI agents produce.
+A campaign is a workspace for a mission: a high-level purpose like your startup, your
+job, or a hobby you keep coming back to. A mission is not a single task. It is a
+durable area of focus that grows over time, accumulating many projects, plans,
+documents, research, and decisions. A campaign keeps all of that in one place, however
+large it gets and however long it runs.
 
 Instead of asking:
 

--- a/docs/methodology/work-items.md
+++ b/docs/methodology/work-items.md
@@ -1,0 +1,174 @@
+---
+title: "Work Items"
+weight: 27
+---
+
+# Work Items
+
+## One Model for Every Kind of Work
+
+A campaign accumulates work in several forms. Ideas land as intents. Design
+documents grow under `workflow/design/`. Exploratory research collects under
+`workflow/explore/`. Larger efforts become festivals. Each of these is "work in
+progress," but each used to have its own shape, its own location, and its own way
+of being tracked.
+
+Work items give all of them one normalized model. An intent, a design doc, an
+explore note, and a festival are all surfaced the same way: you can list them in a
+single dashboard, link them to the code they touch, mark one as the thing you are
+currently working on, and commit changes scoped to it. You stop thinking about four
+different filing systems and start thinking about one stream of work.
+
+This is the organizational primitive underneath a campaign. Campaigns give a mission
+a workspace; work items give the work inside that workspace a shared identity.
+
+## What Is a Work Item?
+
+A work item is any tracked unit of work in a campaign. It has a type, a stable id, a
+title, and a location on disk. `camp` discovers work items across the campaign and
+presents them through one interface.
+
+There are two categories of type:
+
+- **Builtin types** are discovered automatically: `intent`, `design`, `explore`, and
+  `festival`. You do not have to mark these. `camp` knows where they live and surfaces
+  them as work items wherever they appear.
+- **Custom types** are anything else you want to track: `feature`, `bug`, `chore`, or
+  any slug-safe name your team uses. A custom work item lives under
+  `workflow/<type>/<slug>/` and is identified by a `.workitem` marker file in its
+  directory.
+
+## The Dashboard
+
+`camp workitem` (aliases `wi`, `workitems`) is the entry point. With no arguments it
+opens an interactive dashboard across every work item in the campaign. For agents and
+scripts, the same data is available as JSON:
+
+```bash
+camp workitem                          # interactive dashboard
+camp workitem --json                   # machine-readable output
+camp workitem --json --type design     # filter by type
+camp workitem --json --type intent --limit 5
+camp workitem --stage active           # filter by lifecycle stage
+camp workitem --query auth             # search by text
+camp workitem --print                  # select one and print its path
+```
+
+`--print` is built for shell integration: it resolves to a single path you can `cd`
+into or feed to another command.
+
+## The `.workitem` Marker
+
+Custom work items carry a `.workitem` file in their directory. It is a small YAML
+document that gives the work item its identity:
+
+```yaml
+version: v1alpha5
+kind: workitem
+id: feature-timeline-redesign-2026-05-20
+type: feature
+title: Timeline Redesign
+```
+
+You rarely write this by hand. `camp` manages the `version` line and backfills
+internal fields (a short reference used in commit tags, and the quest id active when
+the item was created) as the schema evolves. Builtin work items (intents and
+festivals) are discovered without a marker, because `camp` already knows their layout.
+
+Two commands create the marker for you:
+
+```bash
+camp workitem create my-feature --type feature --title "My feature"   # new directory
+camp workitem adopt workflow/design/existing-spike --title "Spike"    # existing directory
+```
+
+`create` scaffolds a new work item under `workflow/<type>/`. `adopt` attaches a
+marker to a directory that already exists.
+
+## Lifecycle Stages
+
+Some work item types move through stages, which map directly to directories:
+
+| Type | Stages | Location |
+| ---- | ------ | -------- |
+| `intent` | inbox, active, ready | `.campaign/intents/<stage>/` |
+| `festival` | planning, ready, active | `festivals/<stage>/<festival>/` |
+| `design`, `explore`, custom | single location | `workflow/<type>/<slug>/` |
+
+When a stage-bearing item finishes, it moves into a terminal dungeon
+(`workflow/<type>/dungeon/completed/`, `archived/`, or `someday/`). Dungeon items are
+preserved but are not treated as active work. See
+[Campaigns]({{< ref "/methodology/campaigns" >}}) for the surrounding directory layout.
+
+## The Current Work Item
+
+You can mark one work item as the thing you are working on right now. Later commands
+use it as the default context.
+
+```bash
+camp workitem current                          # show the current selection
+camp workitem current feature-timeline-redesign # set it
+camp workitem current --clear                  # clear it
+```
+
+When `camp` needs to know which work item a command applies to, it resolves context in
+order: an explicit selector you pass, then the nearest `.workitem` marker above your
+current directory, then a matching link in the registry, then the current selection.
+`camp workitem resolve --explain` prints the full resolution trace so you can see
+exactly which tier won and why.
+
+## Links
+
+A work item rarely lives in one place. A feature might touch a project repo, a
+worktree, and a festival plan. Links connect a work item to those targets so the
+relationship is recorded and reusable.
+
+```bash
+camp workitem link my-feature --project api-service   # link to a project
+camp workitem link my-feature --festival api-MR0001   # link to a festival
+camp workitem link my-feature --cwd                   # link to the current directory
+camp workitem links                                   # list links
+camp workitem unlink <link-id>                        # remove a link
+```
+
+Each link has a role. A `primary` link marks the active work item for a scope, and
+commit tooling picks it up automatically. `related`, `blocked_by`, and `supersedes`
+roles record context without affecting commit routing. Links are stored in
+`.campaign/workitems/links.yaml`, which is committed with the campaign so the whole
+team shares the same graph.
+
+## Scoped Commits
+
+`camp workitem commit` commits the changes that belong to a work item and nothing
+else. The staging plan is computed from the resolved context and printed before the
+commit runs. It never silently widens to `git add .` at the campaign root.
+
+```bash
+camp workitem commit -m "implement timeline grouping"
+```
+
+The commit carries a short work item reference inside its campaign tag, so every
+commit can be traced back to the work item it served. To retrieve that history later,
+across the campaign root and every linked repo:
+
+```bash
+camp workitem commits my-feature      # all commits attributed to this work item
+```
+
+## Keeping the Registry Healthy
+
+As work moves, links can point at directories that no longer exist or a current
+selection can go stale. `camp workitem doctor` reports these issues, and `--fix`
+repairs the auto-fixable ones (broken links, stale selections, missing references):
+
+```bash
+camp workitem doctor          # report health issues
+camp workitem doctor --fix    # repair what can be repaired automatically
+```
+
+## Why It Matters
+
+Work items are how a campaign stays navigable as it grows. Instead of remembering
+which folder a design doc lives in or which branch a feature is on, you ask the
+campaign: what work exists, what am I on, and what does it touch. The answer is the
+same shape whether the work is an intent, a research note, or a multi-phase festival.

--- a/docs/methodology/workflows-and-gates.md
+++ b/docs/methodology/workflows-and-gates.md
@@ -1,0 +1,168 @@
+---
+title: "Workflows & Gates"
+weight: 28
+---
+
+# Workflows & Gates
+
+## When a Phase Is a Process, Not a Task List
+
+Implementation phases break into numbered sequences and tasks. But some phases are not
+task lists at all. A planning phase, an ingest phase, or a research phase is a guided
+process: read the input, extract the requirements, make the decisions, produce the
+output. There is no clean way to pre-write that as a list of atomic tasks, because each
+step depends on the thinking done in the step before it.
+
+Workflows handle those phases. A workflow drives an agent through a phase one step at a
+time, with checkpoints where a human approves the work before the agent continues.
+Gates handle the other half: a quality check that runs at the end of a phase to confirm
+the phase actually achieved its goal before anything moves forward.
+
+Together they are how `fest` keeps an autonomous agent honest through the parts of the
+work that cannot be reduced to a checklist.
+
+## WORKFLOW.md: Step-Based Phase Guidance
+
+Workflow phases (planning, ingest, research) use a `WORKFLOW.md` file instead of
+numbered sequences. The document is the structure. Each step has four parts:
+
+- **Goal** what the step accomplishes.
+- **Actions** the ordered list of things to do.
+- **Output** the expected result.
+- **Checkpoint** an optional approval gate before the next step.
+
+A step looks like this:
+
+```markdown
+## Step 1: SCOPE
+
+**Goal:** Establish clear research objectives.
+
+**Actions:**
+1. Review inputs from previous phases
+2. Identify the key questions that need answering
+3. Decide what "good enough" looks like
+
+**Output:** Research questions and a source plan
+
+**Checkpoint:** None, proceed to Step 2
+```
+
+Standard festivals auto-scaffold their INGEST and PLAN phases with these files, so the
+planning process is guided out of the box. See
+[Phases]({{< ref "/methodology/phases" >}}) for where WORKFLOW.md sits in the phase
+structure.
+
+## Driving a Workflow
+
+`fest next` surfaces the current step the same way it surfaces the next task, so an
+agent always has one clear thing to do. The `fest workflow` commands move through the
+steps:
+
+```bash
+fest workflow status     # show progress through the workflow
+fest workflow show       # display the current step in full
+fest workflow advance    # complete the current step and move to the next
+fest workflow reset      # return to step 1
+fest workflow validate   # check that step numbering is well-formed
+```
+
+Progress is recorded in `<festival>/.fest/progress_events.jsonl`, an append-only event
+log. Current state is rebuilt by replaying the events, so the history of how a phase
+was worked through is never overwritten.
+
+## Checkpoints and Approval
+
+A step can require explicit human approval before the agent continues. When a step has
+a blocking checkpoint, the agent completes its actions, presents the output, and stops.
+Nothing advances until a person responds:
+
+```bash
+fest workflow approve                       # accept the work and move on
+fest workflow reject --reason "missing the error-handling cases"
+```
+
+`approve` marks the step complete and advances. `reject` sends the step back: it
+becomes blocked, the reason is recorded, and the agent revises in place. When the
+revision is ready, `fest workflow advance` resubmits it. This is the loop that lets an
+agent run autonomously through the routine steps while a human stays in control of the
+decisions that matter.
+
+## GATES.md: Phase-Level Quality Gates
+
+A gate verifies that a phase achieved its goal before the festival moves on. Gates live
+in a `GATES.md` file, and every gate step is itself an approval checkpoint. Instead of
+producing work, a gate step poses a quality or compliance question that must be answered
+and approved:
+
+```markdown
+## Step 1: PHASE GOAL
+
+**Question:** Does the implementation satisfy the phase goal? Were all required
+deliverables produced?
+
+**Actions:**
+1. Re-read PHASE_GOAL.md and compare objectives against actual results
+2. Verify each required deliverable exists and is functional
+3. Confirm the work solves the problem the phase was created for
+
+**Checkpoint:** Approval required, confirm the phase goal is met
+```
+
+Gates are available for all phase types. When `fest` navigates a phase, it routes
+automatically: the WORKFLOW.md runs first if it is incomplete, and the GATES.md runs
+once phase work is done. You do not pick the document; `fest workflow status` and
+`fest next` target the right one for where the phase is.
+
+## Reject, Skip, and Failed-Gate Remediation
+
+Three operator actions look similar but record different audit trails. Pick the one
+that matches what actually happened:
+
+| Action | Meaning | Use when |
+| ------ | ------- | -------- |
+| `fest workflow reject --reason "..."` | The checkpoint was reviewed and rejected. The step is blocked and waits for a revision. | The work needs to be redone in place. |
+| `fest workflow skip --reason "..."` | The step was completed by other means. It is treated as terminal. | The work is genuinely already done elsewhere and needs no revision loop. |
+| `fest workflow reject --reason "..." --remediation-phase <PHASE>` | A gate did not pass; a remediation phase is linked to fix the underlying issues. The gate is logged as failed, not approved and not skipped. | A review gate found real blockers and a new phase was added to correct them. |
+
+The remediation form keeps the trail honest. `fest next` routes into the remediation
+phase, and once that phase completes, routes back to the failed gate for
+re-evaluation, instead of silently passing it.
+
+## Structured Feedback
+
+Not every observation should block a step. `fest feedback` lets an agent record
+observations against named criteria during execution, for a human to aggregate and
+review afterward rather than in the middle of a checkpoint:
+
+```bash
+fest feedback init --criteria "Code quality" --criteria "Performance"
+fest feedback add --criteria "Code quality" --observation "Found duplication in the parser"
+fest feedback view
+fest feedback export --format markdown
+```
+
+This separates "here is something worth noting" from "stop and approve this," so the
+execution flow stays clean while quality signal still gets captured.
+
+## Standalone Workflows
+
+WORKFLOW.md is useful outside a festival too. A standalone workflow is a WORKFLOW.md in
+any directory, with its own runtime so you can track repeated runs of the same process:
+
+```bash
+fest create workflow my-process   # scaffold a WORKFLOW.md and its runtime
+fest workflow start               # begin a tracked run
+fest workflow runs                # list runs
+fest next                         # get the next step in the run
+```
+
+Each run records its own progress events, so a recurring process (a release checklist,
+a review routine) keeps a clean history per execution.
+
+## Why It Matters
+
+Tasks cover the work that can be written down in advance. Workflows and gates cover the
+work that cannot: the thinking-heavy phases and the quality checks that decide whether
+work is actually done. They are what let you hand a phase to an agent, walk away, and
+trust that it either reaches the goal or stops at a checkpoint and asks.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -71,6 +71,14 @@ menu:
       parent: methodology
       url: /methodology/tasks/
       weight: 26
+    - name: Work Items
+      parent: methodology
+      url: /methodology/work-items/
+      weight: 27
+    - name: Workflows & Gates
+      parent: methodology
+      url: /methodology/workflows-and-gates/
+      weight: 28
 
     - name: Guides
       identifier: guides

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -43,6 +43,10 @@ menu:
     - name: Methodology
       identifier: methodology
       weight: 20
+    - name: Why Festival
+      parent: methodology
+      url: /methodology/why-festival/
+      weight: 20
     - name: Overview
       parent: methodology
       url: /methodology/overview/

--- a/themes/festival/layouts/index.html
+++ b/themes/festival/layouts/index.html
@@ -2,12 +2,12 @@
 <div class="home-shell">
   <section class="home-hero">
     <div class="home-hero__copy">
-      <div class="home-hero__eyebrow">Structured AI Execution</div>
-      <h1>Agents at scale. Context that sticks.</h1>
+      <div class="home-hero__eyebrow">The organizational layer for AI work</div>
+      <h1>Where your AI work goes.</h1>
       <p>
-        Festival is a planning layer on top of the AI coding tools you already use.
-        Structure multi-project campaigns into phases, sequences, and tasks, then let
-        agents execute without losing the thread.
+        AI generates plans, code, and research faster than you can organize it.
+        Festival gives every mission one workspace, so you stop asking
+        "where should this go?" and "what was I working on?" and start shipping outcomes.
       </p>
 
       <div class="home-hero__actions">
@@ -121,7 +121,8 @@
     <div class="home-section__intro">
       <h2 class="home-section__heading">Why Teams Use Festival</h2>
       <p class="home-section__lede">
-        AI coding tools are fast inside a repo. Festival adds the planning and operational layer around them.
+        AI coding tools are fast inside a repo. The work they produce still has to live somewhere.
+        Festival is the organizational layer that keeps it in order.
       </p>
     </div>
 


### PR DESCRIPTION
## Why

Festival's public copy (README + docs.fest.build) currently leads with a **solution** framing: context, direction, verification. That is accurate but it under-explains the actual niche problem: **organizing the work you do with AI**.

AI generates plans, code, research, and tasks faster than anyone can file them. The bottleneck moves from *producing* work to *organizing* it. Festival is the organizational layer for that reality. Campaigns answer "where should this go?" and "what was I working on?".

This PR sharpens the problem statement and documents the camp/fest features that make that organizational layer real. Nothing here is auto-generated from the CLIs.

## Positioning reframe

- **README** - rewrote only the "The Problem" section to lead with the organization burden, then funnel into the existing three needs. The tagline, the mermaid diagram, the numbered context/direction/verification list, and "What Festival Does" are unchanged.
- **New page** `docs/methodology/why-festival.md` - dedicated problem framing (the organization problem, why AI makes it worse, campaigns as a workspace for a mission, from organization to outcomes, scale, CTA). Registered first under Methodology.
- **Homepage hero** `themes/festival/layouts/index.html` - reframed eyebrow, H1, lede, and the "Why Teams Use Festival" lede around the organizational layer. Terminal demo, how-it-works cards, install section, and tools grid untouched.

## New feature documentation

Three camp/fest capability areas had no hand-authored coverage. All are source-grounded and registered in the sidebar.

- **New page** `docs/methodology/work-items.md` - the unified work-item model across intents, designs, explore, and festivals. Covers builtin vs custom types, the `.workitem` marker, lifecycle stages, the current selection and context resolution, links and roles, scoped commits with traceable references, and `doctor`. Framed as the organizational primitive underneath a campaign.
- **New page** `docs/methodology/workflows-and-gates.md` - the `fest workflow` step-execution runtime. Covers the WORKFLOW.md step model, `fest next`/`advance`/`show`/`status`, blocking checkpoints with `approve`/`reject`, GATES.md phase gates and auto-routing, reject vs skip vs failed-gate remediation, the `progress_events.jsonl` audit trail, `fest feedback`, and standalone workflows.
- **Expanded** `docs/methodology/campaigns.md` - documents how projects join a campaign two ways: as a remote **submodule** (`camp project add` / `new`) or as a **linked workspace** (`camp project link`) that symlinks a repo already on the user's machine without cloning or moving it. Adds `unlink` vs `remove`, and `camp attach` / `detach` for non-project directories.

## Notes

- No changes under `docs/cli-reference/` (auto-generated).
- Public copy stays plain; no internal-only category vocabulary introduced.

## Verification

- `hugo --quiet` builds clean (Hugo fails the build on broken `{{< ref >}}` links; all cross-links resolve).
- New and expanded pages render; Why Festival appears first under Methodology, Work Items and Workflows & Gates appear after Tasks, and the homepage hero shows the new copy.