### PR TITLE
Pin camp v0.2.12

### DIFF
--- a/docs/cli-reference/camp/camp_dungeon_move.md
+++ b/docs/cli-reference/camp/camp_dungeon_move.md
@@ -12,8 +12,10 @@ Move dungeon items between statuses
 
 Move items within the dungeon or from the parent directory into the dungeon.
 
-Without --triage, moves an item already in the dungeon root to a status directory.
-With --triage, moves an item from the parent directory into the dungeon.
+By default, moves an item already in the dungeon root to a status directory.
+When the item exists in the parent directory and not in the dungeon root, the
+command automatically treats it as triage work and moves it into the dungeon.
+Use --triage to force a parent-directory move.
 With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
 With --workitem, resolves a campaign workitem from anywhere and moves its directory
 into the workitem type's local dungeon.

--- a/docs/cli-reference/camp/camp_list.md
+++ b/docs/cli-reference/camp/camp_list.md
@@ -15,6 +15,11 @@ List all campaigns registered in the global registry.
 Campaigns are registered when created with 'camp init' or manually
 with 'camp register'. The registry lives at ~/.obey/campaign/registry.json.
 
+In a terminal, 'camp list' (with no flags) opens an interactive browser where you
+can deactivate/reactivate campaigns (cycle lifecycle status), reassign their org,
+and copy paths. Piped, with --json/--count, or with any filter/sort flag it
+prints the table instead. Home paths display as '~'.
+
 Output formats:
   table   - Aligned columns with headers (default)
   simple  - Campaign names only, one per line
@@ -24,12 +29,14 @@ Sorting options:
   accessed - Most recently accessed first (default)
   name     - Alphabetically by name
   type     - Alphabetically by type
+  org      - By org (fallback first, then alphabetical), then by name
 
 Examples:
   camp list                  List all campaigns
   camp list --json           Output as JSON
   camp list --format json    Output as JSON
   camp list --sort name      Sort by name
+  camp list --sort org       Sort by org, then name
   camp list --format simple  Names only for scripting
   camp list --count          Print only the total number of campaigns
 
@@ -45,10 +52,11 @@ camp list [flags]
   -f, --format string    Output format (table, simple, json) (default "table")
       --group            Force org grouping
   -h, --help             help for list
+  -i, --interactive      Open the interactive campaign browser (prints the table when stdout is not a terminal)
       --json             Output as JSON (shorthand for --format json)
       --no-group         Suppress org grouping
       --org string       Only campaigns in this org
-  -s, --sort string      Sort by (name, accessed, type) (default "accessed")
+  -s, --sort string      Sort by (name, accessed, type, org) (default "accessed")
       --status string    Only campaigns in this status (active, inactive, reference)
       --tag strings      Only campaigns carrying this tag (repeat for AND)
       --verify-verbose   Show detailed verification output

--- a/docs/cli-reference/camp/camp_org.md
+++ b/docs/cli-reference/camp/camp_org.md
@@ -14,9 +14,16 @@ Group related campaigns into orgs.
 
 Every campaign belongs to exactly one org (default "default"). Orgs are derived:
 an org exists because a campaign names it, and disappears when its last member
-leaves. There is no "org create".
+leaves.
+
+In a terminal, 'camp org' (no arguments) opens an interactive browser of orgs
+and their members where you can move, create, rename, and return campaigns. When
+piped or with --json it prints the current campaign's org instead; use
+'camp org which' to print the org unconditionally.
 
 Commands:
+  which   Print the current campaign's org
+  create  Create an org by joining campaigns (the current campaign if none named)
   add     Assign campaigns to an org (also reassigns; single-membership)
   remove  Return campaigns to the default org
 
@@ -27,7 +34,9 @@ camp org [flags]
 ### Examples
 
 ```
-  camp org                                       Print the current campaign's org
+  camp org                                       Browse and manage orgs interactively (TTY)
+  camp org which                                 Print the current campaign's org
+  camp org create obey                           Add the current campaign to "obey"
   camp org add obey obey-campaign obey-content   Move campaigns into "obey"
   camp org remove obey-content                   Return a campaign to "default"
 ```
@@ -35,8 +44,9 @@ camp org [flags]
 ### Options
 
 ```
-  -h, --help   help for org
-      --json   Output as JSON
+  -h, --help          help for org
+  -i, --interactive   Open the interactive org browser (prints the org list when stdout is not a terminal)
+      --json          Output as JSON
 ```
 
 ### Options inherited from parent commands
@@ -49,7 +59,9 @@ camp org [flags]
 
 * [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
 * [camp org add](../camp_org_add/)	 - Assign campaigns to an org (reassigns; single-membership)
+* [camp org create](../camp_org_create/)	 - Create an org by joining campaigns (the current campaign if none named)
 * [camp org list](../camp_org_list/)	 - List orgs with member and active counts
 * [camp org remove](../camp_org_remove/)	 - Return campaigns to the default org
 * [camp org rename](../camp_org_rename/)	 - Rename an org, reassigning all members atomically
 * [camp org show](../camp_org_show/)	 - Show an org's member campaigns
+* [camp org which](../camp_org_which/)	 - Print the current campaign's org

--- a/docs/cli-reference/camp/camp_org_create.md
+++ b/docs/cli-reference/camp/camp_org_create.md
@@ -1,0 +1,51 @@
+---
+title: "camp org create"
+linkTitle: "camp org create"
+description: "Create an org by joining campaigns (the current campaign if none named)"
+---
+
+## camp org create
+
+Create an org by joining campaigns (the current campaign if none named)
+
+### Synopsis
+
+Create an org by joining campaigns to it.
+
+Run inside a campaign with no campaign arguments to add the current campaign:
+  camp org create obey
+
+Or name the campaigns explicitly:
+  camp org create obey obey-campaign obey-content
+
+Orgs remain derived: "create" assigns membership and never makes an empty org.
+Joining an org that already has members is allowed; there is no "already exists"
+error, and a campaign already in the org is reported as unchanged.
+
+```
+camp org create <org> [campaign...] [flags]
+```
+
+### Examples
+
+```
+  camp org create obey
+  camp org create client-acme acme-site other-site
+```
+
+### Options
+
+```
+  -h, --help   help for create
+      --json   Output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp org](../camp_org/)	 - Group campaigns into orgs

--- a/docs/cli-reference/camp/camp_org_which.md
+++ b/docs/cli-reference/camp/camp_org_which.md
@@ -1,0 +1,36 @@
+---
+title: "camp org which"
+linkTitle: "camp org which"
+description: "Print the current campaign's org"
+---
+
+## camp org which
+
+Print the current campaign's org
+
+```
+camp org which [flags]
+```
+
+### Examples
+
+```
+  camp org which
+```
+
+### Options
+
+```
+  -h, --help   help for which
+      --json   Output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp org](../camp_org/)	 - Group campaigns into orgs

--- a/docs/cli-reference/camp/camp_workitem.md
+++ b/docs/cli-reference/camp/camp_workitem.md
@@ -29,13 +29,18 @@ camp workitem [flags]
 ### Options
 
 ```
-  -h, --help                help for workitem
-      --json                Output as JSON
-      --limit int           Maximum number of items to return
-      --print               Print path only (for shell integration)
-      --query string        Search query to filter items
-      --stage stringArray   Filter by lifecycle stage (none, inbox, active, ready, planning, ritual, chains)
-      --type stringArray    Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')
+      --attention-stage stringArray   Filter by attention stage (current, next, active, parked)
+      --group stringArray             Filter by workitem group
+      --group-by string               Group JSON/list sections by attention_stage, group, or type; --list defaults to group unless set (default "attention_stage")
+  -h, --help                          help for workitem
+      --json                          Output as JSON
+      --limit int                     Maximum number of items to return
+      --list                          Output a compact grouped list
+      --print                         Print path only (for shell integration)
+      --query string                  Search query to filter items
+      --show-parked                   include parked attention-stage workitems in default output
+      --stage stringArray             Filter by lifecycle stage (none, inbox, active, ready, planning, ritual, chains)
+      --type stringArray              Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')
 ```
 
 ### Options inherited from parent commands
@@ -53,9 +58,11 @@ camp workitem [flags]
 * [camp workitem create](../camp_workitem_create/)	 - Create a new workitem with v1 minimum metadata
 * [camp workitem current](../camp_workitem_current/)	 - Get, set, or clear the local current workitem
 * [camp workitem doctor](../camp_workitem_doctor/)	 - Report workitem link-registry health issues
+* [camp workitem group](../camp_workitem_group/)	 - Set or clear the group of a workitem
 * [camp workitem link](../camp_workitem_link/)	 - Attach a workitem to a project, festival, worktree, or campaign path
 * [camp workitem links](../camp_workitem_links/)	 - List workitem links
 * [camp workitem priority](../camp_workitem_priority/)	 - Set or clear the manual priority of a workitem
 * [camp workitem promote](../camp_workitem_promote/)	 - Promote a workitem to a festival, doc, or dungeon status
 * [camp workitem resolve](../camp_workitem_resolve/)	 - Print the workitem the current context resolves to (read-only)
+* [camp workitem stage](../camp_workitem_stage/)	 - Set or clear the attention stage of a workitem
 * [camp workitem unlink](../camp_workitem_unlink/)	 - Remove one or more workitem links

--- a/docs/cli-reference/camp/camp_workitem_group.md
+++ b/docs/cli-reference/camp/camp_workitem_group.md
@@ -1,0 +1,30 @@
+---
+title: "camp workitem group"
+linkTitle: "camp workitem group"
+description: "Set or clear the group of a workitem"
+---
+
+## camp workitem group
+
+Set or clear the group of a workitem
+
+```
+camp workitem group <selector> <group|clear> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for group
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_stage.md
+++ b/docs/cli-reference/camp/camp_workitem_stage.md
@@ -1,0 +1,30 @@
+---
+title: "camp workitem stage"
+linkTitle: "camp workitem stage"
+description: "Set or clear the attention stage of a workitem"
+---
+
+## camp workitem stage
+
+Set or clear the attention stage of a workitem
+
+```
+camp workitem stage <selector> <current|next|active|parked|clear> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for stage
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items


### PR DESCRIPTION
## Summary

- Pin the bundled `camp` submodule from `v0.2.11` to `v0.2.12`.
- Regenerate the stable camp CLI reference docs from the pinned release.
- Keep `fest` pinned at `v0.4.5`.

## Why

This picks up the latest stable camp release for the next Festival aggregate release, including the `camp dungeon move` triage inference behavior and the other camp changes released between `v0.2.11` and `v0.2.12`.

## Validation

- `just docs camp`
- `just test release-pins stable`
- `just test bundled-module-resolution`
- `just test docs-profile`
