### PR TITLE
docs: link examples repo + add Examples docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The same machinery runs at three scales, smallest first:
 
 > List the ready work items with `camp workitem --json`, and for each one create a worktree, dispatch a subagent to implement it, and open a PR.
 
-Full guide: **[Loops & Orchestration](https://docs.fest.build/guides/loops-and-orchestration/)**.
+Full guide: **[Loops & Orchestration](https://docs.fest.build/guides/loops-and-orchestration/)**. See a complete worked festival, plan to execution, in the [examples](https://github.com/Obedience-Corp/examples).
 
 ## Navigation
 
@@ -354,6 +354,7 @@ Full documentation at **[docs.fest.build](https://docs.fest.build)**:
 Repository entry points:
 
 - [README.zh-CN.md](README.zh-CN.md): Simplified Chinese overview for Chinese developers
+- [Example campaigns & festivals](https://github.com/Obedience-Corp/examples): real, cloneable example campaigns and festivals to read and run
 - [Examples](examples/): before/after shapes for resumable AI coding work
 - [Templates](templates/): reusable planning scaffolds for AI-assisted feature work
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,35 @@
+---
+title: "Examples"
+weight: 15
+---
+
+# Examples
+
+Real example campaigns and festivals you can clone, read, and run. Browse them all
+in the [examples repo](https://github.com/Obedience-Corp/examples); the project
+repos live in the [Festival-Examples](https://github.com/Festival-Examples)
+organization.
+
+## Campaigns
+
+A campaign is a workspace that holds the projects, plans, and context for a mission.
+
+- [Festival Example Campaign](https://github.com/Festival-Examples/example-campaign):
+  a public example workspace for learning the `camp` and `fest` CLIs. It preserves
+  the full planning, execution, review, and ritual structure around its example
+  projects, including a fully worked Go todo CLI as the golden path.
+
+## Festivals
+
+A festival is a single structured plan, read one end to end to see how Festival
+breaks a real piece of work into phases, sequences, and tasks and drives it to
+completion.
+
+- [Camp Hardening Festival (CH0001)](https://github.com/Festival-Examples/example-camp-hardening-festival):
+  a complete, worked example festival that hardens the `camp` CLI with safer
+  destructive commands, more consistent JSON output contracts, and stronger
+  git-backed workflows. Planned and executed end to end as 4 phases, 12 sequences,
+  and 145 tasks, then promoted to `dungeon/completed`.
+
+More examples are added over time in the
+[Festival-Examples](https://github.com/Festival-Examples) organization.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -14,10 +14,13 @@ organization.
 
 A campaign is a workspace that holds the projects, plans, and context for a mission.
 
-- [Festival Example Campaign](https://github.com/Festival-Examples/example-campaign):
-  a public example workspace for learning the `camp` and `fest` CLIs. It preserves
-  the full planning, execution, review, and ritual structure around its example
-  projects, including a fully worked Go todo CLI as the golden path.
+### Festival Example Campaign
+
+**Repository:** <https://github.com/Festival-Examples/example-campaign>
+
+A public example workspace for learning the `camp` and `fest` CLIs. It preserves the
+full planning, execution, review, and ritual structure around its example projects,
+including a fully worked Go todo CLI as the golden path.
 
 ## Festivals
 
@@ -25,11 +28,14 @@ A festival is a single structured plan, read one end to end to see how Festival
 breaks a real piece of work into phases, sequences, and tasks and drives it to
 completion.
 
-- [Camp Hardening Festival (CH0001)](https://github.com/Festival-Examples/example-camp-hardening-festival):
-  a complete, worked example festival that hardens the `camp` CLI with safer
-  destructive commands, more consistent JSON output contracts, and stronger
-  git-backed workflows. Planned and executed end to end as 4 phases, 12 sequences,
-  and 145 tasks, then promoted to `dungeon/completed`.
+### Camp Hardening Festival (CH0001)
+
+**Repository:** <https://github.com/Festival-Examples/example-camp-hardening-festival>
+
+A complete, worked example festival that hardens the `camp` CLI with safer
+destructive commands, more consistent JSON output contracts, and stronger git-backed
+workflows. Planned and executed end to end as 4 phases, 12 sequences, and 145 tasks,
+then promoted to `dungeon/completed`.
 
 More examples are added over time in the
 [Festival-Examples](https://github.com/Festival-Examples) organization.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -43,6 +43,10 @@ menu:
       parent: getting-started
       url: /videos/
       weight: 14
+    - name: Examples
+      parent: getting-started
+      url: /examples/
+      weight: 15
 
     - name: Methodology
       identifier: methodology


### PR DESCRIPTION
## What

Surfaces the example campaigns and festivals from the README and the docs site.

## Changes

**README**
- Adds the examples repo to Repository entry points: [Example campaigns & festivals](https://github.com/Obedience-Corp/examples).
- Adds a contextual pointer from the Agentic Loops section to a complete worked festival example, so a reader learning the loop can jump straight to a real one.

**Docs site**
- New `docs/examples.md` (`/examples/`) with **Campaigns** and **Festivals** sections, featuring the [Camp Hardening Festival (CH0001)](https://github.com/Festival-Examples/example-camp-hardening-festival) worked example (4 phases / 12 sequences / 145 tasks, promoted to `dungeon/completed`).
- Wires it into the Getting Started nav (weight 15, after Videos).

Pairs with [Obedience-Corp/examples#1](https://github.com/Obedience-Corp/examples/pull/1), which adds the matching Festivals section to the examples index.

## Verified

`hugo` build clean (364 pages, no errors), the Examples page renders and appears in the sidebar (same wiring as Videos), all links resolve, no emdashes.

## Note

The docs change means a Pages redeploy is needed after merge to publish `/examples/` (the README link is live on GitHub immediately).
