### PR TITLE
docs(site): showcase TUI command demos on landing page and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,55 @@ fest understand                  # Teach an AI agent the full methodology
 
 `fest next` is the entry point for agents: it resolves the next task with context from every level of the hierarchy and respects workflow ordering and completion criteria. See [Agentic Loops](#agentic-loops) for how it drives execution end to end.
 
+## See It in Action
+
+`camp` and `fest` are terminal-native. Here is what the core commands actually look like.
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/cgo-navigation.gif" alt="cgo jumping between projects, festivals, and design directories, plus csw to switch campaigns"><br>
+      <sub><b><code>cgo</code></b><br>Jump anywhere in the workspace</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-workitems.gif" alt="The camp wi dashboard: intents, designs, explores, and festivals in one unified list, narrowed by search"><br>
+      <sub><b><code>camp wi</code></b><br>One queue for every kind of work</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-intent-add.gif" alt="The camp intent add capture form: title, type, concept, and description, then saved to the inbox"><br>
+      <sub><b><code>camp intent add</code></b><br>Capture an idea in seconds</sub>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-intent-explore.gif" alt="The camp intent explore TUI: intents grouped by status with a live preview pane and fuzzy search"><br>
+      <sub><b><code>camp intent explore</code></b><br>Browse and triage the inbox</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-fest-list.gif" alt="fest list showing festivals grouped by status: active, ready, and planning"><br>
+      <sub><b><code>fest list</code></b><br>Every festival, grouped by status</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-fest-show.gif" alt="fest show rendering a festival's phase, sequence, and task tree, cycling between festivals with the arrow keys"><br>
+      <sub><b><code>fest show</code></b><br>Read a plan's full structure</sub>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-fest-watch.gif" alt="fest watch showing a festival's progress bar and task icons updating live as work completes"><br>
+      <sub><b><code>fest watch</code></b><br>Watch progress update live</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-fest-gates-apply.gif" alt="fest gates apply showing a dry-run of the quality gates it would add to each sequence, then applying them with --approve"><br>
+      <sub><b><code>fest gates apply</code></b><br>Add quality gates in one command</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-dungeon-crawl.gif" alt="camp dungeon crawl triaging stale items into the dungeon: move to archived, keep, or skip, ending in a committed summary"><br>
+      <sub><b><code>camp dungeon crawl</code></b><br>Triage stale work into the dungeon</sub>
+    </td>
+  </tr>
+</table>
+
 ## Claude Code Plugin
 
 Install the Festival plugin for Claude Code to get `fest` and `camp` CLI tools, slash commands, methodology skills, and specialized agents in one step:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,55 @@ fest next
 
 After installing, see the [quick start guide](https://docs.fest.build/getting-started/quickstart/) for shell setup and first steps.
 
+## See It in Action
+
+`camp` and `fest` are terminal-native. Here is what the core commands actually look like.
+
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/cgo-navigation.gif" alt="cgo jumping between projects, festivals, and design directories, plus csw to switch campaigns"><br>
+      <sub><b><code>cgo</code></b><br>Jump anywhere in the workspace</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-workitems.gif" alt="The camp wi dashboard: intents, designs, explores, and festivals in one unified list, narrowed by search"><br>
+      <sub><b><code>camp wi</code></b><br>One queue for every kind of work</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-intent-add.gif" alt="The camp intent add capture form: title, type, concept, and description, then saved to the inbox"><br>
+      <sub><b><code>camp intent add</code></b><br>Capture an idea in seconds</sub>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-intent-explore.gif" alt="The camp intent explore TUI: intents grouped by status with a live preview pane and fuzzy search"><br>
+      <sub><b><code>camp intent explore</code></b><br>Browse and triage the inbox</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-fest-list.gif" alt="fest list showing festivals grouped by status: active, ready, and planning"><br>
+      <sub><b><code>fest list</code></b><br>Every festival, grouped by status</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-fest-show.gif" alt="fest show rendering a festival's phase, sequence, and task tree, cycling between festivals with the arrow keys"><br>
+      <sub><b><code>fest show</code></b><br>Read a plan's full structure</sub>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-fest-watch.gif" alt="fest watch showing a festival's progress bar and task icons updating live as work completes"><br>
+      <sub><b><code>fest watch</code></b><br>Watch progress update live</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-fest-gates-apply.gif" alt="fest gates apply showing a dry-run of the quality gates it would add to each sequence, then applying them with --approve"><br>
+      <sub><b><code>fest gates apply</code></b><br>Add quality gates in one command</sub>
+    </td>
+    <td align="center" width="33%">
+      <img src="docs/images/demos/tui-dungeon-crawl.gif" alt="camp dungeon crawl triaging stale items into the dungeon: move to archived, keep, or skip, ending in a committed summary"><br>
+      <sub><b><code>camp dungeon crawl</code></b><br>Triage stale work into the dungeon</sub>
+    </td>
+  </tr>
+</table>
+
 <p align="center"><strong>A 4-day festival, planned and built across three AI tools</strong></p>
 <p align="center"><em>Planned in Claude Code (Fathom), promoted to active, then the <code>fest next</code> loop ran in grok-build, stopped 2 days in, and finished in Codex.</em></p>
 
@@ -307,55 +356,6 @@ fest understand                  # Teach an AI agent the full methodology
 ```
 
 `fest next` is the entry point for agents: it resolves the next task with context from every level of the hierarchy and respects workflow ordering and completion criteria. See [Agentic Loops](#agentic-loops) for how it drives execution end to end.
-
-## See It in Action
-
-`camp` and `fest` are terminal-native. Here is what the core commands actually look like.
-
-<table>
-  <tr>
-    <td align="center" width="33%">
-      <img src="docs/images/demos/cgo-navigation.gif" alt="cgo jumping between projects, festivals, and design directories, plus csw to switch campaigns"><br>
-      <sub><b><code>cgo</code></b><br>Jump anywhere in the workspace</sub>
-    </td>
-    <td align="center" width="33%">
-      <img src="docs/images/demos/tui-workitems.gif" alt="The camp wi dashboard: intents, designs, explores, and festivals in one unified list, narrowed by search"><br>
-      <sub><b><code>camp wi</code></b><br>One queue for every kind of work</sub>
-    </td>
-    <td align="center" width="33%">
-      <img src="docs/images/demos/tui-intent-add.gif" alt="The camp intent add capture form: title, type, concept, and description, then saved to the inbox"><br>
-      <sub><b><code>camp intent add</code></b><br>Capture an idea in seconds</sub>
-    </td>
-  </tr>
-  <tr>
-    <td align="center" width="33%">
-      <img src="docs/images/demos/tui-intent-explore.gif" alt="The camp intent explore TUI: intents grouped by status with a live preview pane and fuzzy search"><br>
-      <sub><b><code>camp intent explore</code></b><br>Browse and triage the inbox</sub>
-    </td>
-    <td align="center" width="33%">
-      <img src="docs/images/demos/tui-fest-list.gif" alt="fest list showing festivals grouped by status: active, ready, and planning"><br>
-      <sub><b><code>fest list</code></b><br>Every festival, grouped by status</sub>
-    </td>
-    <td align="center" width="33%">
-      <img src="docs/images/demos/tui-fest-show.gif" alt="fest show rendering a festival's phase, sequence, and task tree, cycling between festivals with the arrow keys"><br>
-      <sub><b><code>fest show</code></b><br>Read a plan's full structure</sub>
-    </td>
-  </tr>
-  <tr>
-    <td align="center" width="33%">
-      <img src="docs/images/demos/tui-fest-watch.gif" alt="fest watch showing a festival's progress bar and task icons updating live as work completes"><br>
-      <sub><b><code>fest watch</code></b><br>Watch progress update live</sub>
-    </td>
-    <td align="center" width="33%">
-      <img src="docs/images/demos/tui-fest-gates-apply.gif" alt="fest gates apply showing a dry-run of the quality gates it would add to each sequence, then applying them with --approve"><br>
-      <sub><b><code>fest gates apply</code></b><br>Add quality gates in one command</sub>
-    </td>
-    <td align="center" width="33%">
-      <img src="docs/images/demos/tui-dungeon-crawl.gif" alt="camp dungeon crawl triaging stale items into the dungeon: move to archived, keep, or skip, ending in a committed summary"><br>
-      <sub><b><code>camp dungeon crawl</code></b><br>Triage stale work into the dungeon</sub>
-    </td>
-  </tr>
-</table>
 
 ## Claude Code Plugin
 

--- a/themes/festival/assets/css/main.css
+++ b/themes/festival/assets/css/main.css
@@ -1378,6 +1378,31 @@ summary {
   height: auto;
 }
 
+/* Gallery of terminal-native command demos on the landing page. */
+.demo-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+  margin-top: 2.5rem;
+}
+
+.demo-gallery__item {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.demo-gallery__item .terminal-demo {
+  border-radius: 16px;
+}
+
+.demo-gallery__caption {
+  font-size: 0.9rem;
+  color: var(--festival-500);
+  text-align: center;
+}
+
 .cards--steps {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }

--- a/themes/festival/layouts/index.html
+++ b/themes/festival/layouts/index.html
@@ -139,6 +139,114 @@
     </div>
   </section>
 
+  <section class="home-section home-section--demos" id="the-tools">
+    <div class="home-section__intro">
+      <h2 class="home-section__heading home-section__heading--centered">Every command, in motion</h2>
+      <p class="home-section__lede">camp and fest are terminal-native. Here is what the core commands actually look like.</p>
+    </div>
+
+    <div class="demo-gallery">
+      <figure class="demo-gallery__item">
+        <div class="terminal-demo">
+          <div class="terminal-demo__bar">
+            <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
+            <span class="terminal-demo__title">cgo</span>
+          </div>
+          <img src="/images/demos/cgo-navigation.gif" class="terminal-demo__gif" alt="cgo jumping between projects, festivals, and design directories, plus csw to switch campaigns" loading="lazy">
+        </div>
+        <figcaption class="demo-gallery__caption">Jump anywhere in the workspace</figcaption>
+      </figure>
+
+      <figure class="demo-gallery__item">
+        <div class="terminal-demo">
+          <div class="terminal-demo__bar">
+            <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
+            <span class="terminal-demo__title">camp wi</span>
+          </div>
+          <img src="/images/demos/tui-workitems.gif" class="terminal-demo__gif" alt="The camp wi dashboard: intents, designs, explores, and festivals in one unified list, narrowed by search" loading="lazy">
+        </div>
+        <figcaption class="demo-gallery__caption">One queue for every kind of work</figcaption>
+      </figure>
+
+      <figure class="demo-gallery__item">
+        <div class="terminal-demo">
+          <div class="terminal-demo__bar">
+            <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
+            <span class="terminal-demo__title">camp intent add</span>
+          </div>
+          <img src="/images/demos/tui-intent-add.gif" class="terminal-demo__gif" alt="The camp intent add capture form: title, type, concept, and description, then saved to the inbox" loading="lazy">
+        </div>
+        <figcaption class="demo-gallery__caption">Capture an idea in seconds</figcaption>
+      </figure>
+
+      <figure class="demo-gallery__item">
+        <div class="terminal-demo">
+          <div class="terminal-demo__bar">
+            <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
+            <span class="terminal-demo__title">camp intent explore</span>
+          </div>
+          <img src="/images/demos/tui-intent-explore.gif" class="terminal-demo__gif" alt="The camp intent explore TUI: intents grouped by status with a live preview pane and fuzzy search" loading="lazy">
+        </div>
+        <figcaption class="demo-gallery__caption">Browse and triage the inbox</figcaption>
+      </figure>
+
+      <figure class="demo-gallery__item">
+        <div class="terminal-demo">
+          <div class="terminal-demo__bar">
+            <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
+            <span class="terminal-demo__title">fest list</span>
+          </div>
+          <img src="/images/demos/tui-fest-list.gif" class="terminal-demo__gif" alt="fest list showing festivals grouped by status: active, ready, and planning" loading="lazy">
+        </div>
+        <figcaption class="demo-gallery__caption">Every festival, grouped by status</figcaption>
+      </figure>
+
+      <figure class="demo-gallery__item">
+        <div class="terminal-demo">
+          <div class="terminal-demo__bar">
+            <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
+            <span class="terminal-demo__title">fest show</span>
+          </div>
+          <img src="/images/demos/tui-fest-show.gif" class="terminal-demo__gif" alt="fest show rendering a festival's phase, sequence, and task tree, cycling between festivals with the arrow keys" loading="lazy">
+        </div>
+        <figcaption class="demo-gallery__caption">Read a plan's full structure</figcaption>
+      </figure>
+
+      <figure class="demo-gallery__item">
+        <div class="terminal-demo">
+          <div class="terminal-demo__bar">
+            <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
+            <span class="terminal-demo__title">fest watch</span>
+          </div>
+          <img src="/images/demos/tui-fest-watch.gif" class="terminal-demo__gif" alt="fest watch showing a festival's progress bar and task icons updating live as work completes" loading="lazy">
+        </div>
+        <figcaption class="demo-gallery__caption">Watch progress update live</figcaption>
+      </figure>
+
+      <figure class="demo-gallery__item">
+        <div class="terminal-demo">
+          <div class="terminal-demo__bar">
+            <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
+            <span class="terminal-demo__title">fest gates apply</span>
+          </div>
+          <img src="/images/demos/tui-fest-gates-apply.gif" class="terminal-demo__gif" alt="fest gates apply showing a dry-run of the quality gates it would add to each sequence, then applying them with --approve" loading="lazy">
+        </div>
+        <figcaption class="demo-gallery__caption">Add quality gates in one command</figcaption>
+      </figure>
+
+      <figure class="demo-gallery__item">
+        <div class="terminal-demo">
+          <div class="terminal-demo__bar">
+            <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
+            <span class="terminal-demo__title">camp dungeon crawl</span>
+          </div>
+          <img src="/images/demos/tui-dungeon-crawl.gif" class="terminal-demo__gif" alt="camp dungeon crawl triaging stale items into the dungeon: move to archived, keep, or skip, ending in a committed summary" loading="lazy">
+        </div>
+        <figcaption class="demo-gallery__caption">Triage stale work into the dungeon</figcaption>
+      </figure>
+    </div>
+  </section>
+
   <section class="home-section home-section--problem">
     <div class="home-section__intro">
       <h2 class="home-section__heading home-section__heading--centered">Festival is for AI-assisted work that has to stay coherent for months or years</h2>


### PR DESCRIPTION
## What

Surfaces the existing terminal-demo GIFs — currently shown one-per-page across the docs — as a single showcase gallery in two high-visibility places:

- **Landing page** (`themes/festival/layouts/index.html`): a new **"Every command, in motion"** section between *How it works* and the problem cards. A responsive `.demo-gallery` grid of `terminal-demo` cards, one per core command.
- **README** (`README.md`): a **"See It in Action"** 3×3 table under the CLI Overview, same set of GIFs with command + one-line caption.

Both feature the same nine demos: `cgo`, `camp wi`, `camp intent add`, `camp intent explore`, `fest list`, `fest show`, `fest watch`, `fest gates apply`, `camp dungeon crawl`.

## Details

- New `.demo-gallery` CSS reuses the existing `terminal-demo` component (title bar + GIF); nothing new invented visually.
- All GIFs are already committed under `docs/images/demos/` and served at `/images/demos/` — no new assets.
- Landing GIFs use `loading="lazy"` so the top of the page stays fast.

## Verification

- `hugo --gc --minify` builds clean (395 pages, 0 errors).
- Confirmed all 9 GIF refs resolve in the built output and the `.demo-gallery` rule is in the minified CSS bundle.
- Rendered locally and screenshotted: 3-column grid, captions, consistent with site styling.