### PR TITLE
Document Camp and Fest plugin authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,9 +318,9 @@ claude plugin add --source git-subdir --url Obedience-Corp/festival --path claud
 
 If `fest` and `camp` aren't already installed, the plugin installs them automatically on first session. It also checks for updates once per day and notifies you when a new release is available.
 
-Building an Obedience Corp plugin? See the [plugin authoring guide](docs/guides/plugin-authoring.md)
-for runtime asset layout and install conventions, including the standard
-`~/.obey/plugins/<plugin-name>` managed directory.
+Building a Camp or Fest plugin? See the [plugin authoring guide](docs/guides/plugin-authoring.md).
+The basic model is the same as Git plugins: put a `camp-<name>` or `fest-<name>`
+executable on your `PATH`.
 
 ### What you get
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ claude plugin add --source git-subdir --url Obedience-Corp/festival --path claud
 
 If `fest` and `camp` aren't already installed, the plugin installs them automatically on first session. It also checks for updates once per day and notifies you when a new release is available.
 
+Building an Obedience Corp plugin? See the [plugin authoring guide](docs/guides/plugin-authoring.md)
+for runtime asset layout and install conventions, including the standard
+`~/.obey/plugins/<plugin-name>` managed directory.
+
 ### What you get
 
 | Component | Examples |

--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -1,87 +1,163 @@
 ---
-title: "Plugin Authoring"
+title: "Camp and Fest Plugins"
 ---
 
-# Plugin Authoring
+# Camp and Fest Plugins
 
-Festival and Camp can be extended by installable plugins. A plugin may be a
-single executable, or it may be an executable plus support files such as scripts,
-schemas, static web assets, templates, or default config.
+Camp and Fest plugins use the same idea as Git plugins: put an executable with
+the right name on your `PATH`, and the CLI can run it as a subcommand.
 
-## Runtime Asset Directory
+That is all a basic plugin needs.
 
-Obedience Corp plugins should store managed runtime assets under:
+## The Short Version
 
-```text
-~/.obey/plugins/<plugin-name>/
-```
-
-Use a normalized plugin name: lowercase, hyphen-separated, and stable across
-releases. For example, the Camp Timeline plugin uses:
+For Camp, create an executable named:
 
 ```text
-~/.obey/plugins/camp-timeline/
+camp-<name>
 ```
 
-This is the first-class location for plugin-owned files that need to be
-discoverable after installation. It keeps plugin assets in the same ecosystem
-tree as `~/.obey/campaign`, `~/.obey/fest`, and other Obedience Corp state.
-
-## Recommended Layout
-
-A plugin that needs support assets should use a predictable layout:
-
-```text
-~/.obey/plugins/<plugin-name>/
-|-- bin/                 # optional plugin-local executables
-|-- config/              # optional packaged or user-editable config
-|-- data/                # generated plugin data
-|-- output/              # generated reports or artifacts
-|-- scripts/             # Python, shell, or helper runtime files
-|-- schemas/             # JSON schemas or runtime specs
-`-- web/                 # static browser assets, if any
-```
-
-Only create the directories the plugin actually needs.
-
-## Binary Behavior
-
-Plugin binaries should not require the user to run them from the source repo.
-When a plugin needs support files, its CLI should resolve an asset root in a
-clear order:
-
-1. an explicit CLI flag
-2. a plugin-specific environment variable, such as `CAMP_TIMELINE_ROOT`
-3. the source checkout, for local development
-4. an executable-adjacent package layout, such as `share/<plugin-name>`
-5. `~/.obey/plugins/<plugin-name>`
-
-Executable-adjacent `share/<plugin-name>` layouts are useful for Homebrew,
-Linux packages, and archives, but they are packaging fallbacks. The Obedience
-Corp plugin install convention remains `~/.obey/plugins/<plugin-name>`.
-
-## Install and Doctor Commands
-
-Plugins that ship assets should provide a command or installer step that copies
-those assets into the managed directory. For example:
+Then run it as:
 
 ```bash
-camp timeline install-assets
+camp <name>
 ```
 
-Plugins should also expose a doctor check that reports:
+For Fest, create an executable named:
 
-- the selected runtime asset root
-- the source of that selection, such as an environment variable or default path
-- missing required files
-- the command or environment variable needed to repair the install
+```text
+fest-<name>
+```
 
-## Relationship To Command Plugins
+Then run it as:
 
-Camp and Fest also support git-style command plugins discovered from `PATH`,
-such as `camp-<name>` or `fest-<name>`. That executable discovery mechanism is
-separate from the runtime asset convention.
+```bash
+fest <name>
+```
 
-If a command plugin has no support files, installing the executable on `PATH`
-may be enough. If it has support files, those files should still live under
-`~/.obey/plugins/<plugin-name>`.
+The plugin can be a shell script, Python script, Go binary, Node script, Rust
+binary, or anything else your operating system can execute.
+
+## Create A Camp Plugin
+
+Create a file named `camp-hello`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "hello from a camp plugin"
+echo "args: $*"
+```
+
+Make it executable and place it somewhere on your `PATH`:
+
+```bash
+chmod +x camp-hello
+mkdir -p ~/.local/bin
+mv camp-hello ~/.local/bin/
+```
+
+Make sure `~/.local/bin` is on your `PATH`, then run:
+
+```bash
+camp hello
+camp hello --name Ada
+```
+
+Camp looks for `camp-hello`, runs it, and forwards the arguments after
+`hello`. If Camp can detect the current campaign root, it also sets `CAMP_ROOT`
+for the plugin process.
+
+The current public example of this pattern is `camp-graph`: installing the
+`camp-graph` executable makes `camp graph` available.
+
+## Create A Fest Plugin
+
+Create a file named `fest-stats`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "festival stats plugin"
+echo "args: $*"
+```
+
+Make it executable and place it somewhere on your `PATH`:
+
+```bash
+chmod +x fest-stats
+mkdir -p ~/.local/bin
+mv fest-stats ~/.local/bin/
+```
+
+Then run:
+
+```bash
+fest stats
+```
+
+Fest also supports two-word plugin commands. An executable named
+`fest-export-jira` can be run as:
+
+```bash
+fest export jira
+```
+
+When Fest runs a plugin, it sets:
+
+```text
+FEST_PLUGIN=1
+FEST_PLUGIN_COMMAND=<resolved command>
+```
+
+## Optional Fest Manifest
+
+Fest can discover simple `fest-*` executables directly from `PATH`. A manifest
+is optional; use one when you want richer metadata such as summaries, examples,
+or usage hints.
+
+```yaml
+version: 1
+plugins:
+  - command: "export jira"
+    exec: "fest-export-jira"
+    summary: "Export festival work to Jira"
+    examples:
+      - "fest export jira --project PROJ"
+```
+
+Manifest-based plugins are useful for team config repos and future help
+surfaces. For a first plugin, start with an executable on `PATH`.
+
+## Shipping Support Files
+
+Many plugins need only the executable. If your plugin is a single binary or
+script, installing that executable on `PATH` is enough.
+
+Some plugins ship support files such as templates, schemas, static web assets,
+or helper scripts. How you package those files is up to you. Use a stable path,
+document it, and make your plugin's error messages explain how to repair a
+missing install.
+
+Obedience Corp supplied plugins use this managed asset convention:
+
+```text
+~/.obey/plugins/<plugin-name>/
+```
+
+That path is for first-party Obedience Corp plugins that need runtime assets
+outside the source checkout. It lets users and support tools find first-party
+plugin files consistently. You can follow the same convention for your own
+plugin if you want, but user-created plugins are not required to store assets
+there.
+
+## Checklist
+
+- Name the executable `camp-<name>` or `fest-<name>`.
+- Put it on `PATH`.
+- Make it executable.
+- Read arguments from `argv` like any normal CLI.
+- Exit non-zero when the plugin fails.
+- Print clear repair steps when required files or tools are missing.

--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -7,7 +7,8 @@ title: "Camp and Fest Plugins"
 Camp and Fest plugins use the same idea as Git plugins: put an executable with
 the right name on your `PATH`, and the CLI can run it as a subcommand.
 
-That is all a basic plugin needs.
+There is no SDK, registration step, or required manifest for the basic case. If
+you can write a command-line script, you can write a Camp or Fest plugin.
 
 ## The Short Version
 
@@ -36,11 +37,12 @@ fest <name>
 ```
 
 The plugin can be a shell script, Python script, Go binary, Node script, Rust
-binary, or anything else your operating system can execute.
+binary, or anything else your operating system can execute. Camp and Fest do
+not care what language it is written in.
 
-## Create A Camp Plugin
+## Create a Camp Plugin
 
-Create a file named `camp-hello`:
+Here is a complete Camp plugin. Create a file named `camp-hello`:
 
 ```bash
 #!/usr/bin/env bash
@@ -65,16 +67,16 @@ camp hello
 camp hello --name Ada
 ```
 
-Camp looks for `camp-hello`, runs it, and forwards the arguments after
-`hello`. If Camp can detect the current campaign root, it also sets `CAMP_ROOT`
-for the plugin process.
+When you run `camp hello`, Camp looks for `camp-hello`, runs it, and forwards
+the arguments after `hello`. If Camp can detect the current campaign root, it
+also sets `CAMP_ROOT` for the plugin process.
 
 The current public example of this pattern is `camp-graph`: installing the
 `camp-graph` executable makes `camp graph` available.
 
-## Create A Fest Plugin
+## Create a Fest Plugin
 
-Create a file named `fest-stats`:
+Fest works the same way. Create a file named `fest-stats`:
 
 ```bash
 #!/usr/bin/env bash
@@ -114,9 +116,9 @@ FEST_PLUGIN_COMMAND=<resolved command>
 
 ## Optional Fest Manifest
 
-Fest can discover simple `fest-*` executables directly from `PATH`. A manifest
-is optional; use one when you want richer metadata such as summaries, examples,
-or usage hints.
+Fest can discover simple `fest-*` executables directly from `PATH`, so you do
+not need a manifest for your first plugin. Add one when you want richer metadata
+such as summaries, examples, or usage hints.
 
 ```yaml
 version: 1
@@ -128,7 +130,7 @@ plugins:
       - "fest export jira --project PROJ"
 ```
 
-Manifest-based plugins are useful for team config repos and future help
+Manifest-based plugins are useful for team config repos and richer help
 surfaces. For a first plugin, start with an executable on `PATH`.
 
 ## Shipping Support Files

--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -1,0 +1,87 @@
+---
+title: "Plugin Authoring"
+---
+
+# Plugin Authoring
+
+Festival and Camp can be extended by installable plugins. A plugin may be a
+single executable, or it may be an executable plus support files such as scripts,
+schemas, static web assets, templates, or default config.
+
+## Runtime Asset Directory
+
+Obedience Corp plugins should store managed runtime assets under:
+
+```text
+~/.obey/plugins/<plugin-name>/
+```
+
+Use a normalized plugin name: lowercase, hyphen-separated, and stable across
+releases. For example, the Camp Timeline plugin uses:
+
+```text
+~/.obey/plugins/camp-timeline/
+```
+
+This is the first-class location for plugin-owned files that need to be
+discoverable after installation. It keeps plugin assets in the same ecosystem
+tree as `~/.obey/campaign`, `~/.obey/fest`, and other Obedience Corp state.
+
+## Recommended Layout
+
+A plugin that needs support assets should use a predictable layout:
+
+```text
+~/.obey/plugins/<plugin-name>/
+|-- bin/                 # optional plugin-local executables
+|-- config/              # optional packaged or user-editable config
+|-- data/                # generated plugin data
+|-- output/              # generated reports or artifacts
+|-- scripts/             # Python, shell, or helper runtime files
+|-- schemas/             # JSON schemas or runtime specs
+`-- web/                 # static browser assets, if any
+```
+
+Only create the directories the plugin actually needs.
+
+## Binary Behavior
+
+Plugin binaries should not require the user to run them from the source repo.
+When a plugin needs support files, its CLI should resolve an asset root in a
+clear order:
+
+1. an explicit CLI flag
+2. a plugin-specific environment variable, such as `CAMP_TIMELINE_ROOT`
+3. the source checkout, for local development
+4. an executable-adjacent package layout, such as `share/<plugin-name>`
+5. `~/.obey/plugins/<plugin-name>`
+
+Executable-adjacent `share/<plugin-name>` layouts are useful for Homebrew,
+Linux packages, and archives, but they are packaging fallbacks. The Obedience
+Corp plugin install convention remains `~/.obey/plugins/<plugin-name>`.
+
+## Install and Doctor Commands
+
+Plugins that ship assets should provide a command or installer step that copies
+those assets into the managed directory. For example:
+
+```bash
+camp timeline install-assets
+```
+
+Plugins should also expose a doctor check that reports:
+
+- the selected runtime asset root
+- the source of that selection, such as an environment variable or default path
+- missing required files
+- the command or environment variable needed to repair the install
+
+## Relationship To Command Plugins
+
+Camp and Fest also support git-style command plugins discovered from `PATH`,
+such as `camp-<name>` or `fest-<name>`. That executable discovery mechanism is
+separate from the runtime asset convention.
+
+If a command plugin has no support files, installing the executable on `PATH`
+may be enough. If it has support files, those files should still live under
+`~/.obey/plugins/<plugin-name>`.


### PR DESCRIPTION
## Summary

- Add a public-facing Camp and Fest plugin authoring guide.
- Explain the simple Git-style model first: create a camp-<name> or fest-<name> executable on PATH.
- Document argument forwarding, Camp/Fest plugin environment variables, optional Fest manifests, and camp-graph as the current public example.
- Keep ~/.obey/plugins/<plugin-name> documented only as the Obedience Corp supplied-plugin runtime asset convention, not a requirement for user-created plugins.

## Validation

- git diff --check
- line-count check for touched Markdown files
