### PR TITLE
fix: opencode plugin must default-export a function (live-verified)

### DIFF
--- a/.opencode/plugins/festival.js
+++ b/.opencode/plugins/festival.js
@@ -3,9 +3,7 @@ import { fileURLToPath } from "node:url";
 
 const installer = fileURLToPath(new URL("../scripts/ensure-festival.sh", import.meta.url));
 
-export const version = "1.1.0";
-
-export const FestivalPlugin = async ({ $ }) => {
+export default async ({ $ }) => {
   await $`bash ${installer}`.catch(() => {});
   return {};
 };

--- a/packaging/targets/opencode.target.mjs
+++ b/packaging/targets/opencode.target.mjs
@@ -39,8 +39,7 @@ export default {
   harness: "opencode",
   manifests: [],
   emit(ctx) {
-    const plugin = ctx.readTemplate("opencode", "js").replaceAll("__VERSION__", ctx.manifest.version);
-    ctx.writeText(".opencode/plugins/festival.js", plugin, "//");
+    ctx.writeText(".opencode/plugins/festival.js", ctx.readTemplate("opencode", "js"), "//");
     ctx.writeText(".opencode/scripts/ensure-festival.sh", ctx.bundledScript("hooks/scripts/ensure-festival.sh"));
     for (const skill of ctx.skills) {
       ctx.writeText(`.opencode/skills/${skill.name}/SKILL.md`, ctx.readPluginFile(skill.path));

--- a/packaging/targets/opencode.template.js
+++ b/packaging/targets/opencode.template.js
@@ -2,9 +2,7 @@ import { fileURLToPath } from "node:url";
 
 const installer = fileURLToPath(new URL("../scripts/ensure-festival.sh", import.meta.url));
 
-export const version = "__VERSION__";
-
-export const FestivalPlugin = async ({ $ }) => {
+export default async ({ $ }) => {
   await $`bash ${installer}`.catch(() => {});
   return {};
 };


### PR DESCRIPTION
## opencode plugin fails to load (live-verified)

Follow-up to #68 and #70. Sibling to the Codex fix in #70, which merged separately while this one was still being written, so it never made it into `main`.

Live-load verification in **real opencode 1.17.7** (`opencode debug config --print-logs --log-level DEBUG` in a checkout) showed the merged plugin **fails to load**:

```
ERROR message="failed to load plugin" path=.../.opencode/plugins/festival.js error="Plugin export is not a function"
```

opencode treats every module export as a candidate plugin, and the `export const version` string export fails the function check, taking the whole module down. The fix: a single `export default async (...)` with no extra non-function exports (the `version` export was informational and opencode does not consume it).

### Verified on the real CLI
- After the fix: **0 load errors** (`grep -c "failed to load plugin"` went 1 -> 0).
- `opencode debug skill` lists all 8 bundled skills from `.opencode/skills/` (auto-discovery already worked).
- Plugin body runs and resolves the bundled installer path correctly (`fileURLToPath`).

`just plugin check` passes. This is the same class of bug as #70 (Codex): structural validation passed, the real CLI rejected it.
