### PR TITLE
Refresh bundled CLI docs for Festival v0.2.8

### DIFF
--- a/docs/cli-reference/camp/camp_intent.md
+++ b/docs/cli-reference/camp/camp_intent.md
@@ -60,6 +60,7 @@ camp intent [flags]
 * [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
 * [camp intent add](../camp_intent_add/)	 - Create a new intent
 * [camp intent archive](../camp_intent_archive/)	 - Archive an intent
+* [camp intent convert](../camp_intent_convert/)	 - Convert a note into an intent
 * [camp intent count](../camp_intent_count/)	 - Count intents by status directory
 * [camp intent crawl](../camp_intent_crawl/)	 - Interactive intent triage
 * [camp intent edit](../camp_intent_edit/)	 - Edit an existing intent
@@ -68,5 +69,7 @@ camp intent [flags]
 * [camp intent gather](../camp_intent_gather/)	 - Gather related intents into a unified document
 * [camp intent list](../camp_intent_list/)	 - List intents in the campaign
 * [camp intent move](../camp_intent_move/)	 - Move intent to a different status
+* [camp intent note](../camp_intent_note/)	 - Capture a quick note
 * [camp intent promote](../camp_intent_promote/)	 - Promote an intent through the pipeline
+* [camp intent rename](../camp_intent_rename/)	 - Rename an intent
 * [camp intent show](../camp_intent_show/)	 - Show detailed intent information

--- a/docs/cli-reference/camp/camp_intent_add.md
+++ b/docs/cli-reference/camp/camp_intent_add.md
@@ -26,6 +26,7 @@ PROGRAMMATIC (agent) FLAGS:
   --body              Set intent body from a literal string
   --body-file         Read intent body from a file (- for stdin)
   --concept           Set the concept field (e.g., "projects/camp")
+  --note              Create a note instead of a lifecycle intent
   --author            Override the default author attribution
 
   --body and --body-file are mutually exclusive.
@@ -38,6 +39,8 @@ Examples:
   camp intent add                        Fast TUI (3-step form)
   camp intent add --campaign             Pick a target campaign interactively
   camp intent add --full                 Full TUI (includes body)
+  camp intent add --note                 Note TUI (title + body, no type/concept)
+  camp intent add --note "Meeting note" --body "Follow up next week"
   camp intent add -e "Complex feature"   Deep capture with editor
   camp intent add -t feature "New API"   Set type explicitly
   camp intent add "Fix login" --body "The login page returns 500"
@@ -60,6 +63,8 @@ camp intent add [title] [flags]
   -f, --full               Full TUI mode with body textarea
   -h, --help               help for add
       --no-commit          Don't create a git commit
+      --note               Create a note instead of a lifecycle intent
+      --tag stringArray    Add a tag (repeatable)
   -t, --type string        Intent type (idea, feature, bug, research, chore) (default "idea")
 ```
 

--- a/docs/cli-reference/camp/camp_intent_convert.md
+++ b/docs/cli-reference/camp/camp_intent_convert.md
@@ -1,0 +1,45 @@
+---
+title: "camp intent convert"
+linkTitle: "camp intent convert"
+description: "Convert a note into an intent"
+---
+
+## camp intent convert
+
+Convert a note into an intent
+
+### Synopsis
+
+Promote a note into the intent lifecycle.
+
+A note lives outside the inbox → ready → active lifecycle. Converting it moves
+the note into inbox/ and attaches an intent type, after which it behaves like
+any other intent. This is the only bridge from a note into the lifecycle.
+
+Examples:
+  camp intent convert check-daemon-socket --type idea
+  camp intent convert check-daemon-socket -t feature
+
+```
+camp intent convert <id> [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for convert
+      --no-commit     Don't create a git commit
+  -t, --type string   Intent type to attach (idea, feature, bug, research, chore) (default "idea")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp intent](../camp_intent/)	 - Manage campaign intents

--- a/docs/cli-reference/camp/camp_intent_edit.md
+++ b/docs/cli-reference/camp/camp_intent_edit.md
@@ -74,6 +74,7 @@ camp intent edit [id] [flags]
       --set-status string         Change the intent status
       --set-type string           Change the intent type (idea, feature, bug, research, chore)
   -s, --status string             Filter picker by status
+      --tag stringArray           Replace the intent's tags (repeatable)
       --title string              Set a new title
   -t, --type string               Filter picker by type
 ```

--- a/docs/cli-reference/camp/camp_intent_note.md
+++ b/docs/cli-reference/camp/camp_intent_note.md
@@ -1,0 +1,52 @@
+---
+title: "camp intent note"
+linkTitle: "camp intent note"
+description: "Capture a quick note"
+---
+
+## camp intent note
+
+Capture a quick note
+
+### Synopsis
+
+Capture a freeform note. Notes are a separate category from intents: they
+are stored in .campaign/intents/notes/ and do not flow through the
+inbox → ready → active lifecycle. A note carries no type or concept; tags
+organize them.
+
+Fast capture skips the TUI. Interactive capture uses the same title/body/tag
+flow as intent add, but skips the type wheel and concept picker.
+
+Examples:
+  camp intent note "check the daemon socket path"   Capture a note immediately
+  camp intent note "follow up" --body "details..."  Note with a longer body
+  echo "body" | camp intent note "idea" --body-file -
+  camp intent note                                  Note TUI (title + body)
+
+```
+camp intent note [text] [flags]
+```
+
+### Options
+
+```
+      --author string      Override the default author attribution
+      --body string        Set note body as a literal string
+      --body-file string   Read note body from file (- for stdin, 10 MiB cap)
+  -h, --help               help for note
+      --no-commit          Don't create a git commit
+  -t, --tag stringArray    Add a tag (repeatable)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp intent](../camp_intent/)	 - Manage campaign intents

--- a/docs/cli-reference/camp/camp_intent_rename.md
+++ b/docs/cli-reference/camp/camp_intent_rename.md
@@ -1,0 +1,43 @@
+---
+title: "camp intent rename"
+linkTitle: "camp intent rename"
+description: "Rename an intent"
+---
+
+## camp intent rename
+
+Rename an intent
+
+### Synopsis
+
+Rename an intent: update its title and regenerate its human-readable
+filename. The intent's stable id is preserved, so references and lookups survive
+the rename.
+
+Resolution is by exact id (run 'camp intent list' to copy one).
+
+Examples:
+  camp intent rename add-dark-mode-20260119-153412 "Add a dark mode toggle"
+
+```
+camp intent rename <id> <new title> [flags]
+```
+
+### Options
+
+```
+  -h, --help        help for rename
+      --no-commit   Don't create a git commit
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp intent](../camp_intent/)	 - Manage campaign intents

--- a/docs/cli-reference/camp/camp_settings.md
+++ b/docs/cli-reference/camp/camp_settings.md
@@ -12,13 +12,14 @@ Manage camp configuration
 
 Interactive menu for managing camp configuration.
 
-Today, this command edits global user preferences in
-~/.obey/campaign/config.json.
+Global settings live in ~/.obey/campaign/config.json and apply to every
+campaign. Local settings live in .campaign/settings/local.json and apply
+only to the current campaign; a local theme override wins over the global
+theme while you are inside that campaign.
 
-Campaign-local settings still live in files under .campaign/, and the
-"Local Settings" menu is currently a scaffold rather than a full editor.
-See docs/campaign-settings-files.md in the camp repository for the current
-file layout.
+For non-interactive access, use 'camp settings get' and
+'camp settings set'. See docs/campaign-settings-files.md in the camp
+repository for the file layout.
 
 ```
 camp settings [flags]
@@ -27,7 +28,10 @@ camp settings [flags]
 ### Examples
 
 ```
-  camp settings   # Edit global editor/theme preferences
+  camp settings                              # Interactive settings menu
+  camp settings get                          # Print all settings
+  camp settings set global.theme dark        # Set the global theme
+  camp settings set local.theme_override light
 ```
 
 ### Options
@@ -47,3 +51,5 @@ camp settings [flags]
 ### SEE ALSO
 
 * [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp settings get](../camp_settings_get/)	 - Print camp settings
+* [camp settings set](../camp_settings_set/)	 - Set a camp setting

--- a/docs/cli-reference/camp/camp_settings_get.md
+++ b/docs/cli-reference/camp/camp_settings_get.md
@@ -1,0 +1,55 @@
+---
+title: "camp settings get"
+linkTitle: "camp settings get"
+description: "Print camp settings"
+---
+
+## camp settings get
+
+Print camp settings
+
+### Synopsis
+
+Print camp settings non-interactively.
+
+With no key, prints all settings including the effective theme. With a key,
+prints just that value.
+
+Keys:
+  global.theme           Color theme in ~/.obey/campaign/config.json
+  global.editor          Preferred editor
+  global.campaigns_dir   Where camp create places new campaigns
+  global.verbose         Verbose output
+  global.no_color        Disable colored output
+  local.theme_override   Campaign-local theme override (requires a campaign)
+
+```
+camp settings get [key] [flags]
+```
+
+### Examples
+
+```
+  camp settings get
+  camp settings get global.theme
+  camp settings get --json
+```
+
+### Options
+
+```
+  -h, --help   help for get
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp settings](../camp_settings/)	 - Manage camp configuration

--- a/docs/cli-reference/camp/camp_settings_set.md
+++ b/docs/cli-reference/camp/camp_settings_set.md
@@ -1,0 +1,49 @@
+---
+title: "camp settings set"
+linkTitle: "camp settings set"
+description: "Set a camp setting"
+---
+
+## camp settings set
+
+Set a camp setting
+
+### Synopsis
+
+Set a camp setting non-interactively.
+
+Accepts the same keys as 'camp settings get'. Theme values are one of
+adaptive, light, dark, or high-contrast. Boolean values accept true/false.
+Setting local.theme_override to 'inherit' clears the override; local.* keys
+require running inside a campaign.
+
+```
+camp settings set <key> <value> [flags]
+```
+
+### Examples
+
+```
+  camp settings set global.theme dark
+  camp settings set global.verbose true
+  camp settings set local.theme_override light
+  camp settings set local.theme_override inherit
+```
+
+### Options
+
+```
+  -h, --help   help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp settings](../camp_settings/)	 - Manage camp configuration

--- a/docs/cli-reference/camp/camp_workitem.md
+++ b/docs/cli-reference/camp/camp_workitem.md
@@ -57,5 +57,6 @@ camp workitem [flags]
 * [camp workitem doctor](../camp_workitem_doctor/)	 - Report workitem link-registry health issues
 * [camp workitem link](../camp_workitem_link/)	 - Attach a workitem to a project, festival, worktree, or campaign path
 * [camp workitem links](../camp_workitem_links/)	 - List workitem links
+* [camp workitem priority](../camp_workitem_priority/)	 - Set or clear the manual priority of a workitem
 * [camp workitem resolve](../camp_workitem_resolve/)	 - Print the workitem the current context resolves to (read-only)
 * [camp workitem unlink](../camp_workitem_unlink/)	 - Remove one or more workitem links

--- a/docs/cli-reference/camp/camp_workitem_priority.md
+++ b/docs/cli-reference/camp/camp_workitem_priority.md
@@ -1,0 +1,47 @@
+---
+title: "camp workitem priority"
+linkTitle: "camp workitem priority"
+description: "Set or clear the manual priority of a workitem"
+---
+
+## camp workitem priority
+
+Set or clear the manual priority of a workitem
+
+### Synopsis
+
+Set or clear the manual priority of a workitem.
+
+The selector accepts the same forms as 'camp workitem current': a stable
+.workitem id, the workitem key (<type>:<path>), a relative path, or a directory
+slug. Priority is one of high, medium, low, or clear (clear removes any manual
+priority). Assignments persist in .campaign/settings/workitems.json, the same
+store the interactive dashboard writes.
+
+Examples:
+  camp workitem priority festival:festivals/active/demo high
+  camp workitem priority demo clear
+  camp workitem priority demo high --json
+
+```
+camp workitem priority <selector> <high|medium|low|clear> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for priority
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/fest/fest_chain.md
+++ b/docs/cli-reference/fest/fest_chain.md
@@ -30,6 +30,7 @@ Create, validate, and track chains of dependent festivals.
 ### SEE ALSO
 
 * [fest](../fest/)	 - Festival Methodology CLI - goal-oriented project management for AI agents
+* [fest chain add](../fest_chain_add/)	 - Add a festival to a chain
 * [fest chain check](../fest_chain_check/)	 - Check if a festival is unblocked within its chain
 * [fest chain complete](../fest_chain_complete/)	 - Complete and archive a chain
 * [fest chain create](../fest_chain_create/)	 - Create a new festival chain

--- a/docs/cli-reference/fest/fest_chain_add.md
+++ b/docs/cli-reference/fest/fest_chain_add.md
@@ -1,0 +1,43 @@
+---
+title: "fest chain add"
+linkTitle: "fest chain add"
+description: "Add a festival to a chain"
+---
+
+## fest chain add
+
+Add a festival to a chain
+
+### Synopsis
+
+Add a festival as a node in an existing chain, optionally with prerequisite dependency edges. The mutated chain is validated in memory and written only if valid.
+The festival defaults to the current festival context when run inside a festival or linked project.
+
+```
+fest chain add [flags]
+```
+
+### Options
+
+```
+      --after stringArray   prerequisite festival ref/id (repeatable)
+      --chain string        target chain id or name
+      --festival string     festival to add (id, name, or path)
+  -h, --help                help for add
+      --json                emit structured JSON result
+      --note string         optional edge note
+      --type string         edge type: hard | soft (default "hard")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.config/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest chain](../fest_chain/)	 - Manage festival chains (inter-festival dependencies)

--- a/docs/cli-reference/fest/fest_chain_check.md
+++ b/docs/cli-reference/fest/fest_chain_check.md
@@ -10,10 +10,10 @@ Check if a festival is unblocked within its chain
 
 ### Synopsis
 
-Quick check whether a specific festival's hard dependencies are met.
+Quick check whether a specific festival's hard dependencies are met. The festival ref or id is optional when it can be inferred from the current festival or linked project.
 
 ```
-fest chain check <ref-or-id> [flags]
+fest chain check [ref-or-id] [flags]
 ```
 
 ### Options

--- a/docs/cli-reference/fest/fest_chain_complete.md
+++ b/docs/cli-reference/fest/fest_chain_complete.md
@@ -14,8 +14,13 @@ Mark a chain as completed and move it to festivals/dungeon/completed/chains/.
 
 All festivals in the chain must be completed unless --force is used.
 
+The chain id is optional when it can be inferred from the current festival or
+linked project, or selected interactively. Because this archives the chain, an
+inferred or picked target must be confirmed, and a non-interactive run requires
+the chain id to be passed explicitly.
+
 ```
-fest chain complete <chain-id> [flags]
+fest chain complete [chain-id] [flags]
 ```
 
 ### Options

--- a/docs/cli-reference/fest/fest_chain_graph.md
+++ b/docs/cli-reference/fest/fest_chain_graph.md
@@ -10,10 +10,10 @@ Visualize chain dependency graph
 
 ### Synopsis
 
-Render the chain's dependency graph as ASCII waves or Mermaid diagram syntax.
+Render the chain's dependency graph as ASCII waves or Mermaid diagram syntax. The chain id is optional when it can be inferred from the current festival or linked project, or selected interactively in a terminal.
 
 ```
-fest chain graph <chain-id> [flags]
+fest chain graph [chain-id] [flags]
 ```
 
 ### Options

--- a/docs/cli-reference/fest/fest_chain_list.md
+++ b/docs/cli-reference/fest/fest_chain_list.md
@@ -16,6 +16,7 @@ fest chain list [flags]
 
 ```
   -h, --help            help for list
+      --json            emit structured JSON result
       --status string   filter by status (planning|active|completed)
 ```
 

--- a/docs/cli-reference/fest/fest_chain_status.md
+++ b/docs/cli-reference/fest/fest_chain_status.md
@@ -8,8 +8,12 @@ description: "Show chain status and progress"
 
 Show chain status and progress
 
+### Synopsis
+
+Show chain status and progress. The chain id is optional when it can be inferred from the current festival or linked project, or selected interactively in a terminal.
+
 ```
-fest chain status <chain-id> [flags]
+fest chain status [chain-id] [flags]
 ```
 
 ### Options

--- a/docs/cli-reference/fest/fest_chain_validate.md
+++ b/docs/cli-reference/fest/fest_chain_validate.md
@@ -11,10 +11,11 @@ Validate a festival chain
 ### Synopsis
 
 Run all structural validation checks (S1-S10) against a chain definition.
+The chain id is optional when it can be inferred from the current festival or linked project, or selected interactively in a terminal.
 Use --cross to validate across all chains.
 
 ```
-fest chain validate <chain-id> [flags]
+fest chain validate [chain-id] [flags]
 ```
 
 ### Options

--- a/docs/cli-reference/fest/fest_create_festival.md
+++ b/docs/cli-reference/fest/fest_create_festival.md
@@ -25,6 +25,8 @@ fest create festival [flags]
       --markers-file string   JSON file with REPLACE marker hint→value mappings
       --name string           Festival name (required)
   -p, --project string        Project directory path (auto-links to festival)
+      --seed string           Inline seed content written to the ingest phase input_specs/ (requires a type with an ingest phase)
+      --seed-file string      File whose contents seed the ingest phase input_specs/ (mutually exclusive with --seed)
       --skip-markers          Skip REPLACE marker processing
       --tags string           Comma-separated tags
       --type string           Festival type (standard, implementation, research, quick, ritual)


### PR DESCRIPTION
## Summary

Refresh bundled CLI reference docs for the already-pinned release components:

- fest v0.4.3
- camp v0.2.9

This is the docs-refresh commit generated by `just release stable fest=keep camp=keep`; direct push to `main` was blocked by the repository rule requiring PRs.

## Verification

- `just test release-operator` passed before docs generation in the release recipe.
- `just release plan mode=stable fest=keep camp=keep` planned Festival `v0.2.8`.
- Release tag was not created yet; this PR needs to land first.
