### PR TITLE
fix(docs): restore CLI reference command index (permalink-based detection)

### DIFF
--- a/themes/festival/layouts/_default/list.html
+++ b/themes/festival/layouts/_default/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  {{ $isCliLeaf := and .File (in .File.Path "docs/cli-reference/") (ne .File.Path "docs/cli-reference/_index.md") }}
+  {{ $isCliLeaf := and (strings.HasPrefix .RelPermalink "/cli-reference/") (ne .RelPermalink "/cli-reference/") }}
   <article>
     <h1>{{ .Title }}</h1>
     {{ .Content }}


### PR DESCRIPTION
## Problem

The generated CLI reference pages (`/cli-reference/camp/`, `/cli-reference/fest/`) render the main content as a giant flat wall of every command link instead of the intended styled **Commands** card grid. The command cards + descriptions never appear, even though their CSS (`main.css` `.doc-index*`) is fully present.

## Root cause

`themes/festival/layouts/_default/list.html` gated its `.doc-index` view on a **file-path** check:

```gotmpl
{{ $isCliLeaf := and .File (in .File.Path "docs/cli-reference/") ... }}
```

The earlier `refactor(docs): consolidate authored docs into docs` set `contentDir: docs` in `hugo.yaml`. With that, Hugo makes `.File.Path` **content-relative** — it's now `cli-reference/camp/_index.md`, which no longer contains `docs/cli-reference/`. So `$isCliLeaf` is permanently `false` and every CLI page falls through to the `{{ else }}` fallback (`range .Pages` → bare `<div><a>` links).

The sidebar command nav was unaffected because it already keys off `.RelPermalink`, not `.File.Path` — which is why the commands stayed navigable in the sidebar while the page itself broke.

## Fix

Key the CLI-leaf check off `.RelPermalink` (contentDir-independent, and identical to the sidebar partial's existing logic):

```gotmpl
{{ $isCliLeaf := and (strings.HasPrefix .RelPermalink "/cli-reference/") (ne .RelPermalink "/cli-reference/") }}
```

## Verification (local Hugo build + browser)

- `/cli-reference/camp/` and `/cli-reference/fest/` now render the **Commands** card grid (156 / 179 command cards with descriptions); the bare-`<div>` fallback wall is gone.
- `/cli-reference/` overview page unchanged (still just the fest/camp links — correctly *not* a doc-index).
- Sidebar generated command nav still present on both pages.

Note: `docs.fest.build` only redeploys on `v*` tags, so the live site keeps the broken render until the next tagged release.