### PR TITLE
improve festival shell setup

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -78,6 +78,7 @@ archives:
       - LICENSE
       - install.sh
       - completions/*
+      - shell/*
 
 nfpms:
   - id: festival
@@ -112,6 +113,18 @@ nfpms:
         dst: /usr/share/zsh/vendor-completions/_fest
       - src: ./completions/fest.fish
         dst: /usr/share/fish/vendor_completions.d/fest.fish
+      - src: ./completions/camp.bash
+        dst: /usr/share/bash-completion/completions/camp
+      - src: ./completions/_camp
+        dst: /usr/share/zsh/vendor-completions/_camp
+      - src: ./completions/camp.fish
+        dst: /usr/share/fish/vendor_completions.d/camp.fish
+      - src: ./shell/festival.bash
+        dst: /usr/share/festival/shell/festival.bash
+      - src: ./shell/festival.zsh
+        dst: /usr/share/festival/shell/festival.zsh
+      - src: ./shell/festival.fish
+        dst: /usr/share/festival/shell/festival.fish
 
 aurs:
   - name: festival-bin
@@ -138,6 +151,12 @@ aurs:
       install -Dm644 "./completions/fest.bash" "${pkgdir}/usr/share/bash-completion/completions/fest"
       install -Dm644 "./completions/_fest" "${pkgdir}/usr/share/zsh/site-functions/_fest"
       install -Dm644 "./completions/fest.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/fest.fish"
+      install -Dm644 "./completions/camp.bash" "${pkgdir}/usr/share/bash-completion/completions/camp"
+      install -Dm644 "./completions/_camp" "${pkgdir}/usr/share/zsh/site-functions/_camp"
+      install -Dm644 "./completions/camp.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/camp.fish"
+      install -Dm644 "./shell/festival.bash" "${pkgdir}/usr/share/festival/shell/festival.bash"
+      install -Dm644 "./shell/festival.zsh" "${pkgdir}/usr/share/festival/shell/festival.zsh"
+      install -Dm644 "./shell/festival.fish" "${pkgdir}/usr/share/festival/shell/festival.fish"
     commit_msg_template: "Update to {{ .Tag }}"
 
 # Scoop publishing is temporarily disabled while Windows support is stabilized.
@@ -197,21 +216,29 @@ homebrew_casks:
           if OS.mac?
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/fest", "#{staged_path}/camp"]
           end
+          shell_dir = "#{HOMEBREW_PREFIX}/share/festival/shell"
+          system_command "/bin/mkdir", args: ["-p", shell_dir, "#{HOMEBREW_PREFIX}/etc/bash_completion.d", "#{HOMEBREW_PREFIX}/share/zsh/site-functions", "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d"]
+          system_command "/bin/cp", args: ["#{staged_path}/shell/festival.bash", "#{shell_dir}/festival.bash"]
+          system_command "/bin/cp", args: ["#{staged_path}/shell/festival.zsh", "#{shell_dir}/festival.zsh"]
+          system_command "/bin/cp", args: ["#{staged_path}/shell/festival.fish", "#{shell_dir}/festival.fish"]
+          system_command "/bin/cp", args: ["#{staged_path}/completions/camp.bash", "#{HOMEBREW_PREFIX}/etc/bash_completion.d/camp"]
+          system_command "/bin/cp", args: ["#{staged_path}/completions/_camp", "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_camp"]
+          system_command "/bin/cp", args: ["#{staged_path}/completions/camp.fish", "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/camp.fish"]
+        uninstall: |
+          system_command "/bin/rm", args: ["-f", "#{HOMEBREW_PREFIX}/share/festival/shell/festival.bash", "#{HOMEBREW_PREFIX}/share/festival/shell/festival.zsh", "#{HOMEBREW_PREFIX}/share/festival/shell/festival.fish", "#{HOMEBREW_PREFIX}/etc/bash_completion.d/camp", "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_camp", "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/camp.fish"]
 
     caveats: |
-      To activate shell completions and camp shell integration, add to your shell config:
+      Homebrew installs static fest and camp completions. To activate navigation helpers
+      (cgo, cr, csw, cint, fgo, fls) as well, add one line to your shell config:
 
         # bash (~/.bashrc)
-        eval \"$(camp shell-init bash)\"
-        source <(fest completion bash)
+        source \"$(brew --prefix)/share/festival/shell/festival.bash\"
 
         # zsh (~/.zshrc)
-        eval \"$(camp shell-init zsh)\"
-        source <(fest completion zsh)
+        source \"$(brew --prefix)/share/festival/shell/festival.zsh\"
 
         # fish (~/.config/fish/config.fish)
-        camp shell-init fish | source
-        fest completion fish | source
+        source \"$(brew --prefix)/share/festival/shell/festival.fish\"
 
 release:
   github:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ Use `fest system update --force` only when you intentionally want to overwrite l
 ## Quick Start
 
 ```bash
-# Shell integration (add to ~/.zshrc)
+# Shell integration (add one setup path to ~/.zshrc)
+
+# Preferred when installed with install.sh:
+source ~/.local/share/festival/shell/festival.zsh
+
+# Or, if no helper file is installed:
 eval "$(camp shell-init zsh)"
 eval "$(fest shell-init zsh)"
 
@@ -163,7 +168,20 @@ Every project, every plan, every piece of context for this mission lives here. `
 
 ## Navigation
 
-Shell integration gives you shorthand functions that make navigating a campaign instant. Add these to your shell config:
+Shell integration gives you shorthand functions that make navigating a campaign instant. Package installs include helper files that load both CLIs:
+
+```bash
+# install.sh default location
+source ~/.local/share/festival/shell/festival.zsh
+
+# Homebrew
+source "$(brew --prefix)/share/festival/shell/festival.zsh"
+
+# Linux packages
+source /usr/share/festival/shell/festival.zsh
+```
+
+For bash, use `festival.bash`; for fish, use `festival.fish`. If no helper file is installed, use the dynamic fallback:
 
 ```bash
 eval "$(camp shell-init zsh)"   # gives you: cgo, cr, csw, cint

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -20,7 +20,8 @@ npm install -g @obedience-corp/festival
 
 The npm package downloads the matching Festival GitHub release archive for your
 platform, verifies it against the release checksums, and exposes both `fest` and
-`camp`.
+`camp`. It also keeps the release completion and shell-helper assets inside the
+installed package, but it does not edit your shell startup files.
 
 {{< tabs names="macOS, Linux, Windows (Temporarily Paused)" >}}
 
@@ -100,6 +101,8 @@ curl -fsSL https://raw.githubusercontent.com/Obedience-Corp/festival/main/instal
 {{< note >}}
 This downloads pre-built binaries to `~/.local/bin`.
 The installer checks for `git` and stops early if it is missing. If `scc` is not installed, the installer continues and warns that `camp leverage` features will be unavailable until you add it.
+It also installs completion files and shell-helper source files under `~/.local/share/festival/`.
+When run from an interactive terminal, it asks whether to add the helper source line to your detected shell config; the default answer is yes.
 [Review the script source](https://github.com/Obedience-Corp/festival/blob/main/install.sh) before running.
 {{< /note >}}
 
@@ -169,11 +172,27 @@ go install github.com/Obedience-Corp/camp/cmd/camp@latest
 
 ## Shell Integration
 
-Enable navigation features by adding to your `~/.zshrc` or `~/.bashrc`:
+Package installs include sourceable helper files for shell functions such as
+`cgo`, `cr`, `csw`, `cint`, `fgo`, and `fls`. Add the line for your install
+method and shell:
 
 ```bash
-eval "$(fest shell-init zsh)"
+# install.sh default location
+source ~/.local/share/festival/shell/festival.zsh
+
+# Homebrew
+source "$(brew --prefix)/share/festival/shell/festival.zsh"
+
+# Linux packages
+source /usr/share/festival/shell/festival.zsh
+```
+
+For bash, use `festival.bash`; for fish, use `festival.fish`.
+The portable fallback is still:
+
+```bash
 eval "$(camp shell-init zsh)"
+eval "$(fest shell-init zsh)"
 ```
 
 See [Shell Setup]({{< ref "/getting-started/shell-setup" >}}) for details.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -14,7 +14,10 @@ Create your first campaign and festival in under 5 minutes.
 ## 1. Set Up Shell Integration
 
 ```bash
-# Add to ~/.zshrc (or ~/.bashrc)
+# Add to ~/.zshrc when installed with install.sh
+source ~/.local/share/festival/shell/festival.zsh
+
+# Or, if no helper file is installed:
 eval "$(camp shell-init zsh)"
 eval "$(fest shell-init zsh)"
 

--- a/docs/getting-started/shell-setup.md
+++ b/docs/getting-started/shell-setup.md
@@ -9,14 +9,35 @@ Enable shell integration for directory navigation and tab completion.
 
 ## Setup
 
-Add to your `~/.zshrc` or `~/.bashrc`:
+If your installer created Festival helper files, source the helper for your
+shell from your shell config.
 
 ```bash
-eval "$(fest shell-init zsh)"
-eval "$(camp shell-init zsh)"
+# install.sh default location
+source ~/.local/share/festival/shell/festival.zsh
+
+# Homebrew
+source "$(brew --prefix)/share/festival/shell/festival.zsh"
+
+# Linux packages
+source /usr/share/festival/shell/festival.zsh
 ```
 
-For bash, replace `zsh` with `bash`. For fish, replace with `fish`.
+For bash, use `festival.bash`. For fish, use `festival.fish`.
+
+If you do not have an installed helper file, use the dynamic fallback:
+
+```bash
+eval "$(camp shell-init zsh)"
+eval "$(fest shell-init zsh)"
+```
+
+For bash, replace `zsh` with `bash`. For fish, use:
+
+```fish
+camp shell-init fish | source
+fest shell-init fish | source
+```
 
 ## Shell Functions
 

--- a/docs/tutorials/campaign-setup.md
+++ b/docs/tutorials/campaign-setup.md
@@ -34,10 +34,17 @@ my-startup/
 
 ## Shell Integration
 
-Add camp and fest shell functions to your shell config:
+Add camp and fest shell functions to your shell config. If your installer
+created helper files, source the helper:
 
 ```bash
 # Add to ~/.zshrc
+source ~/.local/share/festival/shell/festival.zsh
+```
+
+If no helper file is installed, use the dynamic fallback:
+
+```bash
 eval "$(camp shell-init zsh)"
 eval "$(fest shell-init zsh)"
 ```

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 REPO="Obedience-Corp/festival"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${VERSION:-latest}"
+SHELL_SETUP="${FESTIVAL_INSTALL_SHELL:-auto}"
 
 # Colors
 RED='\033[0;31m'
@@ -22,6 +23,45 @@ error() { echo -e "${RED}Error:${NC} $1" >&2; exit 1; }
 
 command_exists() {
     command -v "$1" >/dev/null 2>&1
+}
+
+usage() {
+    cat <<'EOF'
+Festival installer
+
+Usage:
+  install.sh [--setup-shell|--no-shell]
+
+Environment:
+  VERSION                    Release tag to install, or "latest" (default: latest)
+  INSTALL_DIR                Binary install directory (default: ~/.local/bin)
+  FESTIVAL_INSTALL_SHELL     auto, 1, or 0 (default: auto)
+
+Shell setup:
+  --setup-shell              Add a guarded source block to the detected shell rc file
+  --no-shell                 Install binaries and helper files only
+EOF
+}
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --setup-shell)
+                SHELL_SETUP=1
+                ;;
+            --no-shell)
+                SHELL_SETUP=0
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                error "Unknown argument: $1"
+                ;;
+        esac
+        shift
+    done
 }
 
 # Detect OS
@@ -203,8 +243,185 @@ warn_optional_scc() {
     echo "    $(install_hint scc)"
 }
 
+install_prefix() {
+    local install_dir
+    install_dir="${INSTALL_DIR%/}"
+    case "$install_dir" in
+        */bin) echo "${install_dir%/bin}" ;;
+        *) dirname "$install_dir" ;;
+    esac
+}
+
+shell_helper_dir() {
+    echo "$(install_prefix)/share/festival/shell"
+}
+
+completion_asset_dir() {
+    echo "$(install_prefix)/share/festival/completions"
+}
+
+install_completion_assets() {
+    local tmp_dir="$1"
+    local completions_dir="$2"
+
+    if [ ! -d "${tmp_dir}/completions" ]; then
+        warning "Completion files were not found in the release archive"
+        return 1
+    fi
+
+    mkdir -p "$completions_dir"
+    cp "${tmp_dir}/completions/fest.bash" "$completions_dir/fest.bash"
+    cp "${tmp_dir}/completions/_fest" "$completions_dir/_fest"
+    cp "${tmp_dir}/completions/fest.fish" "$completions_dir/fest.fish"
+    cp "${tmp_dir}/completions/camp.bash" "$completions_dir/camp.bash"
+    cp "${tmp_dir}/completions/_camp" "$completions_dir/_camp"
+    cp "${tmp_dir}/completions/camp.fish" "$completions_dir/camp.fish"
+    success "Installed completion files to ${completions_dir}"
+}
+
+install_shell_helpers() {
+    local tmp_dir="$1"
+    local helper_dir="$2"
+
+    if [ ! -d "${tmp_dir}/shell" ]; then
+        warning "Shell helper files were not found in the release archive"
+        return 1
+    fi
+
+    mkdir -p "$helper_dir"
+    cp "${tmp_dir}/shell/festival.bash" "$helper_dir/festival.bash"
+    cp "${tmp_dir}/shell/festival.zsh" "$helper_dir/festival.zsh"
+    cp "${tmp_dir}/shell/festival.fish" "$helper_dir/festival.fish"
+    success "Installed shell helper files to ${helper_dir}"
+}
+
+detected_shell() {
+    basename "${SHELL:-}" 2>/dev/null || true
+}
+
+shell_rc_file() {
+    case "$1" in
+        zsh) echo "${ZDOTDIR:-$HOME}/.zshrc" ;;
+        bash) echo "$HOME/.bashrc" ;;
+        fish) echo "$HOME/.config/fish/config.fish" ;;
+        *) return 1 ;;
+    esac
+}
+
+should_setup_shell() {
+    local rc_file="$1"
+    local reply
+
+    case "$SHELL_SETUP" in
+        1|true|TRUE|yes|YES|y|Y)
+            return 0
+            ;;
+        0|false|FALSE|no|NO|n|N)
+            return 1
+            ;;
+        auto|"")
+            if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+                printf "Add Festival shell helpers to %s? [Y/n] " "$rc_file" > /dev/tty
+                IFS= read -r reply < /dev/tty || reply=""
+                case "$reply" in
+                    n|N|no|NO)
+                        return 1
+                        ;;
+                    *)
+                        return 0
+                        ;;
+                esac
+            fi
+            return 1
+            ;;
+        *)
+            warning "Ignoring unknown FESTIVAL_INSTALL_SHELL value: ${SHELL_SETUP}"
+            return 1
+            ;;
+    esac
+}
+
+append_shell_block() {
+    local shell_name="$1"
+    local rc_file="$2"
+    local helper_dir="$3"
+
+    mkdir -p "$(dirname "$rc_file")"
+    touch "$rc_file"
+
+    if grep -Fq ">>> festival shell integration >>>" "$rc_file"; then
+        success "Shell helpers already configured in ${rc_file}"
+        return 0
+    fi
+
+    {
+        echo ""
+        echo "# >>> festival shell integration >>>"
+        echo "# Added by the Festival installer. Remove this block to disable cgo/fgo helpers."
+        case "$shell_name" in
+            bash)
+                echo "case \":\$PATH:\" in"
+                echo "  *\":${INSTALL_DIR}:\"*) ;;"
+                echo "  *) export PATH=\"${INSTALL_DIR}:\$PATH\" ;;"
+                echo "esac"
+                echo "source \"${helper_dir}/festival.bash\""
+                ;;
+            zsh)
+                echo "case \":\$PATH:\" in"
+                echo "  *\":${INSTALL_DIR}:\"*) ;;"
+                echo "  *) export PATH=\"${INSTALL_DIR}:\$PATH\" ;;"
+                echo "esac"
+                echo "source \"${helper_dir}/festival.zsh\""
+                ;;
+            fish)
+                echo "if not contains \"${INSTALL_DIR}\" \$PATH"
+                echo "    set -gx PATH \"${INSTALL_DIR}\" \$PATH"
+                echo "end"
+                echo "source \"${helper_dir}/festival.fish\""
+                ;;
+        esac
+        echo "# <<< festival shell integration <<<"
+    } >> "$rc_file"
+
+    success "Added shell helpers to ${rc_file}"
+}
+
+configure_shell_startup() {
+    local helper_dir="$1"
+    local shell_name rc_file
+
+    shell_name="$(detected_shell)"
+    if [ -z "$shell_name" ] || ! rc_file="$(shell_rc_file "$shell_name")"; then
+        warning "Could not detect a supported shell for automatic helper setup"
+        return 1
+    fi
+
+    if should_setup_shell "$rc_file"; then
+        append_shell_block "$shell_name" "$rc_file" "$helper_dir"
+        return 0
+    fi
+
+    return 1
+}
+
+print_shell_setup_hint() {
+    local helper_dir="$1"
+
+    echo ""
+    info "To enable shell integration manually, add the line for your shell:"
+    echo ""
+    echo "  # bash (~/.bashrc)"
+    echo "  source \"${helper_dir}/festival.bash\""
+    echo ""
+    echo "  # zsh (~/.zshrc)"
+    echo "  source \"${helper_dir}/festival.zsh\""
+    echo ""
+    echo "  # fish (~/.config/fish/config.fish)"
+    echo "  source \"${helper_dir}/festival.fish\""
+}
+
 main() {
-    local os arch version archive_name download_url release_metadata tmp_dir=""
+    local os arch version archive_name download_url release_metadata tmp_dir="" helper_dir completions_dir shell_configured=0
 
     require_git
 
@@ -259,6 +476,11 @@ main() {
 
     success "Installed fest and camp to ${INSTALL_DIR}"
 
+    helper_dir="$(shell_helper_dir)"
+    completions_dir="$(completion_asset_dir)"
+    install_completion_assets "$tmp_dir" "$completions_dir" || true
+    install_shell_helpers "$tmp_dir" "$helper_dir" || true
+
     # Verify
     if command -v fest &>/dev/null; then
         success "fest $(fest --version 2>/dev/null || echo 'installed')"
@@ -277,14 +499,19 @@ main() {
         echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
     fi
 
-    # Shell integration
-    echo ""
-    info "To enable shell integration, add to your ~/.zshrc or ~/.bashrc:"
-    echo ""
-    echo "  eval \"\$(fest shell-init zsh)\""
-    echo "  eval \"\$(camp shell-init zsh)\""
-    echo ""
+    if configure_shell_startup "$helper_dir"; then
+        shell_configured=1
+        echo ""
+        info "Restart your shell or source your shell config to use cgo/fgo helpers."
+    fi
+
+    if [ "$shell_configured" -eq 0 ]; then
+        print_shell_setup_hint "$helper_dir"
+        echo ""
+    fi
+
     success "Installation complete"
 }
 
+parse_args "$@"
 main "$@"

--- a/npm/README.md
+++ b/npm/README.md
@@ -38,8 +38,17 @@ are re-enabled.
 ## How It Works
 
 This package downloads the matching Festival GitHub release archive for your
-platform, verifies it against the release `checksums.txt`, and exposes `fest`
-and `camp` on your PATH.
+platform, verifies it against the release `checksums.txt`, exposes `fest`
+and `camp` on your PATH, and keeps the release completion and shell-helper
+assets under `share/festival/` inside the installed npm package.
+
+The npm installer does not edit shell startup files. Add shell integration
+manually with:
+
+```bash
+eval "$(camp shell-init zsh)"
+eval "$(fest shell-init zsh)"
+```
 
 ## Maintainer Notes
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -8,6 +8,18 @@ const { spawnSync } = require("child_process");
 
 const REPO = "Obedience-Corp/festival";
 const BINARIES = ["fest", "camp"];
+const ASSET_DIRECTORIES = ["completions", "shell"];
+const REQUIRED_ASSET_FILES = [
+  ["completions", "fest.bash"],
+  ["completions", "_fest"],
+  ["completions", "fest.fish"],
+  ["completions", "camp.bash"],
+  ["completions", "_camp"],
+  ["completions", "camp.fish"],
+  ["shell", "festival.bash"],
+  ["shell", "festival.zsh"],
+  ["shell", "festival.fish"],
+];
 const DOWNLOAD_ATTEMPTS = 3;
 const DOWNLOAD_TIMEOUT_MS = 60_000;
 const RETRY_BASE_DELAY_MS = 750;
@@ -61,8 +73,15 @@ function binaryPath(name) {
   return path.join(__dirname, "bin", binaryName);
 }
 
-function haveBinaries() {
-  return BINARIES.every((name) => fs.existsSync(binaryPath(name)));
+function assetPath(...parts) {
+  return path.join(__dirname, "share", "festival", ...parts);
+}
+
+function haveInstallArtifacts() {
+  return (
+    BINARIES.every((name) => fs.existsSync(binaryPath(name))) &&
+    REQUIRED_ASSET_FILES.every(([dir, file]) => fs.existsSync(assetPath(dir, file)))
+  );
 }
 
 function sleep(ms) {
@@ -201,7 +220,7 @@ function extractArchive(archivePath, destDir) {
 async function install(options = {}) {
   const force = options.force === true;
 
-  if (!force && haveBinaries()) {
+  if (!force && haveInstallArtifacts()) {
     return;
   }
 
@@ -236,6 +255,19 @@ async function install(options = {}) {
       if (process.platform !== "win32") {
         fs.chmodSync(targetPath, 0o755);
       }
+    }
+
+    for (const dir of ASSET_DIRECTORIES) {
+      const extractedPath = path.join(tempDir, dir);
+      const targetPath = assetPath(dir);
+
+      if (!fs.existsSync(extractedPath)) {
+        throw new Error(`${dir} assets not found in ${filename}`);
+      }
+
+      fs.rmSync(targetPath, { recursive: true, force: true });
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+      fs.cpSync(extractedPath, targetPath, { recursive: true });
     }
 
     console.log("Installed Festival successfully");

--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -1,18 +1,26 @@
 #!/usr/bin/env bash
-# Generate shell completions for fest.
+# Generate shell completions for the bundled CLIs.
 # Called by goreleaser before.hooks.
 set -euo pipefail
 
 mkdir -p completions
 
-# Build a temporary fest binary for the host platform
-echo "Building temporary fest binary for completion generation..."
+cleanup() {
+    rm -f completions/.fest-tmp completions/.camp-tmp
+}
+trap cleanup EXIT
+
+echo "Building temporary binaries for completion generation..."
 (cd fest && go build -o ../completions/.fest-tmp ./cmd/fest)
+(cd camp && go build -o ../completions/.camp-tmp ./cmd/camp)
 
 echo "Generating completions..."
 ./completions/.fest-tmp completion bash > completions/fest.bash
 ./completions/.fest-tmp completion zsh  > completions/_fest
 ./completions/.fest-tmp completion fish > completions/fest.fish
 
-rm -f completions/.fest-tmp
+./completions/.camp-tmp completion bash > completions/camp.bash
+./completions/.camp-tmp completion zsh  > completions/_camp
+./completions/.camp-tmp completion fish > completions/camp.fish
+
 echo "Completions generated in completions/"

--- a/shell/festival.bash
+++ b/shell/festival.bash
@@ -1,6 +1,9 @@
 # Festival shell integration for bash.
 # Source this file from ~/.bashrc after installing Festival.
 
+_festival_shell_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+_festival_completion_dir="${_festival_shell_dir}/../completions"
+
 if command -v camp >/dev/null 2>&1; then
   eval "$(camp shell-init bash)"
 fi
@@ -8,3 +11,10 @@ fi
 if command -v fest >/dev/null 2>&1; then
   eval "$(fest shell-init bash)"
 fi
+
+if type complete >/dev/null 2>&1; then
+  [ -f "${_festival_completion_dir}/camp.bash" ] && source "${_festival_completion_dir}/camp.bash"
+  [ -f "${_festival_completion_dir}/fest.bash" ] && source "${_festival_completion_dir}/fest.bash"
+fi
+
+unset _festival_shell_dir _festival_completion_dir

--- a/shell/festival.bash
+++ b/shell/festival.bash
@@ -1,0 +1,10 @@
+# Festival shell integration for bash.
+# Source this file from ~/.bashrc after installing Festival.
+
+if command -v camp >/dev/null 2>&1; then
+  eval "$(camp shell-init bash)"
+fi
+
+if command -v fest >/dev/null 2>&1; then
+  eval "$(fest shell-init bash)"
+fi

--- a/shell/festival.fish
+++ b/shell/festival.fish
@@ -1,0 +1,10 @@
+# Festival shell integration for fish.
+# Source this file from ~/.config/fish/config.fish after installing Festival.
+
+if command -q camp
+    camp shell-init fish | source
+end
+
+if command -q fest
+    fest shell-init fish | source
+end

--- a/shell/festival.fish
+++ b/shell/festival.fish
@@ -1,10 +1,21 @@
 # Festival shell integration for fish.
 # Source this file from ~/.config/fish/config.fish after installing Festival.
 
+set -l _festival_shell_dir (dirname (status --current-filename))
+set -l _festival_completion_dir "$_festival_shell_dir/../completions"
+
 if command -q camp
     camp shell-init fish | source
 end
 
 if command -q fest
     fest shell-init fish | source
+end
+
+if test -f "$_festival_completion_dir/camp.fish"
+    source "$_festival_completion_dir/camp.fish"
+end
+
+if test -f "$_festival_completion_dir/fest.fish"
+    source "$_festival_completion_dir/fest.fish"
 end

--- a/shell/festival.zsh
+++ b/shell/festival.zsh
@@ -1,16 +1,51 @@
 # Festival shell integration for zsh.
 # Source this file from ~/.zshrc after installing Festival.
 
-# The bundled CLI helpers register zsh and bash-style completions. Initialize
-# zsh completion first so older bundled camp/fest versions do not emit compdef
-# or complete errors when this helper is sourced early in .zshrc.
-autoload -Uz compinit bashcompinit
-if (( $+functions[compinit] )); then
-  compinit -u 2>/dev/null
-fi
-if (( $+functions[bashcompinit] )); then
-  bashcompinit 2>/dev/null
-fi
+_festival_setup_zsh_completions() {
+  local shell_dir completion_dir path_seen path_entry
+
+  shell_dir="${${(%):-%N}:A:h}"
+  completion_dir="${shell_dir:h}/completions"
+
+  if [[ -d "$completion_dir" ]]; then
+    path_seen=0
+    for path_entry in "${fpath[@]}"; do
+      if [[ "$path_entry" == "$completion_dir" ]]; then
+        path_seen=1
+        break
+      fi
+    done
+    (( path_seen )) || fpath=("$completion_dir" $fpath)
+  fi
+
+  autoload -Uz compinit bashcompinit
+  if (( ! $+functions[compdef] && $+functions[compinit] )); then
+    compinit -i 2>/dev/null
+  fi
+  if (( ! $+builtins[complete] && ! $+functions[complete] && $+functions[bashcompinit] )); then
+    bashcompinit 2>/dev/null
+  fi
+}
+
+_festival_register_zsh_cli_completions() {
+  local shell_dir completion_dir
+
+  shell_dir="${${(%):-%N}:A:h}"
+  completion_dir="${shell_dir:h}/completions"
+
+  if (( $+functions[compdef] )) && [[ -d "$completion_dir" ]]; then
+    if [[ -f "$completion_dir/_camp" ]]; then
+      autoload -Uz _camp
+      compdef _camp camp
+    fi
+    if [[ -f "$completion_dir/_fest" ]]; then
+      autoload -Uz _fest
+      compdef _fest fest
+    fi
+  fi
+}
+
+_festival_setup_zsh_completions
 
 if command -v camp >/dev/null 2>&1; then
   eval "$(camp shell-init zsh)"
@@ -19,3 +54,6 @@ fi
 if command -v fest >/dev/null 2>&1; then
   eval "$(fest shell-init zsh)"
 fi
+
+_festival_register_zsh_cli_completions
+unfunction _festival_setup_zsh_completions _festival_register_zsh_cli_completions

--- a/shell/festival.zsh
+++ b/shell/festival.zsh
@@ -1,0 +1,21 @@
+# Festival shell integration for zsh.
+# Source this file from ~/.zshrc after installing Festival.
+
+# The bundled CLI helpers register zsh and bash-style completions. Initialize
+# zsh completion first so older bundled camp/fest versions do not emit compdef
+# or complete errors when this helper is sourced early in .zshrc.
+autoload -Uz compinit bashcompinit
+if (( $+functions[compinit] )); then
+  compinit -u 2>/dev/null
+fi
+if (( $+functions[bashcompinit] )); then
+  bashcompinit 2>/dev/null
+fi
+
+if command -v camp >/dev/null 2>&1; then
+  eval "$(camp shell-init zsh)"
+fi
+
+if command -v fest >/dev/null 2>&1; then
+  eval "$(fest shell-init zsh)"
+fi


### PR DESCRIPTION
## Summary

- generate and package `camp` completions alongside `fest` completions
- ship sourceable `shell/festival.{bash,zsh,fish}` helpers that initialize both CLIs
- make `install.sh` install completion/helper assets and offer guarded shell rc setup, with `--setup-shell`, `--no-shell`, and `FESTIVAL_INSTALL_SHELL`
- keep npm installs non-mutating while preserving downloaded completion/helper assets under the installed package
- update setup docs for helper-file sourcing and dynamic fallback commands

## Validation

- `bash -n install.sh scripts/completions.sh shell/festival.bash shell/festival.zsh`
- `node --check npm/install.js && node --check npm/lib/run.js`
- `just test release-operator`
- `goreleaser check`
- `goreleaser release --snapshot --clean --skip=publish,announce`
- archive/native package inspection for `camp`, `fest`, completions, and shell helpers
- bash and zsh helper smoke tests against snapshot binaries
- `ruby -c dist/homebrew/Casks/festival.rb`
- `npm pack --dry-run` from `npm/`

Note: `fish` is not installed locally, so `fish -n shell/festival.fish` could not be run.
