### PR TITLE
Add search-focused Festival use case pages

### DIFF
--- a/docs/compare/_index.md
+++ b/docs/compare/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Compare"
+description: "Compare Festival with issue trackers, task lists, and project management tools for AI-assisted software work."
+weight: 39
+---
+
+Festival is not a replacement for every planning tool. It is a workflow layer for AI-assisted work that needs executable context, durable handoff, and task-level verification.
+
+Start with [Festival vs Issue Trackers]({{< ref "/compare/festival-vs-issue-trackers" >}}).

--- a/docs/compare/festival-vs-issue-trackers.md
+++ b/docs/compare/festival-vs-issue-trackers.md
@@ -1,0 +1,78 @@
+---
+title: "Festival vs Issue Trackers"
+description: "Compare Festival with GitHub Issues, Linear, Jira, and task lists for AI-assisted software work."
+weight: 39
+---
+
+# Festival vs Issue Trackers
+
+Issue trackers are good at recording what a team intends to do. Festival is built for turning a goal into executable work that an AI agent can pick up, verify, commit, and resume.
+
+You may still use GitHub Issues, Linear, Jira, or a task list. Festival fills a different gap.
+
+## Short Version
+
+Use an issue tracker for prioritization, discussion, assignment, and team visibility.
+
+Use Festival when the work needs structured execution:
+
+- project-local context
+- phase and task hierarchy
+- agent-readable next steps
+- acceptance criteria
+- quality gates
+- handoff notes
+- commit traceability
+
+## Comparison
+
+| Need | Issue tracker | Festival |
+|---|---|---|
+| Team backlog | Strong | Not the primary job |
+| Project discussion | Strong | Supported through docs, but not a comment system |
+| AI agent next task | Usually ambiguous | `fest next` returns the next executable task |
+| Context across sessions | Often scattered | Stored in the workspace |
+| Multi-step execution | Manual coordination | Phases, sequences, and tasks |
+| Verification | Usually checklist text | Task criteria plus gates and commands |
+| Commit traceability | Manual conventions | `fest commit` ties work to the plan |
+| Works without a hosted service | Usually no | Yes, filesystem plus git |
+
+## Where Issue Trackers Break Down For Agents
+
+An issue often describes a desired outcome, but an agent still needs to infer:
+
+- which files matter
+- what order to do the work in
+- what prior decisions constrain the implementation
+- how to verify each step
+- what to do after the first subtask is complete
+
+That inference burns context and creates risk. Festival makes the execution plan explicit.
+
+## How They Work Together
+
+A practical setup is:
+
+1. Use GitHub Issues, Linear, or Jira for product backlog and team discussion.
+2. Promote selected work into a Festival when it becomes AI-executable.
+3. Use Festival to plan phases, sequences, tasks, gates, and verification.
+4. Link commits and PRs back to the issue if needed.
+
+The issue remains the team-level artifact. The festival becomes the execution artifact.
+
+## When Festival Is Overkill
+
+Do not create a festival for every tiny task. A one-line typo fix or a small isolated edit does not need the full structure.
+
+Festival pays for itself when the work is large enough that losing context would cost more than writing the plan.
+
+## Try It
+
+```bash
+camp init my-workspace
+cd my-workspace
+fest create festival --name issue-123-auth-refactor --type standard
+fest next
+```
+
+Next: read [AI Agent Project Management]({{< ref "/use-cases/ai-agent-project-management" >}}) or start with the [Quick Start]({{< ref "/getting-started/quickstart" >}}).

--- a/docs/use-cases/_index.md
+++ b/docs/use-cases/_index.md
@@ -1,0 +1,54 @@
+---
+title: "Use Cases"
+description: "Practical ways to use Festival for AI agent project management, long-running coding sessions, handoffs, and structured AI-assisted software work."
+weight: 35
+---
+
+Festival is for AI-assisted software work that needs more structure than a chat thread, a task list, or a one-off prompt.
+
+These pages describe the common situations where Festival helps: keeping agent sessions coherent, handing work between tools, tracking progress across repos, and turning broad goals into executable steps.
+
+<div class="doc-index__list">
+  <a class="doc-index__item" href="/use-cases/ai-agent-project-management/">
+    <strong>AI Agent Project Management</strong>
+    <span>Plan, execute, and resume AI-assisted work without losing project state.</span>
+  </a>
+  <a class="doc-index__item" href="/use-cases/long-running-ai-coding-sessions/">
+    <strong>Long-Running AI Coding Sessions</strong>
+    <span>Keep multi-day or multi-week coding work coherent across context windows.</span>
+  </a>
+  <a class="doc-index__item" href="/use-cases/claude-code-project-management/">
+    <strong>Claude Code Project Management</strong>
+    <span>Use Festival with Claude Code while keeping plans, tasks, and commits traceable.</span>
+  </a>
+  <a class="doc-index__item" href="/use-cases/ai-agent-handoff/">
+    <strong>AI Agent Handoff</strong>
+    <span>Let a new agent session pick up the next task without reconstructing the whole project.</span>
+  </a>
+</div>
+
+## When Festival Fits
+
+Festival fits best when the work has more than one step and correctness depends on remembering decisions:
+
+- a feature that touches multiple files or repos
+- a refactor that needs planning, staged execution, and verification
+- a launch checklist with docs, release, and follow-up tasks
+- a codebase cleanup that should not be rediscovered every session
+- a research or design effort that needs to become implementation work
+
+If the task is a single prompt or a quick edit, you may not need Festival. If the work will outlive one chat window, Festival gives it a durable home.
+
+## Start Here
+
+Install Festival, create a campaign workspace, then create your first festival:
+
+```bash
+brew install --cask Obedience-Corp/tap/festival
+camp init my-project
+cd my-project
+fest create festival --name first-feature --type standard
+fest next
+```
+
+For the full path, read the [Quick Start]({{< ref "/getting-started/quickstart" >}}).

--- a/docs/use-cases/_index.md
+++ b/docs/use-cases/_index.md
@@ -9,19 +9,19 @@ Festival is for AI-assisted software work that needs more structure than a chat 
 These pages describe the common situations where Festival helps: keeping agent sessions coherent, handing work between tools, tracking progress across repos, and turning broad goals into executable steps.
 
 <div class="doc-index__list">
-  <a class="doc-index__item" href="/use-cases/ai-agent-project-management/">
+  <a class="doc-index__item" href="{{< ref "/use-cases/ai-agent-project-management" >}}">
     <strong>AI Agent Project Management</strong>
     <span>Plan, execute, and resume AI-assisted work without losing project state.</span>
   </a>
-  <a class="doc-index__item" href="/use-cases/long-running-ai-coding-sessions/">
+  <a class="doc-index__item" href="{{< ref "/use-cases/long-running-ai-coding-sessions" >}}">
     <strong>Long-Running AI Coding Sessions</strong>
     <span>Keep multi-day or multi-week coding work coherent across context windows.</span>
   </a>
-  <a class="doc-index__item" href="/use-cases/claude-code-project-management/">
+  <a class="doc-index__item" href="{{< ref "/use-cases/claude-code-project-management" >}}">
     <strong>Claude Code Project Management</strong>
     <span>Use Festival with Claude Code while keeping plans, tasks, and commits traceable.</span>
   </a>
-  <a class="doc-index__item" href="/use-cases/ai-agent-handoff/">
+  <a class="doc-index__item" href="{{< ref "/use-cases/ai-agent-handoff" >}}">
     <strong>AI Agent Handoff</strong>
     <span>Let a new agent session pick up the next task without reconstructing the whole project.</span>
   </a>

--- a/docs/use-cases/ai-agent-handoff.md
+++ b/docs/use-cases/ai-agent-handoff.md
@@ -1,0 +1,89 @@
+---
+title: "AI Agent Handoff"
+description: "Use Festival to hand off AI coding work between sessions, tools, and humans without losing plan context or next actions."
+weight: 38
+---
+
+# AI Agent Handoff
+
+AI agent handoff is the moment when one session stops and another session needs to continue the work. Without a durable handoff, the next agent spends time reconstructing what happened instead of moving the project forward.
+
+Festival makes handoff explicit.
+
+## The Handoff Problem
+
+An AI coding session can end for many normal reasons:
+
+- the context window fills up
+- the human pauses work
+- a different model or tool is needed
+- a review finds new issues
+- the work moves from planning to implementation
+
+If the state only exists in conversation, the next session has to ask: what was the goal, what changed, what failed, what remains, and what should I do next?
+
+## The Festival Handoff
+
+Festival keeps handoff state in the workspace:
+
+- `FESTIVAL_GOAL.md` describes the outcome.
+- phase and sequence files describe where the work is.
+- task files describe executable next steps.
+- status commands show progress.
+- commits preserve traceability.
+- context notes capture decisions and open questions.
+
+The next agent can start with:
+
+```bash
+fest status
+fest next
+```
+
+That is enough to understand where the work stands and what to do next.
+
+## What To Capture Before Ending A Session
+
+Before stopping a long-running session, capture:
+
+- decisions made
+- rejected alternatives
+- files changed
+- checks run
+- known failures
+- unresolved questions
+- the exact next task if it is not already represented
+
+Put that context in the festival files instead of only in chat. The next session can then resume without a verbal briefing.
+
+## Handoff Between Tools
+
+Festival is not tied to one AI product. A task can be started by one tool and finished by another because the state is stored in the filesystem.
+
+Example:
+
+1. A planning session creates the festival.
+2. Claude Code implements the first task.
+3. Codex reviews the diff and updates tests.
+4. A human validates the result.
+5. The next agent runs `fest next`.
+
+No tool owns the project state. The workspace does.
+
+## A Good Handoff Checklist
+
+Run these before you stop:
+
+```bash
+fest status
+git status --short
+```
+
+Then make sure the task state matches reality:
+
+- mark completed work with `fest task completed`
+- leave incomplete work as incomplete
+- record blockers in the task or context notes
+- commit finished work with `fest commit`
+
+Next: read [Agent Workflows]({{< ref "/guides/agent-workflows" >}}) and [Workflows & Gates]({{< ref "/methodology/workflows-and-gates" >}}).

--- a/docs/use-cases/ai-agent-project-management.md
+++ b/docs/use-cases/ai-agent-project-management.md
@@ -1,0 +1,90 @@
+---
+title: "AI Agent Project Management"
+description: "Use Festival as a project management layer for AI agents: goals, phases, tasks, context, progress, and verification stored in your workspace."
+weight: 35
+---
+
+# AI Agent Project Management
+
+AI agents can write code, investigate bugs, draft plans, and edit docs quickly. The hard part is keeping that work organized once it spans multiple sessions, repositories, decisions, and review steps.
+
+Festival is a project management layer for AI-assisted work. It does not replace your coding agent. It gives the agent a structured workspace it can read and update.
+
+## The Problem
+
+Most AI coding work starts in a chat:
+
+1. Explain the goal.
+2. Add context about the repo.
+3. Ask for a plan.
+4. Execute part of the plan.
+5. Run out of context or stop for the day.
+6. Re-explain everything in the next session.
+
+That loop breaks down on real projects. The agent forgets prior decisions, duplicates work, misses verification steps, or implements an old version of the plan.
+
+## The Festival Model
+
+Festival turns project work into a filesystem-backed plan:
+
+- **Campaigns** hold related repos, docs, plans, and research.
+- **Festivals** define a goal and the work needed to reach it.
+- **Phases** group work by stage, such as ingest, plan, implement, review, or release.
+- **Sequences** group related tasks.
+- **Tasks** describe executable units of work with acceptance criteria and verification.
+
+The agent does not need a database or proprietary integration. It needs shell access and file access.
+
+## The Agent Loop
+
+The core loop is intentionally small:
+
+```bash
+fest next
+# agent reads the task, edits files, runs checks
+fest task completed
+fest commit -m "implement feature step"
+fest next
+```
+
+`fest next` gives the agent the next incomplete task with surrounding context. `fest status` and `fest progress` show what is done, what is in flight, and what remains.
+
+## Why This Is Different From a Task List
+
+A normal task list says what should happen. Festival also captures the structure around why it should happen and how to verify it:
+
+- the overall goal
+- phase context
+- task acceptance criteria
+- quality gates
+- command-line workflow
+- commit traceability
+- handoff notes and status
+
+That extra structure matters when a different AI session, a different model, or a human reviewer picks up the work later.
+
+## Good Fits
+
+Use Festival for:
+
+- multi-step coding tasks
+- cross-repository changes
+- refactors with staged verification
+- launch readiness work
+- documentation and release workflows
+- agent-led cleanup efforts
+- human-reviewed implementation plans
+
+Do not reach for Festival for every tiny edit. It is most useful when work has enough shape that losing context would be expensive.
+
+## Start With a Campaign
+
+```bash
+camp init my-product
+cd my-product
+camp project add https://github.com/you/api
+fest create festival --name auth-system --type standard
+fest next
+```
+
+Next: follow the [Quick Start]({{< ref "/getting-started/quickstart" >}}) or read [Agent Workflows]({{< ref "/guides/agent-workflows" >}}).

--- a/docs/use-cases/claude-code-project-management.md
+++ b/docs/use-cases/claude-code-project-management.md
@@ -1,0 +1,71 @@
+---
+title: "Claude Code Project Management"
+description: "Use Festival with Claude Code to give AI coding sessions durable project state, next tasks, progress tracking, and traceable commits."
+weight: 37
+---
+
+# Claude Code Project Management
+
+Claude Code is effective at editing real codebases. Festival gives Claude Code a durable project structure so long-running work does not depend on chat memory.
+
+The pattern is simple: use Claude Code as the coding agent and Festival as the project state.
+
+## What Festival Adds
+
+Festival helps Claude Code sessions answer four questions quickly:
+
+- What is the goal?
+- What has already been done?
+- What is the next task?
+- How do we know this task is complete?
+
+Without that structure, each new session has to infer the plan from files, commits, and conversation history. That is slow and error-prone.
+
+## Add Festival To The Session Instructions
+
+In a repo that uses Festival, tell Claude Code to start with the Festival loop:
+
+```text
+Run fest intro on first contact. Use fest next to get the next task.
+Follow the task acceptance criteria. When complete, run the requested checks,
+mark the task completed, and commit with fest commit.
+```
+
+That instruction gives the agent a repeatable operating model.
+
+## Use `fest next` As The Task Source
+
+The agent should not invent the next task when the project already has a festival. It should run:
+
+```bash
+fest next
+```
+
+The task output includes the work item, surrounding context, and completion expectations. This reduces the amount of repo-wide scanning needed at the start of each session.
+
+## Commit With Traceability
+
+Inside an active festival, use:
+
+```bash
+fest commit -m "implement import validation"
+```
+
+Festival commits tie changes back to the plan, which makes review and status tracking easier. A future session can inspect progress without reverse-engineering intent from a loose commit history.
+
+## Recommended Claude Code Flow
+
+1. Start the session in the campaign or project workspace.
+2. Run `fest intro` if this is the first Festival session.
+3. Run `fest next`.
+4. Let Claude Code execute the task.
+5. Run the task's validation commands.
+6. Mark the task complete.
+7. Commit with `fest commit`.
+8. Run `fest next` again.
+
+## Use Festival With Other Agents Too
+
+This pattern is not Claude-specific. Festival works with any agent that can run shell commands and read files. That makes it useful when you switch between Claude Code, Codex, OpenCode, Crush, Cursor Agents, or custom automation.
+
+Next: read [Agent Workflows]({{< ref "/guides/agent-workflows" >}}) or start with the [Quick Start]({{< ref "/getting-started/quickstart" >}}).

--- a/docs/use-cases/long-running-ai-coding-sessions.md
+++ b/docs/use-cases/long-running-ai-coding-sessions.md
@@ -1,0 +1,95 @@
+---
+title: "Long-Running AI Coding Sessions"
+description: "Use Festival to keep long-running AI coding sessions coherent across context windows, interruptions, handoffs, and verification steps."
+weight: 36
+---
+
+# Long-Running AI Coding Sessions
+
+AI coding agents are strongest when the next step is clear. They are weakest when every session starts by rediscovering the project, reconstructing the plan, and guessing what already happened.
+
+Festival is designed for coding work that lasts longer than one prompt or one chat window.
+
+## Why Long-Running Sessions Fail
+
+Long-running AI-assisted work usually fails for practical reasons:
+
+- the plan lives in chat history instead of the repo
+- the next task is ambiguous
+- acceptance criteria are missing
+- prior decisions are not written down
+- verification commands are forgotten
+- commits are not tied back to the plan
+- a new agent session has to rebuild context from scratch
+
+The result is friction. The agent spends too much time orienting and too little time executing.
+
+## Festival Stores the Work Where Agents Can Read It
+
+Festival keeps work state in files:
+
+```text
+festivals/
+  active/
+    release-readiness-RR0001/
+      FESTIVAL_GOAL.md
+      FESTIVAL_OVERVIEW.md
+      TODO.md
+      001_INGEST/
+      002_PLAN/
+      003_IMPLEMENT/
+```
+
+That structure survives tool changes, session resets, model changes, and context limits.
+
+## Resume With One Command
+
+When a session starts, the agent can run:
+
+```bash
+fest next
+```
+
+The response tells it what to do next and includes the context needed to start. The agent does not need to load the whole workspace or ask the human to summarize everything again.
+
+## Keep Verification Attached To The Work
+
+Long-running work needs more than a checklist. Each task can specify:
+
+- files to inspect or modify
+- acceptance criteria
+- commands to run
+- expected outputs
+- review notes
+- cleanup requirements
+
+That makes the final work easier to review because the task and the commit history tell the same story.
+
+## Example Workflow
+
+```bash
+fest create festival --name docs-launch --type standard
+fest validate
+fest next
+
+# agent works the current task
+just docs build
+fest task completed
+fest commit -m "add launch docs"
+
+fest next
+```
+
+When you stop, the state is still in the festival. When you return, `fest next` resumes the loop.
+
+## When To Use This Pattern
+
+Use Festival when the work has:
+
+- more than one meaningful step
+- multiple files or repos
+- a plan that may change
+- verification requirements
+- a handoff between sessions, humans, or tools
+
+For the complete loop, read [Agent Workflows]({{< ref "/guides/agent-workflows" >}}).

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -108,6 +108,34 @@ menu:
       url: /guides/loops-and-orchestration/
       weight: 34
 
+    - name: Use Cases
+      identifier: use-cases
+      weight: 35
+    - name: AI Agent Project Management
+      parent: use-cases
+      url: /use-cases/ai-agent-project-management/
+      weight: 35
+    - name: Long-Running AI Coding Sessions
+      parent: use-cases
+      url: /use-cases/long-running-ai-coding-sessions/
+      weight: 36
+    - name: Claude Code Project Management
+      parent: use-cases
+      url: /use-cases/claude-code-project-management/
+      weight: 37
+    - name: AI Agent Handoff
+      parent: use-cases
+      url: /use-cases/ai-agent-handoff/
+      weight: 38
+
+    - name: Compare
+      identifier: compare
+      weight: 39
+    - name: Festival vs Issue Trackers
+      parent: compare
+      url: /compare/festival-vs-issue-trackers/
+      weight: 39
+
     - name: Tutorials
       identifier: tutorials
       weight: 40

--- a/themes/festival/layouts/index.html
+++ b/themes/festival/layouts/index.html
@@ -4,8 +4,8 @@
     <div class="home-hero__copy">
       <h1>AI can generate the pieces.<br>Festival keeps the work coherent.</h1>
       <p>
-        A system for managing long-running AI-assisted work across months of
-        decisions, context, artifacts, reviews, and next actions.
+        Loop engineering for AI-assisted work: build repeatable planning,
+        execution, review, and handoff loops that keep moving after the first prompt.
       </p>
 
       <div class="home-hero__actions">
@@ -24,8 +24,8 @@
           <div class="home-stat__label">Build anything at any scale</div>
         </div>
         <div class="home-stat">
-          <div class="home-stat__value">Structured</div>
-          <div class="home-stat__label">phases → sequences → tasks</div>
+          <div class="home-stat__value">Loops</div>
+          <div class="home-stat__label">Build loops that work</div>
         </div>
         <div class="home-stat">
           <div class="home-stat__value">Any AI</div>

--- a/themes/festival/layouts/index.html
+++ b/themes/festival/layouts/index.html
@@ -186,6 +186,47 @@
     </div>
   </section>
 
+  <section class="home-section home-section--next-steps">
+    <div class="home-section__intro">
+      <h2 class="home-section__heading home-section__heading--centered">Use Festival where AI work loses context</h2>
+      <p class="home-section__lede">
+        Start with the workflow problem you are trying to solve, then move into the installation
+        and command reference once the fit is clear.
+      </p>
+    </div>
+
+    <div class="cards">
+      {{ with site.GetPage "/use-cases/ai-agent-project-management" }}
+        <a href="{{ .RelPermalink }}" class="card">
+          <div class="card__title">AI agent project management</div>
+          <div class="card__description">Give agents goals, phases, tasks, status, and verification they can read from the workspace.</div>
+          <span class="card__arrow">Read the use case &rarr;</span>
+        </a>
+      {{ end }}
+      {{ with site.GetPage "/use-cases/long-running-ai-coding-sessions" }}
+        <a href="{{ .RelPermalink }}" class="card">
+          <div class="card__title">Long-running AI coding sessions</div>
+          <div class="card__description">Keep multi-day or multi-week implementation work coherent across context windows and interruptions.</div>
+          <span class="card__arrow">Read the use case &rarr;</span>
+        </a>
+      {{ end }}
+      {{ with site.GetPage "/use-cases/ai-agent-handoff" }}
+        <a href="{{ .RelPermalink }}" class="card">
+          <div class="card__title">AI agent handoff</div>
+          <div class="card__description">Let a new agent, model, or human reviewer resume from the actual next step.</div>
+          <span class="card__arrow">Read the use case &rarr;</span>
+        </a>
+      {{ end }}
+      {{ with site.GetPage "/compare/festival-vs-issue-trackers" }}
+        <a href="{{ .RelPermalink }}" class="card">
+          <div class="card__title">Festival vs issue trackers</div>
+          <div class="card__description">Use backlog tools for team coordination and Festival for executable AI work plans.</div>
+          <span class="card__arrow">Compare the workflow &rarr;</span>
+        </a>
+      {{ end }}
+    </div>
+  </section>
+
   <section class="home-section home-section--install">
     <div class="home-install home-install--center">
       <h2 class="home-section__heading">Structure the ambition. Let AI ship it.</h2>


### PR DESCRIPTION
## Summary
- add use-case pages for AI agent project management, long-running coding sessions, Claude Code workflows, and AI agent handoff
- add a comparison page for Festival vs issue trackers
- wire the new pages into the Hugo sidebar menu and homepage discovery section

## Validation
- hugo --gc --minify --cleanDestinationDir --source . --baseURL "https://fest.build"
- npx pagefind --site public
- curl checks against local Hugo server on http://localhost:1315/

## Notes
- Branch and PR naming intentionally avoid Codex branding.
