### PR TITLE
feat(release): ship stable pin commits through an auto-merged PR

### DIFF
--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -67,7 +67,7 @@ rc fest="latest" camp="latest":
     go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" rc
 
 [no-cd]
-[confirm("This will create a stable festival release on main using the selected fest/camp tags. Run 'just release plan mode=stable fest=... camp=...' first if you want to see the exact tags. Continue?")]
+[confirm("This will create a stable festival release on main using the selected fest/camp tags (the pin commit ships through an auto-merged PR because main is PR-only). Run 'just release plan mode=stable fest=... camp=...' first if you want to see the exact tags. Continue?")]
 stable fest="latest" camp="latest":
     just test release-operator
     go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" stable
@@ -92,7 +92,7 @@ npm-publish-dry-run version="latest" mode="stable":
 # First stable release bootstrap:
 # - create/push fest + camp stable tags at their current HEAD
 # - pin festival submodules to those tags
-# - commit/push submodule pointer update
+# - commit the submodule pointer update (through an auto-merged PR when on main)
 # - create/push festival stable tag
 [private]
 [no-cd]
@@ -104,7 +104,8 @@ draft-bootstrap version fest_version camp_version:
 # - mode=stable: latest stable tags (vX.Y.Z)
 # - mode=rc: latest rc tags (vX.Y.Z-rc.N)
 # - mode=dev: latest dev tags (vX.Y.Z-dev.N)
-# - pin submodules, refresh docs, commit/push pointer update if needed
+# - pin submodules, refresh docs, commit pointer update if needed
+#   (through an auto-merged PR when on main, direct push otherwise)
 # - create/push festival release tag for the selected channel
 [private]
 [no-cd]

--- a/tools/release-operator/commands.go
+++ b/tools/release-operator/commands.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Obedience-Corp/festival/tools/release-operator/internal/operator"
 )
 
+const festivalRepoSlug = "Obedience-Corp/festival"
+
 var submodules = []string{"fest", "camp"}
 
 type repoContext struct {
@@ -182,7 +184,25 @@ func releaseCommitMessage(currentFestTag, currentCampTag, festTag, campTag strin
 	}
 }
 
-func (r *repoContext) commitPinnedArtifacts(currentFestTag, currentCampTag, festTag, campTag string) error {
+const shipBranchPrefix = "release-pin/"
+
+func shipBranchName(releaseTag string) string {
+	return shipBranchPrefix + releaseTag
+}
+
+func shipsViaPullRequest(branch string) bool {
+	return branch == "main"
+}
+
+func releasePRBody(releaseTag, message string) string {
+	return fmt.Sprintf("%s.\n\nCreated by the release operator: main only accepts changes through pull requests, so the pin commit ships through this PR. After the squash merge, the operator tags %s on main to trigger release CI.", message, releaseTag)
+}
+
+func (r *repoContext) currentBranch() (string, error) {
+	return r.git("rev-parse", "--abbrev-ref", "HEAD")
+}
+
+func (r *repoContext) shipPinnedArtifacts(releaseTag, currentFestTag, currentCampTag, festTag, campTag string) error {
 	hasDiff, err := r.cachedDiffExists("fest", "camp", "docs/cli-reference")
 	if err != nil {
 		return err
@@ -191,10 +211,104 @@ func (r *repoContext) commitPinnedArtifacts(currentFestTag, currentCampTag, fest
 		fmt.Printf("Submodule pointers and docs already at fest=%s, camp=%s; no release commit needed.\n", festTag, campTag)
 		return nil
 	}
-	if err := r.runGit("commit", "-m", releaseCommitMessage(currentFestTag, currentCampTag, festTag, campTag)); err != nil {
+
+	branch, err := r.currentBranch()
+	if err != nil {
 		return err
 	}
-	return r.runGit("push", "origin", "HEAD")
+	message := releaseCommitMessage(currentFestTag, currentCampTag, festTag, campTag)
+	if !shipsViaPullRequest(branch) {
+		if err := r.runGit("commit", "-m", message); err != nil {
+			return err
+		}
+		return r.runGit("push", "origin", "HEAD")
+	}
+	return r.shipViaPullRequest(branch, releaseTag, message)
+}
+
+func (r *repoContext) shipViaPullRequest(baseBranch, releaseTag, message string) error {
+	if !ghAuthenticated() {
+		return fmt.Errorf("%s only accepts changes through pull requests and gh is not authenticated; run 'gh auth login' and retry", baseBranch)
+	}
+
+	shipBranch := shipBranchName(releaseTag)
+	if err := r.runGit("switch", "-C", shipBranch); err != nil {
+		return err
+	}
+	if err := r.runGit("commit", "-m", message); err != nil {
+		return err
+	}
+	if err := r.runGit("push", "-f", "-u", "origin", shipBranch); err != nil {
+		return err
+	}
+
+	if !r.hasOpenPullRequest(shipBranch) {
+		if err := runCmd(r.Root, nil, "gh", "pr", "create", "--repo", festivalRepoSlug, "--base", baseBranch, "--head", shipBranch, "--title", message, "--body", releasePRBody(releaseTag, message)); err != nil {
+			return err
+		}
+	}
+	if err := runCmd(r.Root, nil, "gh", "pr", "merge", shipBranch, "--repo", festivalRepoSlug, "--squash", "--delete-branch"); err != nil {
+		return fmt.Errorf("merge release PR for %s: %w (resolve it on GitHub, then rerun the same release command)", shipBranch, err)
+	}
+
+	if err := r.runGit("switch", baseBranch); err != nil {
+		return err
+	}
+	if _, err := r.git("rev-parse", "--verify", "refs/heads/"+shipBranch); err == nil {
+		if err := r.runGit("branch", "-D", shipBranch); err != nil {
+			return err
+		}
+	}
+	if err := r.runGit("pull", "--ff-only", "origin", baseBranch); err != nil {
+		return err
+	}
+	if err := r.runGit("submodule", "update", "--init"); err != nil {
+		return err
+	}
+	dirty, err := worktreeDirty(r.Root)
+	if err != nil {
+		return err
+	}
+	if dirty {
+		return fmt.Errorf("festival repo is dirty after merging %s; resolve manually before tagging", shipBranch)
+	}
+	return nil
+}
+
+func (r *repoContext) hasOpenPullRequest(branch string) bool {
+	out, err := cmdOutput(r.Root, nil, "gh", "pr", "view", branch, "--repo", festivalRepoSlug, "--json", "state", "--jq", ".state")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) == "OPEN"
+}
+
+func (r *repoContext) prepareMainForBundle() error {
+	branch, err := r.currentBranch()
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(branch, shipBranchPrefix) {
+		if err := r.runGit("switch", "main"); err != nil {
+			return err
+		}
+		if err := r.runGit("branch", "-D", branch); err != nil {
+			return err
+		}
+		branch = "main"
+	}
+	if branch != "main" {
+		return nil
+	}
+	if dirty, err := worktreeDirty(r.Root); err != nil {
+		return err
+	} else if dirty {
+		return errors.New("festival repo has uncommitted changes")
+	}
+	if err := r.runGit("pull", "--ff-only", "origin", "main"); err != nil {
+		return err
+	}
+	return r.runGit("submodule", "update", "--init")
 }
 
 func (r *repoContext) ensureTagAbsent(tag string) error {
@@ -523,7 +637,7 @@ func runDraftFromLatest(ctx *repoContext, version string, mode releaseMode, iter
 		return fmt.Errorf("submodules are not pinned to exact %s tags after refresh", mode.Name)
 	}
 
-	if err := ctx.commitPinnedArtifacts(currentFestTag, currentCampTag, festTag, campTag); err != nil {
+	if err := ctx.shipPinnedArtifacts(releaseTag, currentFestTag, currentCampTag, festTag, campTag); err != nil {
 		return err
 	}
 	if err := runPreflight(ctx, mode); err != nil {
@@ -614,7 +728,7 @@ func runDraftBootstrap(ctx *repoContext, festivalVersion, festVersion, campVersi
 	if err := ctx.stageReleaseArtifacts(); err != nil {
 		return err
 	}
-	if err := ctx.commitPinnedArtifacts("", "", festTag, campTag); err != nil {
+	if err := ctx.shipPinnedArtifacts(releaseTag, "", "", festTag, campTag); err != nil {
 		return err
 	}
 
@@ -680,6 +794,10 @@ func runBundleWithRoot(opts bundleOptions) error {
 		return err
 	}
 
+	if err := ctx.prepareMainForBundle(); err != nil {
+		return err
+	}
+
 	state, err := collectState(ctx.Root, opts.Channel, opts.FestSelector, opts.CampSelector)
 	if err != nil {
 		return err
@@ -710,7 +828,7 @@ func runBundleWithRoot(opts bundleOptions) error {
 
 func runCleanup(ctx *repoContext, tag string) error {
 	fmt.Printf("Deleting GitHub release %s...\n", tag)
-	if err := runCmd(ctx.Root, nil, "gh", "release", "delete", tag, "--repo", "Obedience-Corp/festival", "--yes"); err != nil {
+	if err := runCmd(ctx.Root, nil, "gh", "release", "delete", tag, "--repo", festivalRepoSlug, "--yes"); err != nil {
 		fmt.Printf("  No GitHub release found for %s\n", tag)
 	}
 	fmt.Printf("Deleting remote tag %s...\n", tag)
@@ -726,7 +844,7 @@ func runCleanup(ctx *repoContext, tag string) error {
 }
 
 func ghSecretNames(dir string) ([]string, error) {
-	out, err := cmdOutput(dir, nil, "gh", "secret", "list", "--repo", "Obedience-Corp/festival")
+	out, err := cmdOutput(dir, nil, "gh", "secret", "list", "--repo", festivalRepoSlug)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/release-operator/commands.go
+++ b/tools/release-operator/commands.go
@@ -16,8 +16,20 @@ const festivalRepoSlug = "Obedience-Corp/festival"
 
 var submodules = []string{"fest", "camp"}
 
+// ghClient abstracts the GitHub CLI operations the ship-via-PR path needs so
+// the PR create/merge flow can be exercised in tests without hitting GitHub.
+type ghClient interface {
+	authenticated() bool
+	viewerCanMerge(repo string) (bool, error)
+	openPullRequestNumber(repo, branch string) (string, error)
+	createPullRequest(repo, base, head, title, body string) error
+	mergePullRequest(repo, branch string) error
+}
+
 type repoContext struct {
 	Root string
+	// gh overrides the GitHub CLI seam in tests; nil means shell out to gh.
+	gh ghClient
 }
 
 func newRepoContext(root string) (*repoContext, error) {
@@ -26,6 +38,50 @@ func newRepoContext(root string) (*repoContext, error) {
 		return nil, fmt.Errorf("resolve repo root: %w", err)
 	}
 	return &repoContext{Root: absRoot}, nil
+}
+
+func (r *repoContext) ghClient() ghClient {
+	if r.gh != nil {
+		return r.gh
+	}
+	return cliGH{dir: r.Root}
+}
+
+// cliGH is the production ghClient backed by the gh binary.
+type cliGH struct {
+	dir string
+}
+
+func (g cliGH) authenticated() bool {
+	return ghAuthenticated()
+}
+
+func (g cliGH) viewerCanMerge(repo string) (bool, error) {
+	out, err := cmdOutput(g.dir, nil, "gh", "api", "repos/"+repo, "--jq", ".permissions.push")
+	if err != nil {
+		return false, fmt.Errorf("check push permission on %s: %w", repo, err)
+	}
+	return strings.TrimSpace(out) == "true", nil
+}
+
+// openPullRequestNumber returns the number of an open PR for branch, or "" when
+// none is open. Unlike `gh pr view`, `gh pr list` exits 0 with an empty array
+// for the no-PR case, so a non-nil error here is a real gh/network failure and
+// must not be mistaken for "no PR".
+func (g cliGH) openPullRequestNumber(repo, branch string) (string, error) {
+	out, err := cmdOutput(g.dir, nil, "gh", "pr", "list", "--repo", repo, "--head", branch, "--state", "open", "--json", "number", "--jq", ".[0].number // \"\"")
+	if err != nil {
+		return "", fmt.Errorf("query open PR for %s: %w", branch, err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func (g cliGH) createPullRequest(repo, base, head, title, body string) error {
+	return runCmd(g.dir, nil, "gh", "pr", "create", "--repo", repo, "--base", base, "--head", head, "--title", title, "--body", body)
+}
+
+func (g cliGH) mergePullRequest(repo, branch string) error {
+	return runCmd(g.dir, nil, "gh", "pr", "merge", branch, "--repo", repo, "--squash", "--delete-branch")
 }
 
 func (r *repoContext) submodulePath(name string) string {
@@ -227,8 +283,18 @@ func (r *repoContext) shipPinnedArtifacts(releaseTag, currentFestTag, currentCam
 }
 
 func (r *repoContext) shipViaPullRequest(baseBranch, releaseTag, message string) error {
-	if !ghAuthenticated() {
+	gh := r.ghClient()
+	if !gh.authenticated() {
 		return fmt.Errorf("%s only accepts changes through pull requests and gh is not authenticated; run 'gh auth login' and retry", baseBranch)
+	}
+	// Verify the merge is possible before mutating anything, so a permission
+	// gap fails fast instead of after the branch and PR already exist.
+	canMerge, err := gh.viewerCanMerge(festivalRepoSlug)
+	if err != nil {
+		return err
+	}
+	if !canMerge {
+		return fmt.Errorf("the authenticated gh account lacks push permission on %s and cannot merge the release PR; switch to an account with write access (gh auth switch) and retry", festivalRepoSlug)
 	}
 
 	shipBranch := shipBranchName(releaseTag)
@@ -242,13 +308,17 @@ func (r *repoContext) shipViaPullRequest(baseBranch, releaseTag, message string)
 		return err
 	}
 
-	if !r.hasOpenPullRequest(shipBranch) {
-		if err := runCmd(r.Root, nil, "gh", "pr", "create", "--repo", festivalRepoSlug, "--base", baseBranch, "--head", shipBranch, "--title", message, "--body", releasePRBody(releaseTag, message)); err != nil {
+	open, err := gh.openPullRequestNumber(festivalRepoSlug, shipBranch)
+	if err != nil {
+		return err
+	}
+	if open == "" {
+		if err := gh.createPullRequest(festivalRepoSlug, baseBranch, shipBranch, message, releasePRBody(releaseTag, message)); err != nil {
 			return err
 		}
 	}
-	if err := runCmd(r.Root, nil, "gh", "pr", "merge", shipBranch, "--repo", festivalRepoSlug, "--squash", "--delete-branch"); err != nil {
-		return fmt.Errorf("merge release PR for %s: %w (resolve it on GitHub, then rerun the same release command)", shipBranch, err)
+	if err := gh.mergePullRequest(festivalRepoSlug, shipBranch); err != nil {
+		return fmt.Errorf("merge release PR for %s: %w\nThe pin commit is pushed and the PR exists; check the PR for unmet merge requirements (required approvals or status checks), merge it on GitHub, then rerun the same release command to continue tagging", shipBranch, err)
 	}
 
 	if err := r.runGit("switch", baseBranch); err != nil {
@@ -273,14 +343,6 @@ func (r *repoContext) shipViaPullRequest(baseBranch, releaseTag, message string)
 		return fmt.Errorf("festival repo is dirty after merging %s; resolve manually before tagging", shipBranch)
 	}
 	return nil
-}
-
-func (r *repoContext) hasOpenPullRequest(branch string) bool {
-	out, err := cmdOutput(r.Root, nil, "gh", "pr", "view", branch, "--repo", festivalRepoSlug, "--json", "state", "--jq", ".state")
-	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(out) == "OPEN"
 }
 
 func (r *repoContext) prepareMainForBundle() error {

--- a/tools/release-operator/commands_test.go
+++ b/tools/release-operator/commands_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestShipBranchName(t *testing.T) {
+	got := shipBranchName("v0.2.12")
+	if want := "release-pin/v0.2.12"; got != want {
+		t.Fatalf("shipBranchName = %q, want %q", got, want)
+	}
+	if strings.HasPrefix(got, "release/v") {
+		t.Fatalf("ship branch %q collides with the rc release/vX.Y.Z branch convention", got)
+	}
+}
+
+func TestShipsViaPullRequest(t *testing.T) {
+	tests := []struct {
+		branch string
+		want   bool
+	}{
+		{branch: "main", want: true},
+		{branch: "develop", want: false},
+		{branch: "release/v0.3.0", want: false},
+		{branch: "release-pin/v0.2.12", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.branch, func(t *testing.T) {
+			if got := shipsViaPullRequest(tt.branch); got != tt.want {
+				t.Fatalf("shipsViaPullRequest(%q) = %v, want %v", tt.branch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShipPinnedArtifactsNoDiffIsNoop(t *testing.T) {
+	repo := initTestRepo(t)
+	addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+
+	before := gitRevParse(t, repo, "HEAD")
+	if err := ctx.shipPinnedArtifacts("v0.2.0", "v0.4.8", "v0.2.17", "v0.4.8", "v0.2.17"); err != nil {
+		t.Fatalf("shipPinnedArtifacts returned error: %v", err)
+	}
+	if after := gitRevParse(t, repo, "HEAD"); after != before {
+		t.Fatalf("HEAD moved from %s to %s without staged changes", before, after)
+	}
+}
+
+func TestShipPinnedArtifactsDirectPushOffMain(t *testing.T) {
+	repo := initTestRepo(t)
+	bare := addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+
+	runGit(t, repo, "switch", "-c", "develop")
+	stagePinnedDocChange(t, repo, "dev pin\n")
+
+	if err := ctx.shipPinnedArtifacts("v0.2.0-dev.1", "v0.4.8", "v0.2.17", "v0.4.9-dev.1", "v0.2.17"); err != nil {
+		t.Fatalf("shipPinnedArtifacts returned error: %v", err)
+	}
+
+	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "develop" {
+		t.Fatalf("current branch = %q, want develop", branch)
+	}
+	local := gitRevParse(t, repo, "HEAD")
+	remote := gitRevParse(t, bare, "develop")
+	if local != remote {
+		t.Fatalf("origin develop = %s, want pushed commit %s", remote, local)
+	}
+	message, err := gitOutput(repo, "log", "-1", "--format=%s")
+	if err != nil {
+		t.Fatalf("read commit message: %v", err)
+	}
+	if want := "Release: pin fest v0.4.9-dev.1"; message != want {
+		t.Fatalf("commit message = %q, want %q", message, want)
+	}
+}
+
+func TestPrepareMainForBundleFastForwardsStaleMain(t *testing.T) {
+	repo := initTestRepo(t)
+	addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+
+	writeFile(t, filepath.Join(repo, "next.txt"), "next\n")
+	runGit(t, repo, "add", "next.txt")
+	runGit(t, repo, "commit", "-m", "next release commit")
+	runGit(t, repo, "push", "origin", "main")
+	ahead := gitRevParse(t, repo, "HEAD")
+	runGit(t, repo, "reset", "--hard", "HEAD~1")
+
+	if err := ctx.prepareMainForBundle(); err != nil {
+		t.Fatalf("prepareMainForBundle returned error: %v", err)
+	}
+	if head := gitRevParse(t, repo, "HEAD"); head != ahead {
+		t.Fatalf("HEAD = %s, want origin/main %s", head, ahead)
+	}
+}
+
+func TestPrepareMainForBundleLeavesOtherBranchesAlone(t *testing.T) {
+	repo := initTestRepo(t)
+	addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+
+	runGit(t, repo, "switch", "-c", "develop")
+	before := gitRevParse(t, repo, "HEAD")
+
+	if err := ctx.prepareMainForBundle(); err != nil {
+		t.Fatalf("prepareMainForBundle returned error: %v", err)
+	}
+	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "develop" {
+		t.Fatalf("current branch = %q, want develop", branch)
+	}
+	if head := gitRevParse(t, repo, "HEAD"); head != before {
+		t.Fatalf("HEAD moved from %s to %s on a non-main branch", before, head)
+	}
+}
+
+func TestPrepareMainForBundleRecoversFromStaleShipBranch(t *testing.T) {
+	repo := initTestRepo(t)
+	addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+
+	runGit(t, repo, "switch", "-C", "release-pin/v0.2.12")
+	stagePinnedDocChange(t, repo, "abandoned pin\n")
+	runGit(t, repo, "commit", "-m", "Release: pin fest v0.4.9")
+
+	if err := ctx.prepareMainForBundle(); err != nil {
+		t.Fatalf("prepareMainForBundle returned error: %v", err)
+	}
+	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "main" {
+		t.Fatalf("current branch = %q, want main", branch)
+	}
+	if _, err := gitOutput(repo, "rev-parse", "--verify", "refs/heads/release-pin/v0.2.12"); err == nil {
+		t.Fatal("stale ship branch release-pin/v0.2.12 still exists")
+	}
+}
+
+func TestPrepareMainForBundleRejectsDirtyMain(t *testing.T) {
+	repo := initTestRepo(t)
+	addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+
+	writeFile(t, filepath.Join(repo, "README.md"), "dirty\n")
+
+	if err := ctx.prepareMainForBundle(); err == nil {
+		t.Fatal("expected prepareMainForBundle to fail on a dirty main worktree")
+	}
+}
+
+func TestReleasePRBodyMentionsTag(t *testing.T) {
+	body := releasePRBody("v0.2.12", "Release: pin fest v0.4.9")
+	if !strings.Contains(body, "v0.2.12") {
+		t.Fatalf("PR body does not mention the release tag: %q", body)
+	}
+	if !strings.Contains(body, "Release: pin fest v0.4.9") {
+		t.Fatalf("PR body does not include the release message: %q", body)
+	}
+}
+
+func testRepoContext(t *testing.T, repo string) *repoContext {
+	t.Helper()
+	ctx, err := newRepoContext(repo)
+	if err != nil {
+		t.Fatalf("newRepoContext: %v", err)
+	}
+	return ctx
+}
+
+func addBareOrigin(t *testing.T, repo string) string {
+	t.Helper()
+	bare := t.TempDir()
+	runGit(t, bare, "init", "--bare", "-b", "main")
+	runGit(t, repo, "remote", "add", "origin", bare)
+	runGit(t, repo, "push", "-u", "origin", "main")
+	return bare
+}
+
+func stagePinnedDocChange(t *testing.T, repo, content string) {
+	t.Helper()
+	dir := filepath.Join(repo, "docs", "cli-reference")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	writeFile(t, filepath.Join(dir, "pin.md"), content)
+	runGit(t, repo, "add", "docs/cli-reference")
+}
+
+func gitRevParse(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := gitOutput(dir, append([]string{"rev-parse"}, args...)...)
+	if err != nil {
+		t.Fatalf("git rev-parse %v: %v", args, err)
+	}
+	return out
+}

--- a/tools/release-operator/commands_test.go
+++ b/tools/release-operator/commands_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,6 +49,158 @@ func TestShipPinnedArtifactsNoDiffIsNoop(t *testing.T) {
 	}
 	if after := gitRevParse(t, repo, "HEAD"); after != before {
 		t.Fatalf("HEAD moved from %s to %s without staged changes", before, after)
+	}
+}
+
+// fakeGH is an in-memory ghClient. mergePullRequest simulates GitHub's
+// squash-merge by fast-forwarding the bare origin's main to the pushed ship
+// branch tip and deleting the branch, so the operator's post-merge ff-only
+// pull of main behaves as it would after a real merge.
+type fakeGH struct {
+	t           *testing.T
+	bare        string
+	authed      bool
+	canMerge    bool
+	canMergeErr error
+	openNumber  string
+	openErr     error
+	createErr   error
+	mergeErr    error
+	created     int
+	merged      int
+}
+
+func (f *fakeGH) authenticated() bool { return f.authed }
+
+func (f *fakeGH) viewerCanMerge(string) (bool, error) {
+	return f.canMerge, f.canMergeErr
+}
+
+func (f *fakeGH) openPullRequestNumber(_, _ string) (string, error) {
+	return f.openNumber, f.openErr
+}
+
+func (f *fakeGH) createPullRequest(_, _, _, _, _ string) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.created++
+	return nil
+}
+
+func (f *fakeGH) mergePullRequest(_, branch string) error {
+	if f.mergeErr != nil {
+		return f.mergeErr
+	}
+	f.merged++
+	tip := gitRevParse(f.t, f.bare, "refs/heads/"+branch)
+	runGit(f.t, f.bare, "update-ref", "refs/heads/main", tip)
+	runGit(f.t, f.bare, "update-ref", "-d", "refs/heads/"+branch)
+	return nil
+}
+
+func TestShipPinnedArtifactsShipsViaPullRequestOnMain(t *testing.T) {
+	repo := initTestRepo(t)
+	bare := addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+	gh := &fakeGH{t: t, bare: bare, authed: true, canMerge: true}
+	ctx.gh = gh
+
+	stagePinnedDocChange(t, repo, "stable pin\n")
+
+	if err := ctx.shipPinnedArtifacts("v0.2.12", "v0.4.8", "v0.2.17", "v0.4.9", "v0.2.17"); err != nil {
+		t.Fatalf("shipPinnedArtifacts returned error: %v", err)
+	}
+
+	if gh.created != 1 {
+		t.Fatalf("createPullRequest called %d times, want 1", gh.created)
+	}
+	if gh.merged != 1 {
+		t.Fatalf("mergePullRequest called %d times, want 1", gh.merged)
+	}
+	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "main" {
+		t.Fatalf("current branch = %q, want main", branch)
+	}
+	if local, remote := gitRevParse(t, repo, "HEAD"), gitRevParse(t, bare, "main"); local != remote {
+		t.Fatalf("local main = %s, origin main = %s; want fast-forwarded to merged commit", local, remote)
+	}
+	if _, err := gitOutput(repo, "rev-parse", "--verify", "refs/heads/release-pin/v0.2.12"); err == nil {
+		t.Fatal("local ship branch release-pin/v0.2.12 was not deleted")
+	}
+}
+
+func TestShipViaPullRequestSkipsCreateWhenPROpen(t *testing.T) {
+	repo := initTestRepo(t)
+	bare := addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+	gh := &fakeGH{t: t, bare: bare, authed: true, canMerge: true, openNumber: "77"}
+	ctx.gh = gh
+
+	stagePinnedDocChange(t, repo, "resumed pin\n")
+
+	if err := ctx.shipPinnedArtifacts("v0.2.12", "v0.4.8", "v0.2.17", "v0.4.9", "v0.2.17"); err != nil {
+		t.Fatalf("shipPinnedArtifacts returned error: %v", err)
+	}
+	if gh.created != 0 {
+		t.Fatalf("createPullRequest called %d times, want 0 when a PR is already open", gh.created)
+	}
+	if gh.merged != 1 {
+		t.Fatalf("mergePullRequest called %d times, want 1", gh.merged)
+	}
+}
+
+func TestShipViaPullRequestPropagatesOpenPRQueryError(t *testing.T) {
+	repo := initTestRepo(t)
+	bare := addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+	gh := &fakeGH{t: t, bare: bare, authed: true, canMerge: true, openErr: errors.New("gh: network unreachable")}
+	ctx.gh = gh
+
+	stagePinnedDocChange(t, repo, "pin\n")
+
+	err := ctx.shipPinnedArtifacts("v0.2.12", "v0.4.8", "v0.2.17", "v0.4.9", "v0.2.17")
+	if err == nil {
+		t.Fatal("expected a transient open-PR query error to propagate, got nil")
+	}
+	if gh.created != 0 {
+		t.Fatalf("createPullRequest called %d times; a query failure must not fall through to create", gh.created)
+	}
+	if gh.merged != 0 {
+		t.Fatalf("mergePullRequest called %d times, want 0", gh.merged)
+	}
+}
+
+func TestShipViaPullRequestFailsFastWhenCannotMerge(t *testing.T) {
+	repo := initTestRepo(t)
+	bare := addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+	gh := &fakeGH{t: t, bare: bare, authed: true, canMerge: false}
+	ctx.gh = gh
+
+	stagePinnedDocChange(t, repo, "pin\n")
+
+	err := ctx.shipPinnedArtifacts("v0.2.12", "v0.4.8", "v0.2.17", "v0.4.9", "v0.2.17")
+	if err == nil {
+		t.Fatal("expected an error when the account cannot merge")
+	}
+	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "main" {
+		t.Fatalf("current branch = %q; permission check must run before any branch switch", branch)
+	}
+	if gh.created != 0 || gh.merged != 0 {
+		t.Fatalf("create=%d merge=%d; nothing should be attempted when merge is impossible", gh.created, gh.merged)
+	}
+}
+
+func TestShipViaPullRequestFailsWhenUnauthenticated(t *testing.T) {
+	repo := initTestRepo(t)
+	bare := addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+	ctx.gh = &fakeGH{t: t, bare: bare, authed: false, canMerge: true}
+
+	stagePinnedDocChange(t, repo, "pin\n")
+
+	if err := ctx.shipPinnedArtifacts("v0.2.12", "v0.4.8", "v0.2.17", "v0.4.9", "v0.2.17"); err == nil {
+		t.Fatal("expected an error when gh is not authenticated")
 	}
 }
 

--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -382,6 +382,14 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "  just test bundled-module-resolution")
 	fmt.Fprintln(out, "  just release dry-run")
 	fmt.Fprintln(out, "  just release cleanup <tag>")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Stable releases on main:")
+	fmt.Fprintln(out, "  main is PR-only, so the stable pin commit ships through a transient")
+	fmt.Fprintln(out, "  release-pin/<tag> branch that is auto-created and squash-merged.")
+	fmt.Fprintln(out, "  The active gh account needs push access to Obedience-Corp/festival.")
+	fmt.Fprintln(out, "  The main ruleset requires a PR with 0 approvals and no status checks,")
+	fmt.Fprintln(out, "  so a push-capable account merges immediately (no --admin bypass needed).")
+	fmt.Fprintln(out, "  If a run fails after the PR is created, rerun the same command to continue.")
 }
 
 func collectState(repoRoot, channel, festSelector, campSelector string) (operator.BundleInput, error) {


### PR DESCRIPTION
## Problem

The stable bundle flow (`just release stable fest=latest camp=keep`) broke when main got a PR-only ruleset: the operator commits the pin + docs, then does `git push origin HEAD`, which the ruleset rejects. The v0.2.12 release had to be finished by hand (branch, PR #91, squash merge, preflight, tag).

## Change

`commitPinnedArtifacts` is now `shipPinnedArtifacts`. When the base branch is `main`, the pin commit ships through a transient `release-pin/<tag>` branch: force push, `gh pr create`, `gh pr merge --squash --delete-branch`, ff-only pull of main, submodule sync, and a cleanliness check before the flow continues to preflight + tag on the merged commit. Dev (develop) and rc (`release/vX.Y.Z`) channels keep direct push since those branches are not protected.

The `release-pin/` prefix deliberately avoids `release/v*`, which the operator reserves for rc branch detection.

Bundle runs now also start with `prepareMainForBundle`: recover from a leftover `release-pin/*` branch (failed prior run), then ff-only sync local main from origin, so the one command works from a stale clone.

## Rerun safety

- Fails before push: rerun recovers the ship branch and starts over (`switch -C` + force push).
- Fails after merge but before tag: pins already match, so the commit step no-ops and the flow proceeds straight to preflight + tag, still computing the same version.
- Diverged local main (unpushed commits): ff-only pull fails loudly instead of merging silently.

## Verification

- `just test release-operator` green (new tests cover ship-branch naming vs rc convention, direct push off main against a bare origin, no-diff no-op, stale-main fast-forward, ship-branch recovery, dirty-main rejection).
- `just release status` runs clean against the live repo.
- `gofmt`/`go vet` clean on touched files (`internal/operator/marketplace.go` is unformatted on main already; untouched).

## Not covered

The gh-dependent path (`pr create`/`pr merge`) is not exercised by tests; the next stable release is the real end-to-end check. If it fails mid-flow, rerunning the same command is the designed recovery.