### PR TITLE
docs: navigation-first fest next loop prompts

### DIFF
--- a/docs/guides/loops-and-orchestration.md
+++ b/docs/guides/loops-and-orchestration.md
@@ -29,20 +29,32 @@ explore notes, and festivals, and spans every project in the workspace.
 
 ## Loops start with a prompt
 
-A loop usually begins with an instruction you give an agent at the start of a
-session. These prompts are the human interface to the loops below; the rest of this
-guide is what each one does under the hood.
+A loop begins with an instruction you give an agent, and the first thing that
+instruction does is point the agent at the right working directory. This matters: a
+festival does its work in its **linked project or worktree**, not in the festival
+folder, so the loop runs from there. The bracketed paths below are where you point
+the agent (in most agent harnesses, with path autocomplete).
 
-Start a festival:
+Start a festival, when you know where it is linked:
 
-> Execute this festival with the fest next loop: run `fest next`, do the task it
-> prints, then `fest commit`, and repeat until it reports the festival is complete.
-> Stop at any approval gate and ask me before continuing.
+> Navigate to `<linked project or worktree path>` and run the fest next loop: run
+> `fest next`, do the task it prints, then `fest commit`, and repeat until the
+> festival is complete. Stop at any approval gate and ask me before continuing.
 
-Walk a standalone workflow:
+Start a festival, when you are not sure where it is linked:
 
-> Walk this `WORKFLOW.md` with `fest next` and `fest workflow advance`, one step at
-> a time, until the workflow is done.
+> Navigate to `<festival path>`, run `fest go project` to jump to its linked working
+> directory, then run the fest next loop there.
+
+`fest go project` (alias `fgo project`) moves from a festival to its linked project
+or worktree, and `fest go fest` goes back. Links are created with `fest link` from
+inside a festival and listed with `fest links`; if a festival has no link yet,
+`fest link` attaches one.
+
+Walk a standalone WORKFLOW.md (outside a festival):
+
+> Open `<path to the WORKFLOW.md>` and run the fest next loop: `fest next`, do the
+> step, then `fest workflow advance`, and repeat until the workflow is done.
 
 Orchestrate work items across projects:
 
@@ -102,9 +114,10 @@ DECOMPOSE to forward again is a real cycle. See
 ### Complex: a festival
 
 When the work needs decomposition, parallel tracks, and enforced verification, use
-a festival. It organizes work as phases, sequences, and tasks. `fest next` walks
-that structure by dependency and progress; `fest commit` records each step with a
-traceability tag and advances the loop:
+a festival. It organizes work as phases, sequences, and tasks. Run the loop from
+the festival's linked project or worktree (`fest go project` gets you there).
+`fest next` walks that structure by dependency and progress; `fest commit` records
+each step with a traceability tag and advances the loop:
 
 ```bash
 fest next                  # the next actionable task, by dependency and progress


### PR DESCRIPTION
## What

Follow-up to #77. Makes the **"Loops start with a prompt"** section navigation-first, because in practice a `fest next` loop starts by pointing the agent at the right working directory, not by running `fest next` from wherever the session happens to be.

## Why

A festival does its work in its **linked project or worktree**, not in the festival folder, so the loop has to run from there. The previous prompts skipped that step.

## Changes

- **Festival, link known:** "Navigate to `<linked project or worktree path>` and run the fest next loop."
- **Festival, link unknown:** "Navigate to `<festival path>`, run `fest go project` to jump to the linked working directory, then run the loop."
- **Standalone `WORKFLOW.md`:** "Open `<path to the WORKFLOW.md>` and run the fest next loop."
- Documents `fest go project` / `fgo project` / `fest go fest` / `fest link` / `fest links`.
- Adds a one-line reminder in the festival section that the loop runs from the linked project or worktree (`fest go project` gets you there).

## Verified

`hugo` build clean (363 pages, no errors), navigation content renders, all `{{< ref >}}` cross-links resolve, no emdashes. Commands checked against the fest CLI reference (`fest go project`, `fest go fest`, `fest link`).
