### PR TITLE
feat(claude-plugin): add commit-discipline guard hook

### DIFF
--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -23,6 +23,7 @@ claude-plugin/
     hooks.json                  SessionStart + PreToolUse hook wiring
     scripts/ensure-festival.sh  installs and updates fest and camp
     scripts/commit-guard.sh     blocks raw `git commit` inside a campaign
+    scripts/commit-guard.test.sh  unit tests for the guard (run by the gate)
     scripts/sync-check.sh       checks plugin command refs against the CLIs
 ```
 
@@ -76,12 +77,20 @@ Because a plugin hook fires in every session, the guard self-scopes. It blocks a
 Bash command only when all of the following hold, and otherwise exits without
 interfering:
 
-- the command is a raw `git commit` (not a `camp`/`fest` wrapper), and
+- the command has a raw `git commit` segment, and
 - the session is inside a campaign (detected via `camp id`), and
 - `camp` and `jq` are both available.
 
+The command is split on `;`, `&&`, `||`, and newlines and each segment is
+matched start-anchored, so a raw commit hidden after a wrapper in a compound
+command (`fest commit ...; git commit ...`) is still caught, and a `git commit`
+appearing only inside a wrapper's quoted message is not a false positive.
+Detection is a discipline guard, not a security control: it does not defeat
+deliberate obfuscation (`bash -c`, aliases, `eval`).
+
 Outside a campaign, in repos without `camp`, or on machines without `jq`, it
 fails open. Set `CAMP_ALLOW_RAW_GIT=1` to override deliberately for one command.
+`commit-guard.test.sh` encodes the detection matrix and runs in the plugin gate.
 
 ## Local development gate
 

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -4,7 +4,8 @@
 
 A domain plugin that teaches Claude Code to drive the `fest` and `camp` CLIs and
 the Festival methodology. It bundles slash commands, methodology skills,
-specialized agents, and a session hook that keeps the CLIs installed.
+specialized agents, a session hook that keeps the CLIs installed, and a
+commit-discipline guard.
 
 It is not a generic engineering-process library. Its scope is the Festival
 methodology and the fest/camp toolchain. For the methodology itself, see the
@@ -19,8 +20,9 @@ claude-plugin/
   commands/                     10 fest-* and camp-* slash commands
   agents/                       fest-executor, fest-planner
   hooks/
-    hooks.json                  SessionStart hook wiring
+    hooks.json                  SessionStart + PreToolUse hook wiring
     scripts/ensure-festival.sh  installs and updates fest and camp
+    scripts/commit-guard.sh     blocks raw `git commit` inside a campaign
     scripts/sync-check.sh       checks plugin command refs against the CLIs
 ```
 
@@ -62,6 +64,24 @@ On first session the `SessionStart` hook (`hooks/scripts/ensure-festival.sh`)
 downloads `fest` and `camp` if they are missing, checksum-verifies the archive,
 and installs them. It also checks for updates once per day and notifies you when
 a new release is available.
+
+## Commit guard
+
+A `PreToolUse` (Bash) hook (`hooks/scripts/commit-guard.sh`) enforces campaign
+commit discipline: commits must route through `camp commit` (campaign root),
+`camp p commit` (inside `projects/*`), or `fest commit` (during festivals) so
+festival traceability and campaign bookkeeping are preserved.
+
+Because a plugin hook fires in every session, the guard self-scopes. It blocks a
+Bash command only when all of the following hold, and otherwise exits without
+interfering:
+
+- the command is a raw `git commit` (not a `camp`/`fest` wrapper), and
+- the session is inside a campaign (detected via `camp id`), and
+- `camp` and `jq` are both available.
+
+Outside a campaign, in repos without `camp`, or on machines without `jq`, it
+fails open. Set `CAMP_ALLOW_RAW_GIT=1` to override deliberately for one command.
 
 ## Local development gate
 

--- a/claude-plugin/hooks/hooks.json
+++ b/claude-plugin/hooks/hooks.json
@@ -9,5 +9,16 @@
         }
       ]
     }
+  ],
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/commit-guard.sh"
+        }
+      ]
+    }
   ]
 }

--- a/claude-plugin/hooks/scripts/commit-guard.sh
+++ b/claude-plugin/hooks/scripts/commit-guard.sh
@@ -11,39 +11,78 @@
 # Commit discipline: commits must route through the camp/fest wrappers so
 # festival traceability and campaign bookkeeping are preserved. See the
 # campaign-commit skill.
+#
+# Scope: this is a discipline guard, not a security control. It catches direct
+# raw commits, including ones hidden after a wrapper in a compound command
+# (`fest commit ...; git commit ...`). It does not defeat deliberate
+# obfuscation (`bash -c '...'`, aliases, `eval`); `CAMP_ALLOW_RAW_GIT=1` is the
+# supported escape hatch. Detection is intentionally conservative: it may block
+# an unusual wrapper command whose quoted message literally contains
+# `&& git commit` (split as a separator), which the escape hatch covers.
 set -u
 
-# jq parses the tool payload safely. If it is absent, fail open rather than
-# guessing at JSON with a regex and risking a false block.
-command -v jq >/dev/null 2>&1 || exit 0
+# is_raw_git_commit COMMAND -> 0 if any segment invokes a raw `git commit`.
+#
+# The command is split on the `;`, `&&`, `||`, and newline separators, then each
+# segment is matched start-anchored: optional leading whitespace and env
+# assignments, then the `git` executable, then any options/args, then the
+# `commit` subcommand as a whole word. A wrapper (`camp commit`, `fest commit`)
+# starts with a different executable and so never matches; a `git commit` string
+# appearing only inside a wrapper's quoted message is not at a segment start and
+# is not flagged either.
+is_raw_git_commit() {
+  local cmd="$1" segment
+  # Cheap reject: no `commit` token anywhere means nothing to check.
+  case "$cmd" in *commit*) ;; *) return 1 ;; esac
+  # Normalize command separators to newlines with pure bash (no sed/tr quirks).
+  cmd="${cmd//&&/$'\n'}"
+  cmd="${cmd//||/$'\n'}"
+  cmd="${cmd//;/$'\n'}"
+  while IFS= read -r segment; do
+    if printf '%s' "$segment" | grep -Eq '^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*git[[:space:]]+([^[:space:]]+[[:space:]]+)*commit([[:space:]]|$)'; then
+      return 0
+    fi
+  done <<< "$cmd"
+  return 1
+}
 
-input="$(cat)"
-command="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
-[ -z "$command" ] && exit 0
+# in_campaign CWD -> 0 if the session is inside a campaign. Prefers the hook
+# payload's cwd, falling back to the hook process cwd.
+in_campaign() {
+  local cwd="$1"
+  command -v camp >/dev/null 2>&1 || return 1
+  if [ -n "$cwd" ]; then
+    ( cd "$cwd" 2>/dev/null && camp id >/dev/null 2>&1 )
+  else
+    camp id >/dev/null 2>&1
+  fi
+}
 
-# Deliberate escape hatch.
-[ "${CAMP_ALLOW_RAW_GIT:-}" = "1" ] && exit 0
+main() {
+  # jq parses the tool payload safely. If it is absent, fail open rather than
+  # guessing at JSON with a regex and risking a false block.
+  command -v jq >/dev/null 2>&1 || exit 0
 
-# Cheap check first so the common case (any non-commit Bash call) exits without
-# spawning `camp`. `git` followed (past any global options) by the `commit`
-# subcommand; command separators (; & |) bound the match so `git add && camp
-# commit` stays safe.
-printf '%s' "$command" | grep -Eq '(^|[^[:alnum:]])git[[:space:]]+([^;&|]* )?commit([[:space:]]|$)' || exit 0
+  local input command cwd
+  input="$(cat)"
+  command="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+  [ -z "$command" ] && exit 0
 
-# Wrapper invocations are allowed.
-case "$command" in
-  *"camp commit"*|*"camp p commit"*|*"fest commit"*) exit 0 ;;
-esac
+  # Deliberate escape hatch.
+  [ "${CAMP_ALLOW_RAW_GIT:-}" = "1" ] && exit 0
 
-# Only enforce inside a campaign. Without `camp`, or outside a campaign, this is
-# some other repository and the rule does not apply.
-command -v camp >/dev/null 2>&1 || exit 0
-cwd="$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)"
-if [ -n "$cwd" ]; then
-  ( cd "$cwd" 2>/dev/null && camp id >/dev/null 2>&1 ) || exit 0
-else
-  camp id >/dev/null 2>&1 || exit 0
+  is_raw_git_commit "$command" || exit 0
+
+  # Only enforce inside a campaign. Elsewhere this is some other repository and
+  # the rule does not apply.
+  cwd="$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)"
+  in_campaign "$cwd" || exit 0
+
+  echo "raw git commit is forbidden inside a campaign; use \`camp commit\` (campaign root), \`camp p commit\` (inside projects/*), or \`fest commit\` (during festivals); see the campaign-commit skill. Set CAMP_ALLOW_RAW_GIT=1 to override deliberately." >&2
+  exit 2
+}
+
+# Run main only when executed, not when sourced by the test harness.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  main "$@"
 fi
-
-echo "raw git commit is forbidden inside a campaign; use \`camp commit\` (campaign root), \`camp p commit\` (inside projects/*), or \`fest commit\` (during festivals); see the campaign-commit skill. Set CAMP_ALLOW_RAW_GIT=1 to override deliberately." >&2
-exit 2

--- a/claude-plugin/hooks/scripts/commit-guard.sh
+++ b/claude-plugin/hooks/scripts/commit-guard.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash) guard: block raw `git commit` inside a campaign workspace.
+#
+# Ships with the Festival Claude Code plugin. Unlike a campaign-local hook, this
+# fires in every session the plugin is enabled in, so it self-scopes: it only
+# enforces when the Bash command is a raw `git commit` AND the session is inside
+# a campaign (detected via `camp id`). Outside a campaign, when `camp` or `jq`
+# is missing, or when the command is not a raw commit, it exits 0 (fails open)
+# so it never blocks unrelated repositories.
+#
+# Commit discipline: commits must route through the camp/fest wrappers so
+# festival traceability and campaign bookkeeping are preserved. See the
+# campaign-commit skill.
+set -u
+
+# jq parses the tool payload safely. If it is absent, fail open rather than
+# guessing at JSON with a regex and risking a false block.
+command -v jq >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+command="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+[ -z "$command" ] && exit 0
+
+# Deliberate escape hatch.
+[ "${CAMP_ALLOW_RAW_GIT:-}" = "1" ] && exit 0
+
+# Cheap check first so the common case (any non-commit Bash call) exits without
+# spawning `camp`. `git` followed (past any global options) by the `commit`
+# subcommand; command separators (; & |) bound the match so `git add && camp
+# commit` stays safe.
+printf '%s' "$command" | grep -Eq '(^|[^[:alnum:]])git[[:space:]]+([^;&|]* )?commit([[:space:]]|$)' || exit 0
+
+# Wrapper invocations are allowed.
+case "$command" in
+  *"camp commit"*|*"camp p commit"*|*"fest commit"*) exit 0 ;;
+esac
+
+# Only enforce inside a campaign. Without `camp`, or outside a campaign, this is
+# some other repository and the rule does not apply.
+command -v camp >/dev/null 2>&1 || exit 0
+cwd="$(printf '%s' "$input" | jq -r '.cwd // empty' 2>/dev/null)"
+if [ -n "$cwd" ]; then
+  ( cd "$cwd" 2>/dev/null && camp id >/dev/null 2>&1 ) || exit 0
+else
+  camp id >/dev/null 2>&1 || exit 0
+fi
+
+echo "raw git commit is forbidden inside a campaign; use \`camp commit\` (campaign root), \`camp p commit\` (inside projects/*), or \`fest commit\` (during festivals); see the campaign-commit skill. Set CAMP_ALLOW_RAW_GIT=1 to override deliberately." >&2
+exit 2

--- a/claude-plugin/hooks/scripts/commit-guard.test.sh
+++ b/claude-plugin/hooks/scripts/commit-guard.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Unit tests for commit-guard.sh raw-git-commit detection.
+#
+# Sources the guard (its main() is guarded so sourcing only defines functions)
+# and exercises is_raw_git_commit against a matrix of realistic command lines,
+# including the compound-command and `git -C <path>` bypasses reported in
+# review. Pure string logic: no camp, no campaign, no stdin required, so it runs
+# anywhere. Invoked by `just plugin check`.
+set -u
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./commit-guard.sh
+source "$DIR/commit-guard.sh"
+
+fail=0
+check() { # $1 want(block|allow)  $2 command
+  local want="$1" cmd="$2" got
+  if is_raw_git_commit "$cmd"; then got=block; else got=allow; fi
+  if [ "$got" = "$want" ]; then
+    if [ -n "${COMMIT_GUARD_TEST_VERBOSE:-}" ]; then
+      printf 'ok   %-6s %s\n' "$want" "$cmd"
+    fi
+  else
+    printf 'FAIL want=%s got=%s  %s\n' "$want" "$got" "$cmd"
+    fail=1
+  fi
+}
+
+# Raw commits that must be blocked.
+check block 'git commit -m x'
+check block 'git commit'
+check block 'git   commit --amend --no-edit'
+check block 'git -C projects/camp commit -m x'          # unquoted path bypass
+check block 'git -C fest commit'                        # path substring bypass
+check block 'fest commit -m trace; git commit -m sneaky'  # compound after ;
+check block 'camp commit -m ok && git commit -m sneaky'   # compound after &&
+check block 'camp p commit -m ok || git commit -m sneaky' # compound after ||
+check block 'FOO=bar git commit -m x'                   # leading env assignment
+
+# Wrappers and non-commits that must be allowed.
+check allow 'camp commit -m x'
+check allow 'camp p commit -m x'
+check allow 'fest commit -m x'
+check allow 'git add -A && camp commit -m x'
+check allow 'git add -A'
+check allow 'git status'
+check allow 'git log --oneline'
+check allow 'ls -la'
+check allow 'echo git commit'                           # not a git invocation
+check allow 'camp commit -m "mentions git commit inline"'  # git commit in message
+
+if [ "$fail" -ne 0 ]; then
+  echo "commit-guard tests FAILED" >&2
+  exit 1
+fi
+echo "commit-guard tests passed"

--- a/packaging/targets/codex.target.mjs
+++ b/packaging/targets/codex.target.mjs
@@ -43,8 +43,15 @@ mirroring the Claude Code hook, so no manual step is required after \`/plugin in
 }
 
 function codexHooks(ctx) {
+  // Codex mirrors only the SessionStart install hook. Other event types in the
+  // Claude source (e.g. the PreToolUse commit guard) are Claude-Code-specific:
+  // they depend on Claude's tool-call payload schema and exit-code semantics,
+  // which Codex does not share, so we do not fake them here.
+  const source = ctx.sourceHooks.SessionStart
+    ? { SessionStart: ctx.sourceHooks.SessionStart }
+    : {};
   const swapped = JSON.parse(
-    JSON.stringify(ctx.sourceHooks).replaceAll("${CLAUDE_PLUGIN_ROOT}", "${PLUGIN_ROOT}"),
+    JSON.stringify(source).replaceAll("${CLAUDE_PLUGIN_ROOT}", "${PLUGIN_ROOT}"),
   );
   return { _generated: ctx.banner, ...swapped };
 }

--- a/scripts/test_claude_plugin.sh
+++ b/scripts/test_claude_plugin.sh
@@ -536,7 +536,9 @@ codex_target_check "$plugin_dir/.claude-plugin/plugin.json"
 cursor_target_check "$plugin_dir/.claude-plugin/plugin.json"
 opencode_target_check
 gemini_target_check "$plugin_dir/.claude-plugin/plugin.json"
-bash -n "$plugin_dir/hooks/scripts/ensure-festival.sh" "$plugin_dir/hooks/scripts/sync-check.sh"
+bash -n "$plugin_dir/hooks/scripts/ensure-festival.sh" "$plugin_dir/hooks/scripts/sync-check.sh" \
+    "$plugin_dir/hooks/scripts/commit-guard.sh" "$plugin_dir/hooks/scripts/commit-guard.test.sh"
+bash "$plugin_dir/hooks/scripts/commit-guard.test.sh"
 
 if [ -x "$repo_root/fest/bin/fest" ] && [ -x "$repo_root/camp/bin/camp" ]; then
     FEST_BIN="$repo_root/fest/bin/fest" CAMP_BIN="$repo_root/camp/bin/camp" \


### PR DESCRIPTION
## What

Adds a commit-discipline guard to the Festival Claude Code plugin: a `PreToolUse` (Bash) hook that blocks raw `git commit` inside a campaign and steers commits through the `camp`/`fest` wrappers, so festival traceability and campaign bookkeeping are preserved.

This ports the guard we have been running as a campaign-local hook into the plugin, so anyone who installs the plugin for the smoothest Claude Code + Festival experience gets the same enforcement.

## Why the plugin (and why Claude-only)

The *rule* ("route commits through `camp commit` / `camp p commit` / `fest commit`") is general and owned by camp/fest. But this *hook* is a Claude Code artifact: it parses Claude's `tool_input.command` payload and uses Claude's `exit 2` blocking semantics. It cannot fire for Codex, Gemini, or a human at a terminal. So it belongs in the Claude Code adapter (this plugin), alongside the existing `SessionStart` install hook, not in camp/fest core.

Git `pre-commit` hooks were considered and rejected: too easy to bypass (`--no-verify`) and they add an enforcement surface outside the filesystem + git model camp/fest deliberately stay within.

## Self-scoping (important for a plugin hook)

A plugin hook fires in **every** session, so the guard is written to never interfere with unrelated repos. It blocks only when all hold, and otherwise exits 0:

- the command is a raw `git commit` (not a `camp`/`fest` wrapper), and
- the session is inside a campaign, detected via `camp id`, and
- both `camp` and `jq` are available.

Outside a campaign, in repos without `camp`, or on machines without `jq`, it fails open. The cheap `git commit` regex runs first, so `camp id` is only invoked on an actual raw-commit attempt. `CAMP_ALLOW_RAW_GIT=1` overrides for a single command.

## Generator: kept Claude-only

The repo generates the per-harness plugins from `claude-plugin/` as the single source of truth. Only the **codex** target consumed the full `sourceHooks` (blind copy with a variable swap), so regenerating would have injected this hook into `.codex-plugin/hooks/hooks.json` while *not* bundling the script, producing a broken reference and faking Codex support the guard cannot actually provide.

`codexHooks` is now scoped to mirror only the `SessionStart` install hook. Regeneration produces **no diff** in any generated target, so Codex/Cursor/Gemini/opencode output is unchanged. This matches the repo's "documented gap, not faked" philosophy.

## Testing

- `just plugin check` passes (JSON parse, semver/metadata, component frontmatter, in-bundle hook references, CLI sync-check, install-hook smoke, generated-targets check).
- `just plugin generate` yields no target drift.
- `shellcheck` and `bash -n` clean on `commit-guard.sh`.
- Guard behavior verified against simulated PreToolUse payloads:
  - raw `git commit` in a campaign → blocked (exit 2)
  - `camp p commit` / `git add && camp commit` → allowed
  - `git -C <path> commit` in a campaign → blocked
  - raw `git commit` outside a campaign (`cwd=/tmp`) → allowed
  - non-commit command → allowed
  - `CAMP_ALLOW_RAW_GIT=1` → allowed
  - missing `cwd` field falls back to the hook process cwd

## Files

- `claude-plugin/hooks/scripts/commit-guard.sh` (new)
- `claude-plugin/hooks/hooks.json` (add `PreToolUse` wiring)
- `claude-plugin/README.md` (document the guard)
- `packaging/targets/codex.target.mjs` (scope codex to the install hook)
