### PR TITLE
Release: pin fest v0.3.0 and camp v0.2.7

### DIFF
--- a/docs/cli-reference/camp/camp.md
+++ b/docs/cli-reference/camp/camp.md
@@ -75,6 +75,7 @@ camp [flags]
 * [camp pins](../camp_pins/)	 - List all pinned directories
 * [camp plugins](../camp_plugins/)	 - List discovered camp plugins on PATH
 * [camp project](../camp_project/)	 - Manage campaign projects
+* [camp promote](../camp_promote/)	 - Promote the workitem at cwd to a dungeon status
 * [camp pull](../camp_pull/)	 - Pull latest changes from remote
 * [camp push](../camp_push/)	 - Push campaign changes to remote
 * [camp refs-sync](../camp_refs-sync/)	 - Sync submodule ref pointers in campaign root
@@ -94,4 +95,5 @@ camp [flags]
 * [camp unpin](../camp_unpin/)	 - Remove a saved pin
 * [camp unregister](../camp_unregister/)	 - Remove campaign from registry
 * [camp version](../camp_version/)	 - Show version information
+* [camp workflow](../camp_workflow/)	 - Manage workflow collections
 * [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_commit.md
+++ b/docs/cli-reference/camp/camp_commit.md
@@ -37,14 +37,15 @@ camp commit [flags]
 ### Options
 
 ```
-  -a, --all              Stage all changes before committing (default true)
-      --amend            Amend the previous commit
-      --auto-write       Run configured commit message writer
-  -h, --help             help for commit
-      --include-refs     Include submodule ref changes when staging at campaign root
-  -m, --message string   Commit message (required unless --auto-write)
-  -p, --project string   Operate on a specific project/submodule path
-      --sub              Operate on the submodule detected from current directory
+  -a, --all               Stage all changes before committing (default true)
+      --amend             Amend the previous commit
+      --auto-write        Run configured commit message writer
+  -h, --help              help for commit
+      --include-refs      Include submodule ref changes when staging at campaign root
+  -m, --message string    Commit message (required unless --auto-write)
+  -p, --project string    Operate on a specific project/submodule path
+      --sub               Operate on the submodule detected from current directory
+      --workitem string   explicit workitem selector for the commit tag (overrides cwd-based resolution)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp/camp_dungeon_move.md
+++ b/docs/cli-reference/camp/camp_dungeon_move.md
@@ -15,6 +15,8 @@ Move items within the dungeon or from the parent directory into the dungeon.
 Without --triage, moves an item already in the dungeon root to a status directory.
 With --triage, moves an item from the parent directory into the dungeon.
 With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
+With --workitem, resolves a campaign workitem from anywhere and moves its directory
+into the workitem type's local dungeon.
 Moves are always auto-committed so dungeon history remains auditable.
 
 Statuses: completed, archived, someday
@@ -25,6 +27,7 @@ Examples:
   camp dungeon move old-project --triage         Move parent item into dungeon root
   camp dungeon move old-project archived --triage Move parent item directly to archived
   camp dungeon move stale-note.md --triage --to-docs architecture/api Route to docs subdirectory
+  camp dungeon move feature-slug archived --workitem Move workitem directory to its local archive
 
 ```
 camp dungeon move <item> [status] [flags]
@@ -36,6 +39,7 @@ camp dungeon move <item> [status] [flags]
   -h, --help             help for move
       --to-docs string   Route triage item into an existing campaign-root docs/<subdir> (requires --triage)
       --triage           Move from parent directory (not from dungeon root)
+      --workitem         Resolve item as a campaign workitem and move its directory to the local dungeon
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp/camp_project_commit.md
+++ b/docs/cli-reference/camp/camp_project_commit.md
@@ -30,13 +30,14 @@ camp project commit [flags]
 ### Options
 
 ```
-  -a, --all              Stage all changes (default true)
-      --amend            Amend the previous commit
-      --auto-write       Run configured commit message writer
-  -h, --help             help for commit
-  -m, --message string   Commit message (required unless --auto-write)
-  -p, --project string   Project name (auto-detected from cwd if not specified)
-      --sync             Sync submodule ref at campaign root after commit (opt-in)
+  -a, --all               Stage all changes (default true)
+      --amend             Amend the previous commit
+      --auto-write        Run configured commit message writer
+  -h, --help              help for commit
+  -m, --message string    Commit message (required unless --auto-write)
+  -p, --project string    Project name (auto-detected from cwd if not specified)
+      --sync              Sync submodule ref at campaign root after commit (opt-in)
+      --workitem string   explicit workitem selector for the commit tag (overrides cwd-based resolution)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp/camp_promote.md
+++ b/docs/cli-reference/camp/camp_promote.md
@@ -1,0 +1,50 @@
+---
+title: "camp promote"
+linkTitle: "camp promote"
+description: "Promote the workitem at cwd to a dungeon status"
+---
+
+## camp promote
+
+Promote the workitem at cwd to a dungeon status
+
+### Synopsis
+
+Promote the directory-style workitem containing the current working
+directory to a named status. Status directories live under the workitem
+type's local dungeon (workflow/<type>/dungeon/<status>/); outside the
+dungeon a workitem is treated as active.
+
+Run this from anywhere inside workflow/<type>/<slug>/. The workitem
+boundary is detected from cwd. The status argument is the destination
+directory name (e.g., completed, archived, someday) - no need to spell
+out "dungeon/".
+
+Examples:
+  camp promote completed   Shelve the workitem to its local dungeon/completed
+  camp promote archived    Move to dungeon/archived
+  camp promote someday     Move to dungeon/someday
+
+```
+camp promote <status> [flags]
+```
+
+### Options
+
+```
+  -h, --help        help for promote
+      --json        Output result as JSON
+      --no-commit   Skip auto-commit after promotion
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces

--- a/docs/cli-reference/camp/camp_workflow.md
+++ b/docs/cli-reference/camp/camp_workflow.md
@@ -1,0 +1,40 @@
+---
+title: "camp workflow"
+linkTitle: "camp workflow"
+description: "Manage workflow collections"
+---
+
+## camp workflow
+
+Manage workflow collections
+
+### Synopsis
+
+Manage workflow collections.
+
+A workflow collection is a campaign directory under workflow/<type>/ with
+navigation config and workitem type support.
+
+### Options
+
+```
+  -h, --help   help for workflow
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp workflow create](../camp_workflow_create/)	 - Create a custom workflow collection
+* [camp workflow doctor](../camp_workflow_doctor/)	 - Report workflow surface inconsistencies
+* [camp workflow list](../camp_workflow_list/)	 - List user-created workflow collections
+* [camp workflow shortcut](../camp_workflow_shortcut/)	 - Manage navigation shortcuts for workflow collections
+* [camp workflow show](../camp_workflow_show/)	 - Show a workflow collection's config and recent workitems
+* [camp workflow sync](../camp_workflow_sync/)	 - Repair auto-fixable doctor findings

--- a/docs/cli-reference/camp/camp_workflow_create.md
+++ b/docs/cli-reference/camp/camp_workflow_create.md
@@ -1,0 +1,36 @@
+---
+title: "camp workflow create"
+linkTitle: "camp workflow create"
+description: "Create a custom workflow collection"
+---
+
+## camp workflow create
+
+Create a custom workflow collection
+
+```
+camp workflow create <type> [flags]
+```
+
+### Options
+
+```
+      --dry-run           report planned writes without modifying the filesystem
+  -h, --help              help for create
+      --json              emit a structured JSON result
+      --replace           replace an existing shortcut or concept with the same name
+      --shortcut string   navigation shortcut for this workflow
+      --title string      human-readable workflow title
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](../camp_workflow/)	 - Manage workflow collections

--- a/docs/cli-reference/camp/camp_workflow_doctor.md
+++ b/docs/cli-reference/camp/camp_workflow_doctor.md
@@ -1,0 +1,32 @@
+---
+title: "camp workflow doctor"
+linkTitle: "camp workflow doctor"
+description: "Report workflow surface inconsistencies"
+---
+
+## camp workflow doctor
+
+Report workflow surface inconsistencies
+
+```
+camp workflow doctor [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for doctor
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](../camp_workflow/)	 - Manage workflow collections

--- a/docs/cli-reference/camp/camp_workflow_list.md
+++ b/docs/cli-reference/camp/camp_workflow_list.md
@@ -1,0 +1,32 @@
+---
+title: "camp workflow list"
+linkTitle: "camp workflow list"
+description: "List user-created workflow collections"
+---
+
+## camp workflow list
+
+List user-created workflow collections
+
+```
+camp workflow list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](../camp_workflow/)	 - Manage workflow collections

--- a/docs/cli-reference/camp/camp_workflow_shortcut.md
+++ b/docs/cli-reference/camp/camp_workflow_shortcut.md
@@ -1,0 +1,28 @@
+---
+title: "camp workflow shortcut"
+linkTitle: "camp workflow shortcut"
+description: "Manage navigation shortcuts for workflow collections"
+---
+
+## camp workflow shortcut
+
+Manage navigation shortcuts for workflow collections
+
+### Options
+
+```
+  -h, --help   help for shortcut
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](../camp_workflow/)	 - Manage workflow collections
+* [camp workflow shortcut add](../camp_workflow_shortcut_add/)	 - Attach a navigation shortcut to an existing workflow

--- a/docs/cli-reference/camp/camp_workflow_shortcut_add.md
+++ b/docs/cli-reference/camp/camp_workflow_shortcut_add.md
@@ -1,0 +1,33 @@
+---
+title: "camp workflow shortcut add"
+linkTitle: "camp workflow shortcut add"
+description: "Attach a navigation shortcut to an existing workflow"
+---
+
+## camp workflow shortcut add
+
+Attach a navigation shortcut to an existing workflow
+
+```
+camp workflow shortcut add <type> <key> [flags]
+```
+
+### Options
+
+```
+  -h, --help      help for add
+      --json      emit a structured JSON result
+      --replace   replace an existing shortcut with the same name
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow shortcut](../camp_workflow_shortcut/)	 - Manage navigation shortcuts for workflow collections

--- a/docs/cli-reference/camp/camp_workflow_show.md
+++ b/docs/cli-reference/camp/camp_workflow_show.md
@@ -1,0 +1,32 @@
+---
+title: "camp workflow show"
+linkTitle: "camp workflow show"
+description: "Show a workflow collection's config and recent workitems"
+---
+
+## camp workflow show
+
+Show a workflow collection's config and recent workitems
+
+```
+camp workflow show <type> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](../camp_workflow/)	 - Manage workflow collections

--- a/docs/cli-reference/camp/camp_workflow_sync.md
+++ b/docs/cli-reference/camp/camp_workflow_sync.md
@@ -1,0 +1,33 @@
+---
+title: "camp workflow sync"
+linkTitle: "camp workflow sync"
+description: "Repair auto-fixable doctor findings"
+---
+
+## camp workflow sync
+
+Repair auto-fixable doctor findings
+
+```
+camp workflow sync [flags]
+```
+
+### Options
+
+```
+      --apply   perform writes (default: report only)
+  -h, --help    help for sync
+      --json    emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](../camp_workflow/)	 - Manage workflow collections

--- a/docs/cli-reference/camp/camp_workitem.md
+++ b/docs/cli-reference/camp/camp_workitem.md
@@ -50,4 +50,12 @@ camp workitem [flags]
 
 * [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
 * [camp workitem adopt](../camp_workitem_adopt/)	 - Attach .workitem metadata to an existing directory
+* [camp workitem commit](../camp_workitem_commit/)	 - Commit changes scoped to the resolved workitem
+* [camp workitem commits](../camp_workitem_commits/)	 - List commits referencing a workitem across linked repos
 * [camp workitem create](../camp_workitem_create/)	 - Create a new workitem with v1 minimum metadata
+* [camp workitem current](../camp_workitem_current/)	 - Get, set, or clear the local current workitem
+* [camp workitem doctor](../camp_workitem_doctor/)	 - Report workitem link-registry health issues
+* [camp workitem link](../camp_workitem_link/)	 - Attach a workitem to a project, festival, worktree, or campaign path
+* [camp workitem links](../camp_workitem_links/)	 - List workitem links
+* [camp workitem resolve](../camp_workitem_resolve/)	 - Print the workitem the current context resolves to (read-only)
+* [camp workitem unlink](../camp_workitem_unlink/)	 - Remove one or more workitem links

--- a/docs/cli-reference/camp/camp_workitem_adopt.md
+++ b/docs/cli-reference/camp/camp_workitem_adopt.md
@@ -17,6 +17,7 @@ camp workitem adopt <dir> [flags]
 ```
   -h, --help           help for adopt
       --id string      override the generated id
+      --quest string   capture quest_id from this quest (defaults to CAMP_QUEST env var if set)
       --title string   human-readable title
       --type string    workitem type (feature, bug, chore, or custom) (default "feature")
 ```

--- a/docs/cli-reference/camp/camp_workitem_commit.md
+++ b/docs/cli-reference/camp/camp_workitem_commit.md
@@ -1,0 +1,53 @@
+---
+title: "camp workitem commit"
+linkTitle: "camp workitem commit"
+description: "Commit changes scoped to the resolved workitem"
+---
+
+## camp workitem commit
+
+Commit changes scoped to the resolved workitem
+
+### Synopsis
+
+Stage and commit changes belonging to a resolved workitem.
+
+The staging plan is computed from the resolver context (cwd-aware, with
+explicit positional <selector> or --project overrides) and printed to stderr
+before the commit runs. The plan never silently widens to "git add ." at the
+campaign root.
+
+See docs/workitem-commit-reference.md for the staging matrix and flag
+precedence.
+
+```
+camp workitem commit [selector] [flags]
+```
+
+### Options
+
+```
+      --dry-run                     print the staging plan and exit without committing
+      --exclude stringArray         path to remove from the staging plan (repeatable)
+      --festival string             festival id for the festival resolver tier
+  -h, --help                        help for commit
+      --include stringArray         additional path to stage (repeatable; relative to repo root)
+      --include-submodule-pointer   include dirty project submodule pointers in the plan
+      --json                        emit the staging plan and commit result as JSON on stdout
+  -m, --message string              commit message (required unless --dry-run)
+      --project string              force project-repo context by name (skips resolver)
+      --staged                      commit whatever is already in the git index
+      --workitem string             explicit workitem selector (overrides cwd-based resolution)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_commits.md
+++ b/docs/cli-reference/camp/camp_workitem_commits.md
@@ -1,0 +1,46 @@
+---
+title: "camp workitem commits"
+linkTitle: "camp workitem commits"
+description: "List commits referencing a workitem across linked repos"
+---
+
+## camp workitem commits
+
+List commits referencing a workitem across linked repos
+
+### Synopsis
+
+Search the campaign root and every linked project/repo/worktree/festival
+repo for commits whose campaign tag references this workitem's ref.
+
+Default sort: most recent first across all repos. Use --json for structured
+output. Repos that are not git checkouts or that fail their git log invocation
+are reported under "errors" in JSON mode; table mode warns on stderr when
+repo queries fail.
+
+```
+camp workitem commits [selector] [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for commits
+      --json              emit JSON instead of the default table
+      --limit int         maximum commits to return (default 100)
+      --offset int        number of commits to skip (after sorting)
+      --ref string        query by workitem ref directly (e.g. WI-abc123) — skips resolver
+      --workitem string   alias for the positional <selector>
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_create.md
+++ b/docs/cli-reference/camp/camp_workitem_create.md
@@ -18,6 +18,8 @@ camp workitem create <slug> [flags]
       --dir string     parent dir override (default: workflow/<type>)
   -h, --help           help for create
       --id string      override the generated id
+      --json           emit a structured JSON result
+      --quest string   capture quest_id from this quest (defaults to CAMP_QUEST env var if set)
       --title string   human-readable title
       --type string    workitem type (feature, bug, chore, or custom) (default "feature")
 ```

--- a/docs/cli-reference/camp/camp_workitem_current.md
+++ b/docs/cli-reference/camp/camp_workitem_current.md
@@ -1,0 +1,33 @@
+---
+title: "camp workitem current"
+linkTitle: "camp workitem current"
+description: "Get, set, or clear the local current workitem"
+---
+
+## camp workitem current
+
+Get, set, or clear the local current workitem
+
+```
+camp workitem current [selector] [flags]
+```
+
+### Options
+
+```
+      --clear   remove the local current.yaml selection
+  -h, --help    help for current
+      --json    emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_doctor.md
+++ b/docs/cli-reference/camp/camp_workitem_doctor.md
@@ -1,0 +1,33 @@
+---
+title: "camp workitem doctor"
+linkTitle: "camp workitem doctor"
+description: "Report workitem link-registry health issues"
+---
+
+## camp workitem doctor
+
+Report workitem link-registry health issues
+
+```
+camp workitem doctor [flags]
+```
+
+### Options
+
+```
+      --fix    auto-repair findings tagged auto_fixable
+  -h, --help   help for doctor
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_link.md
+++ b/docs/cli-reference/camp/camp_workitem_link.md
@@ -1,0 +1,39 @@
+---
+title: "camp workitem link"
+linkTitle: "camp workitem link"
+description: "Attach a workitem to a project, festival, worktree, or campaign path"
+---
+
+## camp workitem link
+
+Attach a workitem to a project, festival, worktree, or campaign path
+
+```
+camp workitem link <selector> [path] [flags]
+```
+
+### Options
+
+```
+      --allow-missing     allow the workitem and scope target to not exist (migrations)
+      --cwd               use current working directory as the scope
+      --festival string   festival id or relative path under festivals/
+  -h, --help              help for link
+      --json              emit a structured JSON result
+      --project string    project name (matches projects/<name>)
+      --replace           replace an existing primary link on the same scope
+      --role string       primary | related | blocked_by | supersedes (default "primary")
+      --worktree string   worktree relative path under projects/worktrees/
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_links.md
+++ b/docs/cli-reference/camp/camp_workitem_links.md
@@ -1,0 +1,32 @@
+---
+title: "camp workitem links"
+linkTitle: "camp workitem links"
+description: "List workitem links"
+---
+
+## camp workitem links
+
+List workitem links
+
+```
+camp workitem links [selector] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for links
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_resolve.md
+++ b/docs/cli-reference/camp/camp_workitem_resolve.md
@@ -1,0 +1,35 @@
+---
+title: "camp workitem resolve"
+linkTitle: "camp workitem resolve"
+description: "Print the workitem the current context resolves to (read-only)"
+---
+
+## camp workitem resolve
+
+Print the workitem the current context resolves to (read-only)
+
+```
+camp workitem resolve [flags]
+```
+
+### Options
+
+```
+      --explain           print the tier-by-tier resolution trace
+      --festival string   festival id for the festival tier
+  -h, --help              help for resolve
+      --json              emit a structured JSON result
+      --workitem string   explicit workitem selector (overrides cwd-based detection)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_unlink.md
+++ b/docs/cli-reference/camp/camp_workitem_unlink.md
@@ -1,0 +1,37 @@
+---
+title: "camp workitem unlink"
+linkTitle: "camp workitem unlink"
+description: "Remove one or more workitem links"
+---
+
+## camp workitem unlink
+
+Remove one or more workitem links
+
+```
+camp workitem unlink [selector] [path] [flags]
+```
+
+### Options
+
+```
+      --all               remove every link matching the selector
+      --festival string   festival scope filter
+  -h, --help              help for unlink
+      --id string         remove the link with this lnk_ id
+      --json              emit a structured JSON result
+      --project string    project scope filter
+      --worktree string   worktree scope filter
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/fest/fest_create.md
+++ b/docs/cli-reference/fest/fest_create.md
@@ -34,4 +34,4 @@ fest create [flags]
 * [fest create phase](../fest_create_phase/)	 - Insert a new phase and render its goal file
 * [fest create sequence](../fest_create_sequence/)	 - Insert a new sequence and render its goal file
 * [fest create task](../fest_create_task/)	 - Insert a new task file in a sequence
-* [fest create workflow](../fest_create_workflow/)	 - Create a WORKFLOW.md for a phase from structured step definitions
+* [fest create workflow](../fest_create_workflow/)	 - Create a standalone or phase WORKFLOW.md from structured step definitions

--- a/docs/cli-reference/fest/fest_create_workflow.md
+++ b/docs/cli-reference/fest/fest_create_workflow.md
@@ -1,29 +1,36 @@
 ---
 title: "fest create workflow"
 linkTitle: "fest create workflow"
-description: "Create a WORKFLOW.md for a phase from structured step definitions"
+description: "Create a standalone or phase WORKFLOW.md from structured step definitions"
 ---
 
 ## fest create workflow
 
-Create a WORKFLOW.md for a phase from structured step definitions
+Create a standalone or phase WORKFLOW.md from structured step definitions
 
 ### Synopsis
 
-Generate a WORKFLOW.md file for an existing phase directory.
+Generate a parseable WORKFLOW.md from prompts, inline JSON, or a steps file.
 
-Takes structured JSON input (inline or file) and produces a parseable WORKFLOW.md
-that matches the format expected by the workflow parser.
+Outside a festival phase, this creates WORKFLOW.md in the current directory,
+initializes .workflow/ runtime state, and starts a tracked run so fest next works
+immediately.
+
+Inside a festival phase, or when --path/--festival targets a phase, this writes
+the phase WORKFLOW.md without standalone runtime state.
 
 Examples:
 ```bash
-  # From a steps file
+  # Standalone workflow in the current directory
+  fest create workflow demo
+
+  # Standalone workflow from inline JSON (for agents)
+  fest create workflow demo --steps '{"title":"Review","steps":[...]}'
+
+  # Phase workflow from a steps file
   fest create workflow --steps-file steps.json --position after
 
-  # Inline JSON (for agents)
-  fest create workflow --steps '{"title":"Review","steps":[...]}' --position before
-
-  # With explicit phase path
+  # Explicit phase path
   fest create workflow --steps-file steps.json --path ./004_POLISH
 ```
 
@@ -38,8 +45,8 @@ fest create workflow [flags]
       --festival string     Festival root override
   -h, --help                help for workflow
       --json                Emit JSON output
-      --no-init             skip .workflow/ runtime init (standalone mode only)
-      --path string         Phase directory path (default ".")
+      --no-init             skip .workflow/ runtime init (advanced standalone mode)
+      --path string         Phase directory path (festival mode) (default ".")
       --position string     Workflow position relative to sequences (before|after) (default "after")
       --steps string        Inline JSON with workflow definition
       --steps-file string   Path to JSON file with workflow definition

--- a/docs/cli-reference/fest/fest_watch.md
+++ b/docs/cli-reference/fest/fest_watch.md
@@ -14,7 +14,8 @@ Watch the in-progress state of a festival.
 
 With a selector, fest watch resolves a festival by directory name or logical ID.
 Without a selector, it watches the current festival when run from a festival
-directory, or the linked festival when run from a linked project directory.
+directory, the linked festival when run from a linked project directory, or a
+standalone WORKFLOW.md from that workflow directory.
 
 From a campaign or festivals workspace in an interactive terminal, fest watch
 opens a festival picker. Watch mode refreshes in place until you press Ctrl+C.

--- a/docs/cli-reference/fest/fest_workflow.md
+++ b/docs/cli-reference/fest/fest_workflow.md
@@ -78,9 +78,11 @@ Examples:
 * [fest workflow approve](../fest_workflow_approve/)	 - Approve a blocking checkpoint
 * [fest workflow init](../fest_workflow_init/)	 - Initialize standalone workflow runtime
 * [fest workflow reject](../fest_workflow_reject/)	 - Reject checkpoint with feedback
+* [fest workflow renumber](../fest_workflow_renumber/)	 - Renumber step headings in a WORKFLOW.md to a contiguous 1-indexed sequence
 * [fest workflow reset](../fest_workflow_reset/)	 - Reset workflow to step 1
 * [fest workflow runs](../fest_workflow_runs/)	 - List runs of a standalone workflow
 * [fest workflow show](../fest_workflow_show/)	 - Display current step details
 * [fest workflow skip](../fest_workflow_skip/)	 - Operator override: mark workflow steps as skipped/completed
 * [fest workflow start](../fest_workflow_start/)	 - Start a new run for a standalone workflow
 * [fest workflow status](../fest_workflow_status/)	 - Show workflow progress
+* [fest workflow validate](../fest_workflow_validate/)	 - Validate WORKFLOW.md step numbering

--- a/docs/cli-reference/fest/fest_workflow_reject.md
+++ b/docs/cli-reference/fest/fest_workflow_reject.md
@@ -17,6 +17,18 @@ to reject and request revisions.
 
 The feedback will be recorded in the workflow state for reference.
 
+Failed gates with remediation:
+  Use --remediation-phase to record that a phase gate did not pass and
+  to link a remediation phase that will correct the underlying issues.
+  After the remediation phase completes, 'fest next' routes back to the
+  failed gate for re-evaluation rather than treating it as approved.
+
+Examples:
+```bash
+  fest workflow reject --reason "needs revision"
+  fest workflow reject --reason "PR not ready" --remediation-phase 005_FIX_PR_302
+```
+
 ```
 fest workflow reject [flags]
 ```
@@ -24,8 +36,9 @@ fest workflow reject [flags]
 ### Options
 
 ```
-  -h, --help            help for reject
-  -r, --reason string   reason for rejection (required)
+  -h, --help                       help for reject
+  -r, --reason string              reason for rejection (required)
+      --remediation-phase string   link a remediation phase for a failed gate (e.g. 005_FIX_PR_302)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest/fest_workflow_renumber.md
+++ b/docs/cli-reference/fest/fest_workflow_renumber.md
@@ -1,0 +1,61 @@
+---
+title: "fest workflow renumber"
+linkTitle: "fest workflow renumber"
+description: "Renumber step headings in a WORKFLOW.md to a contiguous 1-indexed sequence"
+---
+
+## fest workflow renumber
+
+Renumber step headings in a WORKFLOW.md to a contiguous 1-indexed sequence
+
+### Synopsis
+
+Renumber the "## Step N:" headings inside a WORKFLOW.md so they form a
+contiguous 1-indexed sequence (Step 1, Step 2, ..., Step K) in document order.
+
+Only the heading lines are touched. Step body text, the Workflow State Tracking
+table, and any other markdown content are left exactly as written.
+
+The default target is ./WORKFLOW.md. Pass an explicit path to target another file.
+
+Like other renumber commands, --dry-run is the default so you can preview the
+plan; pass --skip-dry-run to write changes immediately.
+
+Known v1 limitations:
+  - Cross-references inside step bodies (for example "see Step 3") are not
+    rewritten. Update those references by hand after renumbering if needed.
+
+Examples:
+```bash
+  fest workflow renumber                              # preview ./WORKFLOW.md
+  fest workflow renumber ./phases/001_PLAN/WORKFLOW.md
+  fest workflow renumber --skip-dry-run               # apply changes
+  fest workflow renumber --skip-dry-run --backup      # write .bak alongside
+```
+
+```
+fest workflow renumber [path] [flags]
+```
+
+### Options
+
+```
+      --backup         write a .bak copy of the original before applying
+      --dry-run        preview changes without writing (default true)
+  -h, --help           help for renumber
+      --skip-dry-run   skip preview and apply changes immediately
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.config/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --phase string    specify phase directory (e.g., 001_INGEST)
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest workflow](../fest_workflow/)	 - Manage workflow-based phase execution

--- a/docs/cli-reference/fest/fest_workflow_validate.md
+++ b/docs/cli-reference/fest/fest_workflow_validate.md
@@ -1,0 +1,43 @@
+---
+title: "fest workflow validate"
+linkTitle: "fest workflow validate"
+description: "Validate WORKFLOW.md step numbering"
+---
+
+## fest workflow validate
+
+Validate WORKFLOW.md step numbering
+
+### Synopsis
+
+Validate a standalone WORKFLOW.md file for correct step numbering.
+
+Step headings ('## Step N:') must start at 1 and form a contiguous sequence
+with no gaps or duplicates. No other checks are performed (section names,
+state-tracking tables, and checkpoint syntax are deliberately not validated).
+
+If no path is provided, defaults to ./WORKFLOW.md in the current directory.
+
+```
+fest workflow validate [path] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for validate
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.config/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --phase string    specify phase directory (e.g., 001_INGEST)
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest workflow](../fest_workflow/)	 - Manage workflow-based phase execution


### PR DESCRIPTION
## Purpose

Stage the next stable festival release by pinning the bundled CLIs to their latest stable tags and regenerating the CLI reference docs. Opened as a PR so CI can verify the bundle **before** the stable release tag is cut.

Produced with the standard command:

```bash
just refresh   # = just release refresh-stable  +  CLI_RELEASE_CHANNEL=stable just docs all
```

## Submodule pins

| CLI | Was | Now |
| --- | --- | --- |
| fest | v0.2.8 | **v0.3.0** |
| camp | v0.2.6 | **v0.2.7** |

Planned festival release tag after merge: **v0.2.6** (patch bump from v0.2.5).

## What changed

- `camp` and `fest` submodule pointers bumped to the latest stable tags.
- 31 regenerated pages under `docs/cli-reference/` (stable profile). New command pages reflect surfaces added since the previous pins: `camp workitem` (commit/commits/current/doctor/link/links/resolve/unlink), `camp workflow` (create/doctor/list/shortcut/show/sync), `camp promote`, and `fest workflow validate`/`renumber`.

## Verification (local)

- `just release preflight stable` - passed, including the beginner-path smoke test (`fest next` reaches the `001_INGEST` workflow).
- `just test bundled-module-resolution` - passed (`fest: ok`, `camp: ok`).
- `CLI_RELEASE_CHANNEL=stable just docs all` - regenerated cleanly.

## After merge

Cut the stable release from the pinned tags:

```bash
just release stable fest=latest camp=latest   # tags + publishes via CI
```