### PR TITLE
docs(site): landing page overhaul (fest watch GIF hero, star CTAs, system theme, npm, copy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ fest next
 After installing, see the [quick start guide](https://docs.fest.build/getting-started/quickstart/) for shell setup and first steps.
 
 <p align="center">
-  <img src="docs/images/fest-show.gif" alt="Animated fest show tree for the camp-hardening CH0001 festival" width="400">
+  <img src="docs/images/fest-show.gif" alt="Animated fest watch tree for the camp-hardening CH0001 festival" width="400">
 </p>
 
 <p align="center"><em><a href="https://github.com/Festival-Examples/example-camp-hardening-festival">See the festival behind this demo &rarr;</a></em></p>

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -32,7 +32,7 @@ completion.
 
 **Repository:** <https://github.com/Festival-Examples/example-camp-hardening-festival>
 
-<img src="/images/fest-show.gif" alt="Animated fest show tree for the camp-hardening CH0001 festival" width="480">
+<img src="/images/fest-show.gif" alt="Animated fest watch tree for the camp-hardening CH0001 festival" width="480">
 
 A complete, worked example festival that hardens the `camp` CLI with safer
 destructive commands, more consistent JSON output contracts, and stronger git-backed

--- a/themes/festival/assets/css/main.css
+++ b/themes/festival/assets/css/main.css
@@ -1155,6 +1155,26 @@ summary {
   text-align: center;
 }
 
+.home-hero__visual {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.home-hero__visual .terminal-demo {
+  width: 100%;
+  max-width: 360px;
+}
+
+.home-hero__visual-caption {
+  max-width: 360px;
+  margin: 1rem auto 0;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--festival-400);
+  text-align: center;
+}
+
 .home-hero__stats {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/themes/festival/layouts/_default/baseof.html
+++ b/themes/festival/layouts/_default/baseof.html
@@ -62,12 +62,26 @@
     try {
       urlTheme = new URLSearchParams(window.location.search).get('theme');
     } catch (e) {}
-    var defaultTheme = {{ if .IsHome }}"light"{{ else }}"dark"{{ end }};
+    var stored = null;
+    try { stored = localStorage.getItem('theme'); } catch (e) {}
+    var systemDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
     var theme = (urlTheme === 'dark' || urlTheme === 'light')
       ? urlTheme
-      : (localStorage.getItem('theme') || defaultTheme);
+      : (stored || (systemDark ? 'dark' : 'light'));
     document.documentElement.setAttribute('data-theme', theme);
   })();
+
+  // Follow the system color scheme when the user has not picked a theme manually.
+  if (window.matchMedia) {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+      var picked = false;
+      try { picked = !!localStorage.getItem('theme'); } catch (err) {}
+      if (!picked) {
+        document.documentElement.setAttribute('data-theme', e.matches ? 'dark' : 'light');
+        if (typeof updateThemeIcon === 'function') updateThemeIcon();
+      }
+    });
+  }
 
   function toggleTheme() {
     var current = document.documentElement.getAttribute('data-theme');

--- a/themes/festival/layouts/index.html
+++ b/themes/festival/layouts/index.html
@@ -7,7 +7,8 @@
       <p>
         AI generates plans, code, and research faster than you can organize it.
         Festival gives every mission one workspace, so you stop asking
-        "where should this go?" and "what was I working on?" and start shipping outcomes.
+        "where should this go?" and "what was I working on?" Structured loops carry
+        long-running goals all the way to done, not just to a plan that stalls.
       </p>
 
       <div class="home-hero__actions">
@@ -16,6 +17,9 @@
         {{ end }}
         {{ with site.GetPage "/getting-started/quickstart" }}
           <a href="{{ .RelPermalink }}" class="btn btn--secondary">Read the Quick Start</a>
+        {{ end }}
+        {{ with site.Params.repo }}
+          <a href="{{ . }}" class="btn btn--secondary" target="_blank" rel="noopener">★ Star on GitHub</a>
         {{ end }}
       </div>
 
@@ -43,21 +47,11 @@
             <span class="terminal-demo__dot terminal-demo__dot--yellow"></span>
             <span class="terminal-demo__dot terminal-demo__dot--green"></span>
           </div>
-          <span class="terminal-demo__title">~/my-startup</span>
+          <span class="terminal-demo__title">fest watch</span>
         </div>
-        <div class="terminal-demo__body">
-          <div class="terminal-demo__line"><span class="terminal-demo__prompt">$</span> cgo f</div>
-          <div class="terminal-demo__line terminal-demo__line--muted">~/my-startup/festivals</div>
-          <div class="terminal-demo__line"><span class="terminal-demo__prompt">$</span> fest create festival --name "search-rewrite" --type standard</div>
-          <div class="terminal-demo__line terminal-demo__line--accent">✓ Festival created: search-rewrite</div>
-          <div class="terminal-demo__line terminal-demo__line--muted">001_INGEST/ 002_PLAN/ 003_IMPLEMENT/</div>
-          <div class="terminal-demo__line"><span class="terminal-demo__prompt">$</span> fest validate</div>
-          <div class="terminal-demo__line terminal-demo__line--accent">✓ Festival is valid. Ready for execution.</div>
-          <div class="terminal-demo__line"><span class="terminal-demo__prompt">$</span> fest next</div>
-          <div class="terminal-demo__line terminal-demo__line--highlight">→ 003_IMPLEMENT/01/03 search_query_builder</div>
-          <div class="terminal-demo__line terminal-demo__line--muted">3 festivals active. Agents working autonomously.</div>
-        </div>
+        <img src="/images/fest-show.gif" alt="fest watch rendering a worked festival tree of phases, sequences, and tasks" style="display:block;width:100%;height:auto;" loading="lazy">
       </div>
+      <p class="home-hero__visual-caption"><code>fest watch</code> on a real festival. fest is the planning system that breaks a long-running, complex, or highly specific goal into structured work and drives it to completion.</p>
     </div>
   </section>
 
@@ -119,10 +113,11 @@
 
   <section class="home-section home-section--contrast">
     <div class="home-section__intro">
-      <h2 class="home-section__heading">Why Teams Use Festival</h2>
+      <h2 class="home-section__heading">Why People Use Festival</h2>
       <p class="home-section__lede">
-        AI coding tools are fast inside a repo. The work they produce still has to live somewhere.
-        Festival is the organizational layer that keeps it in order.
+        AI generates a flood of plans, code, and research. Getting good results out of it still
+        takes constant manual steering. People use Festival because they want AI to do the work
+        the right way the first time, not after a dozen rounds of correction.
       </p>
     </div>
 
@@ -153,10 +148,14 @@
       <div class="home-install__copy">
         <h2 class="home-section__heading">Install and Start Fast</h2>
         <p class="home-section__lede">
-          The launch-critical path is simple: install Festival, create a campaign, and get to the first actionable `fest next`.
+          The launch-critical path is simple: install Festival with npm or Homebrew, create a campaign, and get to the first actionable `fest next`.
         </p>
       </div>
       <div class="home-install__actions">
+        <div class="home-install__terminal">
+          <span class="home-install__prompt">$</span>
+          <code>npm install -g @obedience-corp/festival</code>
+        </div>
         <div class="home-install__terminal">
           <span class="home-install__prompt">$</span>
           <code>brew install --cask Obedience-Corp/tap/festival</code>
@@ -180,6 +179,9 @@
       <span>Codex</span>
       <span>OpenCode</span>
       <span>Crush</span>
+      <span>Grok build</span>
+      <span>OpenClaw</span>
+      <span>Hermes</span>
       <span>Aider</span>
       <span>Cursor Agents</span>
       <span>Custom tooling</span>

--- a/themes/festival/layouts/partials/header.html
+++ b/themes/festival/layouts/partials/header.html
@@ -20,7 +20,7 @@
       <a href="{{ .RelPermalink }}" class="site-header__link site-header__link--desktop">Install</a>
     {{ end }}
     {{ with .Site.Params.repo }}
-      <a href="{{ . }}" class="site-header__link site-header__link--desktop" target="_blank" rel="noopener">GitHub</a>
+      <a href="{{ . }}" class="site-header__link site-header__link--desktop" target="_blank" rel="noopener">★ Star</a>
     {{ end }}
       <a href="https://fest.build/feedback" class="site-header__link site-header__link--desktop">Feedback</a>
     <button class="search-trigger" aria-label="Search">


### PR DESCRIPTION
## What

Landing-page overhaul for the docs site. This work was pushed to PR #82's branch **after** #82 was squash-merged, so it ended up stranded with no PR. Recovered here as a clean branch off `main`.

## Changes (`themes/festival/...` + docs)

- **Hero GIF:** replace the hand-built fake terminal mockup with the real `fest watch` recording (capped at 360px and centered so it sits right on desktop and mobile), with a caption: it shows `fest`, the planning system that drives long-running, complex, or highly specific goals to completion.
- **Hero copy:** "Structured loops carry long-running goals all the way to done, not just to a plan that stalls."
- **"Why Teams" → "Why People Use Festival"** (honest), reframed around AI generating a flood of output that takes constant manual steering, and wanting AI to do the work right the first time.
- **System light/dark:** default to `prefers-color-scheme`, follow live changes, manual toggle still overrides.
- **npm install** added first (higher conversion) alongside Homebrew.
- **Site-wide star CTA:** header "GitHub" → "★ Star" + a "★ Star on GitHub" hero button.
- **AI-tools list:** added Grok build, OpenClaw, Hermes.

## Verified

`hugo` build clean (364 pages). Earlier screenshotted at desktop (light + dark via `?theme=dark`) and mobile on the original branch; the recovered files are byte-identical.

## Note

Needs a Pages redeploy after merge to publish. The `fest watch` filename stays `fest-show.gif` (how it was generated).
