### PR TITLE
feat(release-operator): emit-marketplace-entry for obey marketplace [OI0006]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,9 +81,10 @@ jobs:
         env:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
+          MARKETPLACE_PUBLISH_TOKEN: ${{ secrets.MARKETPLACE_PUBLISH_TOKEN }}
         run: |
           missing=0
-          for name in HOMEBREW_TAP_GITHUB_TOKEN AUR_SSH_KEY; do
+          for name in HOMEBREW_TAP_GITHUB_TOKEN AUR_SSH_KEY MARKETPLACE_PUBLISH_TOKEN; do
             if [ -z "${!name:-}" ]; then
               echo "::error::Missing required secret ${name}"
               missing=1
@@ -166,6 +167,22 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_MODE: ${{ steps.release_channel.outputs.mode }}
         run: scripts/publish_npm_package.sh
+
+      - name: Generate marketplace entry
+        run: |
+          go -C tools/release-operator run . emit-marketplace-entry \
+            --repo-root ../.. \
+            --tag "${GITHUB_REF_NAME}" \
+            --channel "${{ steps.release_channel.outputs.mode }}" \
+            --checksums dist/checksums.txt \
+            --output dist/marketplace/obey-package.json
+
+      - name: Publish marketplace entry
+        env:
+          MARKETPLACE_PUBLISH_TOKEN: ${{ secrets.MARKETPLACE_PUBLISH_TOKEN }}
+          FESTIVAL_TAG: ${{ github.ref_name }}
+          RELEASE_CHANNEL: ${{ steps.release_channel.outputs.mode }}
+        run: scripts/publish_marketplace_entry.sh
 
   npm-publish:
     if: github.event_name == 'workflow_dispatch'

--- a/scripts/publish_marketplace_entry.sh
+++ b/scripts/publish_marketplace_entry.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${FESTIVAL_TAG:?missing FESTIVAL_TAG}"
+: "${RELEASE_CHANNEL:?missing RELEASE_CHANNEL}"
+
+repo_url="${MARKETPLACE_REPO_URL:-}"
+if [ -z "${repo_url}" ]; then
+  : "${MARKETPLACE_PUBLISH_TOKEN:?missing MARKETPLACE_PUBLISH_TOKEN}"
+  repo_url="https://x-access-token:${MARKETPLACE_PUBLISH_TOKEN}@github.com/Obedience-Corp/marketplace.git"
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+git clone --depth 1 "${repo_url}" "${work}/marketplace"
+
+dest_dir="${work}/marketplace/packages/obedience-corp/festival"
+mkdir -p "${dest_dir}"
+cp dist/marketplace/obey-package.json "${dest_dir}/obey-package.json"
+
+python3 scripts/upsert_marketplace_index.py \
+  "${work}/marketplace/index.json" \
+  "obedience-corp/festival" \
+  "${RELEASE_CHANNEL}"
+
+cd "${work}/marketplace"
+git config user.name "obey-release-bot"
+git config user.email "release@obediencecorp.com"
+git add packages/obedience-corp/festival/obey-package.json index.json
+
+if git diff --cached --quiet; then
+  echo "marketplace already up to date for ${FESTIVAL_TAG} (${RELEASE_CHANNEL}); nothing to publish"
+  exit 0
+fi
+
+git commit -m "Publish obedience-corp/festival ${FESTIVAL_TAG} (${RELEASE_CHANNEL})"
+git push origin HEAD:main

--- a/scripts/upsert_marketplace_index.py
+++ b/scripts/upsert_marketplace_index.py
@@ -1,0 +1,31 @@
+import json, sys, datetime
+
+index_path, pkg_id, channel = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(index_path) as fh:
+    index = json.load(fh)
+
+index.setdefault("source", "official-obey")
+packages = index.setdefault("packages", [])
+
+changed = False
+entry = next((p for p in packages if p.get("id") == pkg_id), None)
+if entry is None:
+    entry = {"id": pkg_id, "channels": []}
+    packages.append(entry)
+    changed = True
+
+channels = entry.setdefault("channels", [])
+if channel not in channels:
+    channels.append(channel)
+    channels.sort()
+    changed = True
+
+if not changed:
+    sys.exit(0)
+
+index["updatedAt"] = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+with open(index_path, "w") as fh:
+    json.dump(index, fh, indent=2)
+    fh.write("\n")

--- a/tools/release-operator/internal/operator/marketplace.go
+++ b/tools/release-operator/internal/operator/marketplace.go
@@ -1,0 +1,175 @@
+package operator
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+type MarketplaceEntryInput struct {
+	FestivalVersion string
+	Channel         string
+	PublishedAt     string
+	CampVersion     string
+	FestVersion     string
+	Artifacts       []ArtifactInput
+}
+
+type ArtifactInput struct {
+	OS       string
+	Arch     string
+	Filename string
+	URL      string
+	SHA256   string
+}
+
+type productManifest struct {
+	SchemaVersion    int           `json:"schema_version"`
+	ID               string        `json:"id"`
+	Class            string        `json:"class"`
+	DisplayName      string        `json:"display_name"`
+	Summary          string        `json:"summary"`
+	Description      string        `json:"description"`
+	Homepage         string        `json:"homepage"`
+	Licenses         []string      `json:"licenses"`
+	Aliases          []string      `json:"aliases"`
+	Tags             []string      `json:"tags"`
+	SupportedScopes  []string      `json:"supported_scopes"`
+	ProvidesBinaries []string      `json:"provides_binaries"`
+	HostRuntimes     []hostRuntime `json:"host_runtimes"`
+	Releases         []release     `json:"releases"`
+}
+
+type hostRuntime struct {
+	Runtime     string   `json:"runtime"`
+	DisplayName string   `json:"display_name"`
+	Features    []string `json:"features"`
+}
+
+type release struct {
+	Version       string            `json:"version"`
+	Channel       string            `json:"channel"`
+	PublishedAt   string            `json:"published_at"`
+	Components    map[string]string `json:"components"`
+	Compatibility compatibility     `json:"compatibility"`
+	Dependencies  []any             `json:"dependencies"`
+	Artifacts     []artifact        `json:"artifacts"`
+	Install       installBlock      `json:"install"`
+}
+
+type compatibility struct {
+	OS   []string `json:"os"`
+	Arch []string `json:"arch"`
+}
+
+type artifact struct {
+	Kind     string   `json:"kind"`
+	OS       string   `json:"os"`
+	Arch     string   `json:"arch"`
+	Filename string   `json:"filename"`
+	URL      string   `json:"url"`
+	SHA256   string   `json:"sha256"`
+	Binaries []string `json:"binaries"`
+}
+
+type installBlock struct {
+	Entries []installEntry `json:"entries"`
+}
+
+type installEntry struct {
+	Kind           string `json:"kind"`
+	Source         string `json:"source"`
+	ExecutableName string `json:"executable_name"`
+}
+
+func BuildMarketplaceEntry(in MarketplaceEntryInput) ([]byte, error) {
+	if in.FestivalVersion == "" || in.Channel == "" || in.CampVersion == "" || in.FestVersion == "" {
+		return nil, fmt.Errorf("missing required marketplace entry input")
+	}
+	if len(in.Artifacts) == 0 {
+		return nil, fmt.Errorf("no artifacts for %s", in.FestivalVersion)
+	}
+
+	sorted := append([]ArtifactInput(nil), in.Artifacts...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].OS != sorted[j].OS {
+			return sorted[i].OS < sorted[j].OS
+		}
+		return sorted[i].Arch < sorted[j].Arch
+	})
+
+	arts := make([]artifact, 0, len(sorted))
+	osSet := map[string]struct{}{}
+	archSet := map[string]struct{}{}
+	for _, a := range sorted {
+		if a.OS == "" || a.Arch == "" || a.Filename == "" || a.URL == "" || a.SHA256 == "" {
+			return nil, fmt.Errorf("incomplete artifact for %s/%s", a.OS, a.Arch)
+		}
+		arts = append(arts, artifact{
+			Kind:     "suite-archive",
+			OS:       a.OS,
+			Arch:     a.Arch,
+			Filename: a.Filename,
+			URL:      a.URL,
+			SHA256:   a.SHA256,
+			Binaries: []string{"camp", "fest"},
+		})
+		osSet[a.OS] = struct{}{}
+		if a.Arch != "all" {
+			archSet[a.Arch] = struct{}{}
+		}
+	}
+	archSet["amd64"] = struct{}{}
+	archSet["arm64"] = struct{}{}
+
+	m := productManifest{
+		SchemaVersion: 1,
+		ID:            "obedience-corp/festival",
+		Class:         "product",
+		DisplayName:   "Festival Suite",
+		Summary:       "The camp + fest CLI suite, released and versioned together.",
+		Description:   "Festival Methodology CLI suite. camp and fest are co-tested and shipped as one versioned product; both binaries report the festival release version.",
+		Homepage:      "https://fest.build",
+		Licenses:      []string{"FSL-1.1-ALv2"},
+		Aliases:       []string{"festival", "camp", "fest"},
+		Tags:          []string{"festival", "planning", "cli"},
+		SupportedScopes:  []string{"user"},
+		ProvidesBinaries: []string{"camp", "fest"},
+		HostRuntimes: []hostRuntime{
+			{Runtime: "camp-cli", DisplayName: "Camp CLI plugins", Features: []string{}},
+			{Runtime: "fest-cli", DisplayName: "Fest CLI plugins", Features: []string{}},
+			{Runtime: "fest-extension", DisplayName: "Fest methodology extensions", Features: []string{"marketplace_extension_source_v1"}},
+		},
+		Releases: []release{{
+			Version:     in.FestivalVersion,
+			Channel:     in.Channel,
+			PublishedAt: in.PublishedAt,
+			Components:  map[string]string{"camp": in.CampVersion, "fest": in.FestVersion},
+			Compatibility: compatibility{
+				OS:   sortedKeys(osSet),
+				Arch: sortedKeys(archSet),
+			},
+			Dependencies: []any{},
+			Artifacts:    arts,
+			Install: installBlock{Entries: []installEntry{
+				{Kind: "binary", Source: "camp", ExecutableName: "camp"},
+				{Kind: "binary", Source: "fest", ExecutableName: "fest"},
+			}},
+		}},
+	}
+
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal product manifest: %w", err)
+	}
+	return append(out, '\n'), nil
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/tools/release-operator/internal/operator/marketplace_test.go
+++ b/tools/release-operator/internal/operator/marketplace_test.go
@@ -1,0 +1,80 @@
+package operator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildMarketplaceEntry_Golden(t *testing.T) {
+	in := MarketplaceEntryInput{
+		FestivalVersion: "0.2.10",
+		Channel:         "stable",
+		PublishedAt:     "2026-06-23T00:50:22Z",
+		CampVersion:     "0.2.11",
+		FestVersion:     "0.4.5",
+		Artifacts: []ArtifactInput{
+			{OS: "linux", Arch: "arm64", Filename: "festival-0.2.10-linux-arm64.tar.gz",
+				URL:    "https://github.com/Obedience-Corp/festival/releases/download/v0.2.10/festival-0.2.10-linux-arm64.tar.gz",
+				SHA256: "2f92ec66886efd8a4eca34db169c49dff9408ab7c565dec7f8557e4ddd61302b"},
+			{OS: "darwin", Arch: "all", Filename: "festival-0.2.10-macOS-all.tar.gz",
+				URL:    "https://github.com/Obedience-Corp/festival/releases/download/v0.2.10/festival-0.2.10-macOS-all.tar.gz",
+				SHA256: "4eab84d04cb088a8abf98bd740c0b20b685be5e8e6863c4752edc0d939f915a3"},
+			{OS: "linux", Arch: "amd64", Filename: "festival-0.2.10-linux-x86_64.tar.gz",
+				URL:    "https://github.com/Obedience-Corp/festival/releases/download/v0.2.10/festival-0.2.10-linux-x86_64.tar.gz",
+				SHA256: "faab388d34c7d1224c3a7d940256b45b1e52af9f89f8e72a1b50ef377a42d0aa"},
+		},
+	}
+
+	got, err := BuildMarketplaceEntry(in)
+	if err != nil {
+		t.Fatalf("BuildMarketplaceEntry: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "festival-v0.2.10.golden.json")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+			t.Fatalf("mkdir golden dir: %v", err)
+		}
+		if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+			t.Fatalf("update golden: %v", err)
+		}
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("manifest mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestBuildMarketplaceEntry_DeterministicAcrossRuns(t *testing.T) {
+	in := MarketplaceEntryInput{
+		FestivalVersion: "0.2.10", Channel: "stable", PublishedAt: "2026-06-23T00:50:22Z",
+		CampVersion: "0.2.11", FestVersion: "0.4.5",
+		Artifacts: []ArtifactInput{{OS: "darwin", Arch: "all", Filename: "x", URL: "u", SHA256: "s"}},
+	}
+	a, err := BuildMarketplaceEntry(in)
+	if err != nil {
+		t.Fatalf("first build: %v", err)
+	}
+	b, err := BuildMarketplaceEntry(in)
+	if err != nil {
+		t.Fatalf("second build: %v", err)
+	}
+	if string(a) != string(b) {
+		t.Fatal("non-deterministic output")
+	}
+}
+
+func TestBuildMarketplaceEntry_RejectsMissingInput(t *testing.T) {
+	if _, err := BuildMarketplaceEntry(MarketplaceEntryInput{Channel: "stable"}); err == nil {
+		t.Fatal("expected error for missing version/components")
+	}
+	if _, err := BuildMarketplaceEntry(MarketplaceEntryInput{
+		FestivalVersion: "0.2.10", Channel: "stable", CampVersion: "0.2.11", FestVersion: "0.4.5",
+	}); err == nil {
+		t.Fatal("expected error for missing artifacts")
+	}
+}

--- a/tools/release-operator/internal/operator/testdata/festival-v0.2.10.golden.json
+++ b/tools/release-operator/internal/operator/testdata/festival-v0.2.10.golden.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": 1,
+  "id": "obedience-corp/festival",
+  "class": "product",
+  "display_name": "Festival Suite",
+  "summary": "The camp + fest CLI suite, released and versioned together.",
+  "description": "Festival Methodology CLI suite. camp and fest are co-tested and shipped as one versioned product; both binaries report the festival release version.",
+  "homepage": "https://fest.build",
+  "licenses": [
+    "FSL-1.1-ALv2"
+  ],
+  "aliases": [
+    "festival",
+    "camp",
+    "fest"
+  ],
+  "tags": [
+    "festival",
+    "planning",
+    "cli"
+  ],
+  "supported_scopes": [
+    "user"
+  ],
+  "provides_binaries": [
+    "camp",
+    "fest"
+  ],
+  "host_runtimes": [
+    {
+      "runtime": "camp-cli",
+      "display_name": "Camp CLI plugins",
+      "features": []
+    },
+    {
+      "runtime": "fest-cli",
+      "display_name": "Fest CLI plugins",
+      "features": []
+    },
+    {
+      "runtime": "fest-extension",
+      "display_name": "Fest methodology extensions",
+      "features": [
+        "marketplace_extension_source_v1"
+      ]
+    }
+  ],
+  "releases": [
+    {
+      "version": "0.2.10",
+      "channel": "stable",
+      "published_at": "2026-06-23T00:50:22Z",
+      "components": {
+        "camp": "0.2.11",
+        "fest": "0.4.5"
+      },
+      "compatibility": {
+        "os": [
+          "darwin",
+          "linux"
+        ],
+        "arch": [
+          "amd64",
+          "arm64"
+        ]
+      },
+      "dependencies": [],
+      "artifacts": [
+        {
+          "kind": "suite-archive",
+          "os": "darwin",
+          "arch": "all",
+          "filename": "festival-0.2.10-macOS-all.tar.gz",
+          "url": "https://github.com/Obedience-Corp/festival/releases/download/v0.2.10/festival-0.2.10-macOS-all.tar.gz",
+          "sha256": "4eab84d04cb088a8abf98bd740c0b20b685be5e8e6863c4752edc0d939f915a3",
+          "binaries": [
+            "camp",
+            "fest"
+          ]
+        },
+        {
+          "kind": "suite-archive",
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "festival-0.2.10-linux-x86_64.tar.gz",
+          "url": "https://github.com/Obedience-Corp/festival/releases/download/v0.2.10/festival-0.2.10-linux-x86_64.tar.gz",
+          "sha256": "faab388d34c7d1224c3a7d940256b45b1e52af9f89f8e72a1b50ef377a42d0aa",
+          "binaries": [
+            "camp",
+            "fest"
+          ]
+        },
+        {
+          "kind": "suite-archive",
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "festival-0.2.10-linux-arm64.tar.gz",
+          "url": "https://github.com/Obedience-Corp/festival/releases/download/v0.2.10/festival-0.2.10-linux-arm64.tar.gz",
+          "sha256": "2f92ec66886efd8a4eca34db169c49dff9408ab7c565dec7f8557e4ddd61302b",
+          "binaries": [
+            "camp",
+            "fest"
+          ]
+        }
+      ],
+      "install": {
+        "entries": [
+          {
+            "kind": "binary",
+            "source": "camp",
+            "executable_name": "camp"
+          },
+          {
+            "kind": "binary",
+            "source": "fest",
+            "executable_name": "fest"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -162,9 +162,107 @@ func run(args []string) error {
 			return err
 		}
 		return runCleanup(ctx, *tag)
+	case "emit-marketplace-entry":
+		fs := commandFlags("emit-marketplace-entry")
+		repoRoot := fs.String("repo-root", ".", "festival repo root")
+		tag := fs.String("tag", "", "release tag, e.g. v0.2.10 (required)")
+		channel := fs.String("channel", "stable", "release channel")
+		checksums := fs.String("checksums", "dist/checksums.txt", "path to checksums.txt")
+		output := fs.String("output", "dist/marketplace/obey-package.json", "output path for the generated product manifest")
+		publishedAt := fs.String("published-at", "", "RFC3339 published timestamp (optional)")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *tag == "" {
+			return errors.New("missing required --tag")
+		}
+		return runEmitMarketplaceEntry(*repoRoot, *tag, *channel, *checksums, *output, *publishedAt)
 	default:
 		return fmt.Errorf("unknown command %q", args[0])
 	}
+}
+
+func runEmitMarketplaceEntry(repoRoot, tag, channel, checksumsPath, outputPath, publishedAt string) error {
+	festTag, err := exactTagAt(filepath.Join(repoRoot, "fest"))
+	if err != nil {
+		return fmt.Errorf("resolve fest tag: %w", err)
+	}
+	campTag, err := exactTagAt(filepath.Join(repoRoot, "camp"))
+	if err != nil {
+		return fmt.Errorf("resolve camp tag: %w", err)
+	}
+	if festTag == "" || campTag == "" {
+		return fmt.Errorf("fest/camp submodules are not pinned to exact tags (fest=%q camp=%q)", festTag, campTag)
+	}
+
+	checksumsAbs := checksumsPath
+	if !filepath.IsAbs(checksumsAbs) {
+		checksumsAbs = filepath.Join(repoRoot, checksumsPath)
+	}
+	arts, err := suiteArtifactsFromChecksums(checksumsAbs, tag)
+	if err != nil {
+		return err
+	}
+
+	out, err := operator.BuildMarketplaceEntry(operator.MarketplaceEntryInput{
+		FestivalVersion: strings.TrimPrefix(tag, "v"),
+		Channel:         channel,
+		PublishedAt:     publishedAt,
+		CampVersion:     strings.TrimPrefix(campTag, "v"),
+		FestVersion:     strings.TrimPrefix(festTag, "v"),
+		Artifacts:       arts,
+	})
+	if err != nil {
+		return err
+	}
+
+	outAbs := outputPath
+	if !filepath.IsAbs(outAbs) {
+		outAbs = filepath.Join(repoRoot, outputPath)
+	}
+	if err := os.MkdirAll(filepath.Dir(outAbs), 0o755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+	if err := os.WriteFile(outAbs, out, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", outAbs, err)
+	}
+	fmt.Printf("wrote %s (%d bytes)\n", outAbs, len(out))
+	return nil
+}
+
+func suiteArtifactsFromChecksums(path, tag string) ([]operator.ArtifactInput, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read checksums: %w", err)
+	}
+	platform := map[string][2]string{
+		"macOS-all.tar.gz":    {"darwin", "all"},
+		"linux-x86_64.tar.gz": {"linux", "amd64"},
+		"linux-arm64.tar.gz":  {"linux", "arm64"},
+	}
+	var arts []operator.ArtifactInput
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		sum, name := fields[0], fields[1]
+		for suffix, osarch := range platform {
+			if strings.HasSuffix(name, suffix) {
+				arts = append(arts, operator.ArtifactInput{
+					OS:       osarch[0],
+					Arch:     osarch[1],
+					Filename: name,
+					URL:      fmt.Sprintf("https://github.com/Obedience-Corp/festival/releases/download/%s/%s", tag, name),
+					SHA256:   sum,
+				})
+			}
+		}
+	}
+	if len(arts) != 3 {
+		return nil, fmt.Errorf("expected 3 suite artifacts in %s, found %d", path, len(arts))
+	}
+	return arts, nil
 }
 
 func runDraftCommand(args []string, modeName string) error {


### PR DESCRIPTION
Part of festival OI0006 (obey-installer marketplace distribution), phase 003.02.

Adds `release-operator emit-marketplace-entry`: resolves the pinned fest/camp submodule tags + parses `dist/checksums.txt` to generate the `obedience-corp/festival` product manifest that the obey marketplace serves. Pure `BuildMarketplaceEntry` with golden + determinism tests.

Verified: `go test ./...` green; real CLI run against the live v0.2.10 checksums produces output byte-identical to the golden and semantically identical to the committed `Obedience-Corp/marketplace` manifest.

Follow-up on this branch: the release-workflow step that publishes the generated manifest to the marketplace repo (needs repo secret `MARKETPLACE_PUBLISH_TOKEN`).

Note: the release-operator module has pre-existing errcheck lint findings unrelated to this change.