### PR TITLE
Include Festival repo changes in bundled release notes

### DIFF
--- a/tools/release-notes/internal/notes/format.go
+++ b/tools/release-notes/internal/notes/format.go
@@ -14,6 +14,7 @@ type ReleaseInfo struct {
 
 type ReleaseNotesInput struct {
 	FestivalTag string
+	Festival    ReleaseInfo
 	Fest        ReleaseInfo
 	Camp        ReleaseInfo
 }
@@ -29,6 +30,7 @@ func Render(in ReleaseNotesInput) (string, error) {
 		return "", fmt.Errorf("camp release info is incomplete")
 	}
 
+	festivalBody := normalizeGeneratedNotes(in.Festival.Body)
 	festBody := normalizeBody(in.Fest.Body, in.Fest.Repo, in.Fest.Tag)
 	campBody := normalizeBody(in.Camp.Body, in.Camp.Repo, in.Camp.Tag)
 
@@ -46,7 +48,13 @@ func Render(in ReleaseNotesInput) (string, error) {
 	writeLine(fmt.Sprintf("- `fest` %s ([release](%s))", in.Fest.Tag, in.Fest.URL))
 	writeLine(fmt.Sprintf("- `camp` %s ([release](%s))", in.Camp.Tag, in.Camp.URL))
 	writeLine("")
-	writeLine("The component release notes below describe the actual CLI changes in this bundle.")
+	writeLine("This release also includes Festival distribution, packaging, documentation, and plugin changes.")
+	writeLine("")
+	writeLine("## Festival Changes")
+	writeLine("")
+	writeLine(festivalBody)
+	writeLine("")
+	writeLine("The component release notes below describe the bundled CLI changes.")
 	writeLine("")
 	writeLine("## fest " + in.Fest.Tag)
 	writeLine("")
@@ -84,4 +92,22 @@ func normalizeBody(body, repo, tag string) string {
 		repo = "component"
 	}
 	return fmt.Sprintf("_No published release notes found for %s %s._", repo, tag)
+}
+
+func normalizeGeneratedNotes(body string) string {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return "_No Festival repository changes were reported for this release._"
+	}
+	return demoteMarkdownHeadings(trimmed)
+}
+
+func demoteMarkdownHeadings(markdown string) string {
+	lines := strings.Split(markdown, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "#") {
+			lines[i] = "#" + line
+		}
+	}
+	return strings.Join(lines, "\n")
 }

--- a/tools/release-notes/internal/notes/format_test.go
+++ b/tools/release-notes/internal/notes/format_test.go
@@ -8,6 +8,12 @@ import (
 func TestRenderIncludesComponentReleaseBodies(t *testing.T) {
 	out, err := Render(ReleaseNotesInput{
 		FestivalTag: "v0.1.2",
+		Festival: ReleaseInfo{
+			Repo: "festival",
+			Tag:  "v0.1.2",
+			URL:  "https://example.com/festival/v0.1.2",
+			Body: "## What's Changed\n* Festival packaging fix\n\n**Full Changelog**: https://example.com/festival/compare/v0.1.1...v0.1.2",
+		},
 		Fest: ReleaseInfo{
 			Repo: "fest",
 			Tag:  "v0.1.1",
@@ -29,6 +35,9 @@ func TestRenderIncludesComponentReleaseBodies(t *testing.T) {
 		"## Festival v0.1.2",
 		"- `fest` v0.1.1 ([release](https://example.com/fest/v0.1.1))",
 		"- `camp` v0.1.1 ([release](https://example.com/camp/v0.1.1))",
+		"## Festival Changes",
+		"### What's Changed",
+		"* Festival packaging fix",
 		"## fest v0.1.1",
 		"* Fest fix",
 		"## camp v0.1.1",
@@ -45,6 +54,11 @@ func TestRenderIncludesComponentReleaseBodies(t *testing.T) {
 func TestRenderFallsBackWhenComponentBodyMissing(t *testing.T) {
 	out, err := Render(ReleaseNotesInput{
 		FestivalTag: "v0.1.2",
+		Festival: ReleaseInfo{
+			Repo: "festival",
+			Tag:  "v0.1.2",
+			URL:  "https://example.com/festival/v0.1.2",
+		},
 		Fest: ReleaseInfo{
 			Repo: "fest",
 			Tag:  "v0.1.1",
@@ -61,6 +75,7 @@ func TestRenderFallsBackWhenComponentBodyMissing(t *testing.T) {
 	}
 
 	for _, want := range []string{
+		"_No Festival repository changes were reported for this release._",
 		"_No published release notes found for fest v0.1.1._",
 		"_No published release notes found for camp v0.1.1._",
 	} {

--- a/tools/release-notes/main.go
+++ b/tools/release-notes/main.go
@@ -67,9 +67,19 @@ func run(args []string) error {
 	if err != nil {
 		return fmt.Errorf("fetch camp release %s: %w", campTag, err)
 	}
+	festivalNotes, err := fetchGeneratedReleaseNotes("Obedience-Corp/festival", *tag)
+	if err != nil {
+		return fmt.Errorf("fetch festival release notes %s: %w", *tag, err)
+	}
 
 	rendered, err := notes.Render(notes.ReleaseNotesInput{
 		FestivalTag: *tag,
+		Festival: notes.ReleaseInfo{
+			Repo: "festival",
+			Tag:  *tag,
+			URL:  releaseURL("Obedience-Corp/festival", *tag),
+			Body: festivalNotes.Body,
+		},
 		Fest: notes.ReleaseInfo{
 			Repo: "fest",
 			Tag:  festRelease.TagName,
@@ -99,7 +109,7 @@ func run(args []string) error {
 	}
 
 	fmt.Printf("Wrote release notes to %s\n", absOutput)
-	fmt.Printf("Included fest %s and camp %s\n", festRelease.TagName, campRelease.TagName)
+	fmt.Printf("Included festival %s, fest %s, and camp %s\n", *tag, festRelease.TagName, campRelease.TagName)
 	return nil
 }
 
@@ -132,6 +142,25 @@ func fetchRelease(repo, tag string) (releaseView, error) {
 		return releaseView{}, fmt.Errorf("release %s in %s returned incomplete metadata", tag, repo)
 	}
 	return view, nil
+}
+
+func fetchGeneratedReleaseNotes(repo, tag string) (releaseView, error) {
+	out, err := cmdOutput("", "gh", "api", "repos/"+repo+"/releases/generate-notes", "-f", "tag_name="+tag)
+	if err != nil {
+		return releaseView{}, err
+	}
+
+	var view releaseView
+	if err := json.Unmarshal([]byte(out), &view); err != nil {
+		return releaseView{}, fmt.Errorf("parse generated release notes output: %w", err)
+	}
+	view.TagName = tag
+	view.URL = releaseURL(repo, tag)
+	return view, nil
+}
+
+func releaseURL(repo, tag string) string {
+	return fmt.Sprintf("https://github.com/%s/releases/tag/%s", repo, tag)
 }
 
 func isReleaseMissing(err error) bool {


### PR DESCRIPTION
## Summary

Include GitHub-generated Festival repository changes in bundled release notes before the `fest` and `camp` component sections.

This fixes the gap seen in the `v0.2.8` release notes, where component changes were present but Festival repo changes from PRs #62, #63, and #64 were omitted.

## Changes

- Fetch `Obedience-Corp/festival` generated release notes with GitHub's `releases/generate-notes` endpoint.
- Render a `Festival Changes` section before the component release notes.
- Demote generated markdown headings so the generated body nests cleanly under the Festival section.
- Add formatter coverage for generated Festival notes and the empty fallback.

## Verification

- `go -C tools/release-notes test ./...`
- `just test release-notes`
- Rendered `v0.2.8` notes locally and confirmed the Festival PR section appears before component notes.
- `git diff --check`

The live `v0.2.8` release notes were also updated manually to include the missing Festival highlights.
