### PR TITLE
docs(plugin): propagate fest-standalone-workflows skill to all plugin targets

### DIFF
--- a/.cursor-plugin/README.md
+++ b/.cursor-plugin/README.md
@@ -7,7 +7,7 @@ supports as plugin components, per `packaging/survey/cursor.md` and `packaging/s
 
 ## Bundled (all four surfaces)
 
-- **Skills** (`skills: "./skills/"`), 8:
+- **Skills** (`skills: "./skills/"`), 9:
   - `camp-navigation`
   - `camp-projects`
   - `campaign-commit`
@@ -16,6 +16,7 @@ supports as plugin components, per `packaging/survey/cursor.md` and `packaging/s
   - `fest-execution`
   - `fest-methodology`
   - `fest-planning`
+  - `fest-standalone-workflows`
 - **Commands** (`commands: "./commands/"`): 10 slash commands.
 - **Agents** (`agents: "./agents/"`): 2 agents.
 - **Hooks** (`hooks: "./hooks/hooks.json"`): the blocking install hook described below.

--- a/.cursor-plugin/skills/fest-planning/SKILL.md
+++ b/.cursor-plugin/skills/fest-planning/SKILL.md
@@ -84,6 +84,24 @@ fgo fest
 fest scaffold from-plan --plan STRUCTURE.md --name my-festival
 ```
 
+## Standalone WORKFLOW.md (Outside a Festival)
+
+For a short, repeatable step checklist that does not need a full festival
+(phases/sequences/tasks), scaffold a standalone `WORKFLOW.md` instead:
+
+```bash
+fest create workflow <name>
+# or, equivalently:
+fest workflow create <name>
+```
+
+Both accept `--steps '<json>'` / `--steps-file <file>` for agent mode,
+`--type` for the standalone workflow type, and `--no-init` for advanced mode
+(skip runtime init and lazily bootstrap a tracked run on first
+`fest workflow advance`). See the `fest-standalone-workflows` skill for the
+full step-JSON schema and execution loop. Reach for a full festival instead
+when the work needs multi-phase planning, sequencing, or quality gates.
+
 ## Common Mistakes
 
 - Using `fest link --project ...` (invalid flag).

--- a/.cursor-plugin/skills/fest-standalone-workflows/SKILL.md
+++ b/.cursor-plugin/skills/fest-standalone-workflows/SKILL.md
@@ -17,7 +17,7 @@ WORKFLOW.md -> fest next -> do step -> fest workflow advance -> repeat
 ## When to Use This vs. a Full Festival
 
 - **Standalone workflow**: a short, repeatable checklist that can live in any
-  directory — a code-review checklist, a release-cut runbook, a one-off
+  directory: a code-review checklist, a release-cut runbook, a one-off
   investigation. Minimal ceremony, no phases/sequences.
 - **Full festival**: multi-phase work that needs planning, sequencing, and
   quality gates over an extended effort. Use `fest create festival` instead
@@ -56,7 +56,7 @@ This scaffolds `WORKFLOW.md`, initializes `.workflow/` runtime state, and
 starts a tracked run, so `fest next` works immediately.
 
 `fest workflow create <name>` is an alias of `fest create workflow <name>`
-and accepts the same flags — use whichever noun you reach for first.
+and accepts the same flags. Use whichever noun you reach for first.
 
 For human interactive creation, run the command without `--steps` from a TTY:
 
@@ -80,7 +80,7 @@ It prompts for title, intent, and step lines in `Name|Goal` form.
 - `--path <dir>` / `--festival <root>`: target a festival phase instead of
   standalone mode. Inside a festival phase, or with either of these flags
   set, the command writes the phase's `WORKFLOW.md` with no standalone
-  runtime — do not pass these when you want a standalone workflow.
+  runtime, so do not pass these when you want a standalone workflow.
 
 ## Step JSON Contract
 
@@ -119,10 +119,10 @@ fest next
 
 ## Common Mistakes
 
-- Passing `--path` or `--festival` when creating a standalone workflow —
+- Passing `--path` or `--festival` when creating a standalone workflow;
   those target a festival phase instead.
 - Using `title` inside each step object. Step objects require `name` and
   `goal`, not `title`.
-- Assuming `--no-init` is required before `fest next` will work. It is not —
+- Assuming `--no-init` is required before `fest next` will work. It is not:
   the default (no flag) already initializes runtime state and starts a
   tracked run in one step.

--- a/.cursor-plugin/skills/fest-standalone-workflows/SKILL.md
+++ b/.cursor-plugin/skills/fest-standalone-workflows/SKILL.md
@@ -108,6 +108,10 @@ Valid checkpoint values:
 - `documentation`
 - `approval_required`
 
+`approval_required` is accepted when the file is created, but standalone
+execution cannot advance through blocking approval checkpoints. Use a festival
+phase when the workflow needs user-approval gates.
+
 ## Execution Loop
 
 ```bash
@@ -126,3 +130,6 @@ fest next
 - Assuming `--no-init` is required before `fest next` will work. It is not:
   the default (no flag) already initializes runtime state and starts a
   tracked run in one step.
+- Adding `approval_required` to a standalone workflow. The file will validate
+  at creation time, but `fest workflow advance` cannot cross that blocking
+  checkpoint outside a festival phase.

--- a/.cursor-plugin/skills/fest-standalone-workflows/SKILL.md
+++ b/.cursor-plugin/skills/fest-standalone-workflows/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: fest-standalone-workflows
+description: Create and run lightweight standalone `WORKFLOW.md` loops with `fest create workflow`, `fest next`, and `fest workflow advance`. Use when a user wants step-by-step workflow guidance inside any ordinary directory, explore/design work item, project folder, or thin-start workflow.
+---
+
+# Fest Standalone Workflows
+
+Use a standalone `WORKFLOW.md` when work needs a guided step loop in an ordinary
+directory, without setting up a full festival (phases/sequences/tasks).
+
+Thin-start loop:
+
+```text
+WORKFLOW.md -> fest next -> do step -> fest workflow advance -> repeat
+```
+
+## When to Use This vs. a Full Festival
+
+- **Standalone workflow**: a short, repeatable checklist that can live in any
+  directory — a code-review checklist, a release-cut runbook, a one-off
+  investigation. Minimal ceremony, no phases/sequences.
+- **Full festival**: multi-phase work that needs planning, sequencing, and
+  quality gates over an extended effort. Use `fest create festival` instead
+  (see the `fest-planning` skill).
+
+## Create
+
+Run from the directory that should own the workflow:
+
+```bash
+mkdir -p my-workflow && cd my-workflow
+
+fest create workflow my-workflow --steps '{
+  "title": "My Workflow",
+  "description": "A lightweight guided loop.",
+  "steps": [
+    {
+      "name": "PLAN",
+      "goal": "Decide what needs to happen.",
+      "actions": ["Write the goal.", "List the unknowns."],
+      "checkpoint": "none"
+    },
+    {
+      "name": "DO",
+      "goal": "Do the work.",
+      "actions": ["Make the change.", "Validate it."],
+      "checkpoint": "verification"
+    }
+  ]
+}'
+
+fest next
+```
+
+This scaffolds `WORKFLOW.md`, initializes `.workflow/` runtime state, and
+starts a tracked run, so `fest next` works immediately.
+
+`fest workflow create <name>` is an alias of `fest create workflow <name>`
+and accepts the same flags — use whichever noun you reach for first.
+
+For human interactive creation, run the command without `--steps` from a TTY:
+
+```bash
+fest create workflow my-workflow
+```
+
+It prompts for title, intent, and step lines in `Name|Goal` form.
+
+## Flags
+
+- `--steps '<json>'` / `--steps-file <file>`: agent mode, inline JSON or a
+  JSON file. See the step schema below.
+- `--agent`: strict agent mode (implies `--json`).
+- `--type <type>`: standalone workflow type (default `task`).
+- `--no-init`: advanced mode. Writes `WORKFLOW.md` only, without initializing
+  `.workflow/` runtime state or starting a run. `fest next` still works in
+  this mode, but reports the workflow as not-started; the first mutating
+  command (`fest workflow advance`) bootstraps a tracked run lazily. Use this
+  when you want to author the document before committing to a tracked run.
+- `--path <dir>` / `--festival <root>`: target a festival phase instead of
+  standalone mode. Inside a festival phase, or with either of these flags
+  set, the command writes the phase's `WORKFLOW.md` with no standalone
+  runtime — do not pass these when you want a standalone workflow.
+
+## Step JSON Contract
+
+Workflow-level fields:
+
+- `title` (required)
+- `description` (optional)
+- `steps` (required, non-empty)
+
+Each step needs:
+
+- `name`
+- `goal`
+
+Useful optional step fields:
+
+- `actions`
+- `output`
+- `checkpoint`
+
+Valid checkpoint values:
+
+- `none`
+- `verification`
+- `documentation`
+- `approval_required`
+
+## Execution Loop
+
+```bash
+fest next
+# do the visible step
+fest workflow advance
+fest next
+```
+
+## Common Mistakes
+
+- Passing `--path` or `--festival` when creating a standalone workflow —
+  those target a festival phase instead.
+- Using `title` inside each step object. Step objects require `name` and
+  `goal`, not `title`.
+- Assuming `--no-init` is required before `fest next` will work. It is not —
+  the default (no flag) already initializes runtime state and starts a
+  tracked run in one step.

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -21,7 +21,7 @@ load (failures are swallowed so opencode still starts).
 
 ## Skills
 
-The 8 Festival skills ship under `.opencode/skills/` and are picked up by
+The 9 Festival skills ship under `.opencode/skills/` and are picked up by
 opencode's native skill auto-discovery. No manual registration is required.
 
 ## Manual fallback

--- a/.opencode/skills/fest-planning/SKILL.md
+++ b/.opencode/skills/fest-planning/SKILL.md
@@ -84,6 +84,24 @@ fgo fest
 fest scaffold from-plan --plan STRUCTURE.md --name my-festival
 ```
 
+## Standalone WORKFLOW.md (Outside a Festival)
+
+For a short, repeatable step checklist that does not need a full festival
+(phases/sequences/tasks), scaffold a standalone `WORKFLOW.md` instead:
+
+```bash
+fest create workflow <name>
+# or, equivalently:
+fest workflow create <name>
+```
+
+Both accept `--steps '<json>'` / `--steps-file <file>` for agent mode,
+`--type` for the standalone workflow type, and `--no-init` for advanced mode
+(skip runtime init and lazily bootstrap a tracked run on first
+`fest workflow advance`). See the `fest-standalone-workflows` skill for the
+full step-JSON schema and execution loop. Reach for a full festival instead
+when the work needs multi-phase planning, sequencing, or quality gates.
+
 ## Common Mistakes
 
 - Using `fest link --project ...` (invalid flag).

--- a/.opencode/skills/fest-standalone-workflows/SKILL.md
+++ b/.opencode/skills/fest-standalone-workflows/SKILL.md
@@ -17,7 +17,7 @@ WORKFLOW.md -> fest next -> do step -> fest workflow advance -> repeat
 ## When to Use This vs. a Full Festival
 
 - **Standalone workflow**: a short, repeatable checklist that can live in any
-  directory — a code-review checklist, a release-cut runbook, a one-off
+  directory: a code-review checklist, a release-cut runbook, a one-off
   investigation. Minimal ceremony, no phases/sequences.
 - **Full festival**: multi-phase work that needs planning, sequencing, and
   quality gates over an extended effort. Use `fest create festival` instead
@@ -56,7 +56,7 @@ This scaffolds `WORKFLOW.md`, initializes `.workflow/` runtime state, and
 starts a tracked run, so `fest next` works immediately.
 
 `fest workflow create <name>` is an alias of `fest create workflow <name>`
-and accepts the same flags — use whichever noun you reach for first.
+and accepts the same flags. Use whichever noun you reach for first.
 
 For human interactive creation, run the command without `--steps` from a TTY:
 
@@ -80,7 +80,7 @@ It prompts for title, intent, and step lines in `Name|Goal` form.
 - `--path <dir>` / `--festival <root>`: target a festival phase instead of
   standalone mode. Inside a festival phase, or with either of these flags
   set, the command writes the phase's `WORKFLOW.md` with no standalone
-  runtime — do not pass these when you want a standalone workflow.
+  runtime, so do not pass these when you want a standalone workflow.
 
 ## Step JSON Contract
 
@@ -119,10 +119,10 @@ fest next
 
 ## Common Mistakes
 
-- Passing `--path` or `--festival` when creating a standalone workflow —
+- Passing `--path` or `--festival` when creating a standalone workflow;
   those target a festival phase instead.
 - Using `title` inside each step object. Step objects require `name` and
   `goal`, not `title`.
-- Assuming `--no-init` is required before `fest next` will work. It is not —
+- Assuming `--no-init` is required before `fest next` will work. It is not:
   the default (no flag) already initializes runtime state and starts a
   tracked run in one step.

--- a/.opencode/skills/fest-standalone-workflows/SKILL.md
+++ b/.opencode/skills/fest-standalone-workflows/SKILL.md
@@ -108,6 +108,10 @@ Valid checkpoint values:
 - `documentation`
 - `approval_required`
 
+`approval_required` is accepted when the file is created, but standalone
+execution cannot advance through blocking approval checkpoints. Use a festival
+phase when the workflow needs user-approval gates.
+
 ## Execution Loop
 
 ```bash
@@ -126,3 +130,6 @@ fest next
 - Assuming `--no-init` is required before `fest next` will work. It is not:
   the default (no flag) already initializes runtime state and starts a
   tracked run in one step.
+- Adding `approval_required` to a standalone workflow. The file will validate
+  at creation time, but `fest workflow advance` cannot cross that blocking
+  checkpoint outside a festival phase.

--- a/.opencode/skills/fest-standalone-workflows/SKILL.md
+++ b/.opencode/skills/fest-standalone-workflows/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: fest-standalone-workflows
+description: Create and run lightweight standalone `WORKFLOW.md` loops with `fest create workflow`, `fest next`, and `fest workflow advance`. Use when a user wants step-by-step workflow guidance inside any ordinary directory, explore/design work item, project folder, or thin-start workflow.
+---
+
+# Fest Standalone Workflows
+
+Use a standalone `WORKFLOW.md` when work needs a guided step loop in an ordinary
+directory, without setting up a full festival (phases/sequences/tasks).
+
+Thin-start loop:
+
+```text
+WORKFLOW.md -> fest next -> do step -> fest workflow advance -> repeat
+```
+
+## When to Use This vs. a Full Festival
+
+- **Standalone workflow**: a short, repeatable checklist that can live in any
+  directory — a code-review checklist, a release-cut runbook, a one-off
+  investigation. Minimal ceremony, no phases/sequences.
+- **Full festival**: multi-phase work that needs planning, sequencing, and
+  quality gates over an extended effort. Use `fest create festival` instead
+  (see the `fest-planning` skill).
+
+## Create
+
+Run from the directory that should own the workflow:
+
+```bash
+mkdir -p my-workflow && cd my-workflow
+
+fest create workflow my-workflow --steps '{
+  "title": "My Workflow",
+  "description": "A lightweight guided loop.",
+  "steps": [
+    {
+      "name": "PLAN",
+      "goal": "Decide what needs to happen.",
+      "actions": ["Write the goal.", "List the unknowns."],
+      "checkpoint": "none"
+    },
+    {
+      "name": "DO",
+      "goal": "Do the work.",
+      "actions": ["Make the change.", "Validate it."],
+      "checkpoint": "verification"
+    }
+  ]
+}'
+
+fest next
+```
+
+This scaffolds `WORKFLOW.md`, initializes `.workflow/` runtime state, and
+starts a tracked run, so `fest next` works immediately.
+
+`fest workflow create <name>` is an alias of `fest create workflow <name>`
+and accepts the same flags — use whichever noun you reach for first.
+
+For human interactive creation, run the command without `--steps` from a TTY:
+
+```bash
+fest create workflow my-workflow
+```
+
+It prompts for title, intent, and step lines in `Name|Goal` form.
+
+## Flags
+
+- `--steps '<json>'` / `--steps-file <file>`: agent mode, inline JSON or a
+  JSON file. See the step schema below.
+- `--agent`: strict agent mode (implies `--json`).
+- `--type <type>`: standalone workflow type (default `task`).
+- `--no-init`: advanced mode. Writes `WORKFLOW.md` only, without initializing
+  `.workflow/` runtime state or starting a run. `fest next` still works in
+  this mode, but reports the workflow as not-started; the first mutating
+  command (`fest workflow advance`) bootstraps a tracked run lazily. Use this
+  when you want to author the document before committing to a tracked run.
+- `--path <dir>` / `--festival <root>`: target a festival phase instead of
+  standalone mode. Inside a festival phase, or with either of these flags
+  set, the command writes the phase's `WORKFLOW.md` with no standalone
+  runtime — do not pass these when you want a standalone workflow.
+
+## Step JSON Contract
+
+Workflow-level fields:
+
+- `title` (required)
+- `description` (optional)
+- `steps` (required, non-empty)
+
+Each step needs:
+
+- `name`
+- `goal`
+
+Useful optional step fields:
+
+- `actions`
+- `output`
+- `checkpoint`
+
+Valid checkpoint values:
+
+- `none`
+- `verification`
+- `documentation`
+- `approval_required`
+
+## Execution Loop
+
+```bash
+fest next
+# do the visible step
+fest workflow advance
+fest next
+```
+
+## Common Mistakes
+
+- Passing `--path` or `--festival` when creating a standalone workflow —
+  those target a festival phase instead.
+- Using `title` inside each step object. Step objects require `name` and
+  `goal`, not `title`.
+- Assuming `--no-init` is required before `fest next` will work. It is not —
+  the default (no flag) already initializes runtime state and starts a
+  tracked run in one step.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ and tasks, with quality gates between them.
 ## What ships
 
 - The `fest` and `camp` CLIs, which the session-start hook installs and keeps current.
-- 8 skills describing the workflows:
+- 9 skills describing the workflows:
 
 - `camp-navigation`: Navigate campaign workspaces with `cgo` and `camp go`. Use when you need to move between projects/festivals/workflow directories, switch context quickly, or resolve script-safe paths with `camp go --print`.
 - `camp-projects`: Manage campaign submodule projects. Use when committing inside `projects/*`, deciding status/pull/push scope (root vs submodule vs all), or creating/removing project worktrees.
@@ -19,6 +19,7 @@ and tasks, with quality gates between them.
 - `fest-execution`: Execute active festival tasks. Use when finding the next task, marking tasks completed/blocked/reset, committing with festival traceability, advancing workflow steps, and validating sequence progress.
 - `fest-methodology`: Use when the user mentions festivals, the fest CLI, phases, sequences, or tasks, or when working inside a `festivals/` directory. Provides the core Festival methodology model so Claude understands the planning system.
 - `fest-planning`: Plan and scaffold festivals. Use when creating festival/phase/sequence/task structure, enforcing naming rules, linking festivals to projects, and promoting lifecycle states.
+- `fest-standalone-workflows`: Create and run lightweight standalone `WORKFLOW.md` loops with `fest create workflow`, `fest next`, and `fest workflow advance`. Use when a user wants step-by-step workflow guidance inside any ordinary directory, explore/design work item, project folder, or thin-start workflow.
 
 ## Learn more
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,3 +22,4 @@ curl -fsSL https://raw.githubusercontent.com/Obedience-Corp/festival/main/instal
 @./claude-plugin/skills/fest-execution/SKILL.md
 @./claude-plugin/skills/fest-methodology/SKILL.md
 @./claude-plugin/skills/fest-planning/SKILL.md
+@./claude-plugin/skills/fest-standalone-workflows/SKILL.md

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -16,7 +16,7 @@ docs linked at the end.
 ```
 claude-plugin/
   .claude-plugin/plugin.json    plugin manifest (name, version, description)
-  skills/                       8 skills, one SKILL.md each
+  skills/                       9 skills, one SKILL.md each
   commands/                     10 fest-* and camp-* slash commands
   agents/                       fest-executor, fest-planner
   hooks/
@@ -115,7 +115,7 @@ every local default test run, not only in the release workflow.
 - Supporting-file pattern. Keep `SKILL.md` short (when to use, core loop, key
   commands) and move heavy reference into sibling files loaded just in time.
   Split a skill when its `SKILL.md` crosses roughly 100 lines or carries a large
-  reference table. The current 8 skills are short and stay single-file.
+  reference table. The current 9 skills are short and stay single-file.
 
 ## Methodology docs
 

--- a/claude-plugin/skills/fest-planning/SKILL.md
+++ b/claude-plugin/skills/fest-planning/SKILL.md
@@ -84,6 +84,24 @@ fgo fest
 fest scaffold from-plan --plan STRUCTURE.md --name my-festival
 ```
 
+## Standalone WORKFLOW.md (Outside a Festival)
+
+For a short, repeatable step checklist that does not need a full festival
+(phases/sequences/tasks), scaffold a standalone `WORKFLOW.md` instead:
+
+```bash
+fest create workflow <name>
+# or, equivalently:
+fest workflow create <name>
+```
+
+Both accept `--steps '<json>'` / `--steps-file <file>` for agent mode,
+`--type` for the standalone workflow type, and `--no-init` for advanced mode
+(skip runtime init and lazily bootstrap a tracked run on first
+`fest workflow advance`). See the `fest-standalone-workflows` skill for the
+full step-JSON schema and execution loop. Reach for a full festival instead
+when the work needs multi-phase planning, sequencing, or quality gates.
+
 ## Common Mistakes
 
 - Using `fest link --project ...` (invalid flag).

--- a/claude-plugin/skills/fest-standalone-workflows/SKILL.md
+++ b/claude-plugin/skills/fest-standalone-workflows/SKILL.md
@@ -17,7 +17,7 @@ WORKFLOW.md -> fest next -> do step -> fest workflow advance -> repeat
 ## When to Use This vs. a Full Festival
 
 - **Standalone workflow**: a short, repeatable checklist that can live in any
-  directory — a code-review checklist, a release-cut runbook, a one-off
+  directory: a code-review checklist, a release-cut runbook, a one-off
   investigation. Minimal ceremony, no phases/sequences.
 - **Full festival**: multi-phase work that needs planning, sequencing, and
   quality gates over an extended effort. Use `fest create festival` instead
@@ -56,7 +56,7 @@ This scaffolds `WORKFLOW.md`, initializes `.workflow/` runtime state, and
 starts a tracked run, so `fest next` works immediately.
 
 `fest workflow create <name>` is an alias of `fest create workflow <name>`
-and accepts the same flags — use whichever noun you reach for first.
+and accepts the same flags. Use whichever noun you reach for first.
 
 For human interactive creation, run the command without `--steps` from a TTY:
 
@@ -80,7 +80,7 @@ It prompts for title, intent, and step lines in `Name|Goal` form.
 - `--path <dir>` / `--festival <root>`: target a festival phase instead of
   standalone mode. Inside a festival phase, or with either of these flags
   set, the command writes the phase's `WORKFLOW.md` with no standalone
-  runtime — do not pass these when you want a standalone workflow.
+  runtime, so do not pass these when you want a standalone workflow.
 
 ## Step JSON Contract
 
@@ -119,10 +119,10 @@ fest next
 
 ## Common Mistakes
 
-- Passing `--path` or `--festival` when creating a standalone workflow —
+- Passing `--path` or `--festival` when creating a standalone workflow;
   those target a festival phase instead.
 - Using `title` inside each step object. Step objects require `name` and
   `goal`, not `title`.
-- Assuming `--no-init` is required before `fest next` will work. It is not —
+- Assuming `--no-init` is required before `fest next` will work. It is not:
   the default (no flag) already initializes runtime state and starts a
   tracked run in one step.

--- a/claude-plugin/skills/fest-standalone-workflows/SKILL.md
+++ b/claude-plugin/skills/fest-standalone-workflows/SKILL.md
@@ -108,6 +108,10 @@ Valid checkpoint values:
 - `documentation`
 - `approval_required`
 
+`approval_required` is accepted when the file is created, but standalone
+execution cannot advance through blocking approval checkpoints. Use a festival
+phase when the workflow needs user-approval gates.
+
 ## Execution Loop
 
 ```bash
@@ -126,3 +130,6 @@ fest next
 - Assuming `--no-init` is required before `fest next` will work. It is not:
   the default (no flag) already initializes runtime state and starts a
   tracked run in one step.
+- Adding `approval_required` to a standalone workflow. The file will validate
+  at creation time, but `fest workflow advance` cannot cross that blocking
+  checkpoint outside a festival phase.

--- a/claude-plugin/skills/fest-standalone-workflows/SKILL.md
+++ b/claude-plugin/skills/fest-standalone-workflows/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: fest-standalone-workflows
+description: Create and run lightweight standalone `WORKFLOW.md` loops with `fest create workflow`, `fest next`, and `fest workflow advance`. Use when a user wants step-by-step workflow guidance inside any ordinary directory, explore/design work item, project folder, or thin-start workflow.
+---
+
+# Fest Standalone Workflows
+
+Use a standalone `WORKFLOW.md` when work needs a guided step loop in an ordinary
+directory, without setting up a full festival (phases/sequences/tasks).
+
+Thin-start loop:
+
+```text
+WORKFLOW.md -> fest next -> do step -> fest workflow advance -> repeat
+```
+
+## When to Use This vs. a Full Festival
+
+- **Standalone workflow**: a short, repeatable checklist that can live in any
+  directory — a code-review checklist, a release-cut runbook, a one-off
+  investigation. Minimal ceremony, no phases/sequences.
+- **Full festival**: multi-phase work that needs planning, sequencing, and
+  quality gates over an extended effort. Use `fest create festival` instead
+  (see the `fest-planning` skill).
+
+## Create
+
+Run from the directory that should own the workflow:
+
+```bash
+mkdir -p my-workflow && cd my-workflow
+
+fest create workflow my-workflow --steps '{
+  "title": "My Workflow",
+  "description": "A lightweight guided loop.",
+  "steps": [
+    {
+      "name": "PLAN",
+      "goal": "Decide what needs to happen.",
+      "actions": ["Write the goal.", "List the unknowns."],
+      "checkpoint": "none"
+    },
+    {
+      "name": "DO",
+      "goal": "Do the work.",
+      "actions": ["Make the change.", "Validate it."],
+      "checkpoint": "verification"
+    }
+  ]
+}'
+
+fest next
+```
+
+This scaffolds `WORKFLOW.md`, initializes `.workflow/` runtime state, and
+starts a tracked run, so `fest next` works immediately.
+
+`fest workflow create <name>` is an alias of `fest create workflow <name>`
+and accepts the same flags — use whichever noun you reach for first.
+
+For human interactive creation, run the command without `--steps` from a TTY:
+
+```bash
+fest create workflow my-workflow
+```
+
+It prompts for title, intent, and step lines in `Name|Goal` form.
+
+## Flags
+
+- `--steps '<json>'` / `--steps-file <file>`: agent mode, inline JSON or a
+  JSON file. See the step schema below.
+- `--agent`: strict agent mode (implies `--json`).
+- `--type <type>`: standalone workflow type (default `task`).
+- `--no-init`: advanced mode. Writes `WORKFLOW.md` only, without initializing
+  `.workflow/` runtime state or starting a run. `fest next` still works in
+  this mode, but reports the workflow as not-started; the first mutating
+  command (`fest workflow advance`) bootstraps a tracked run lazily. Use this
+  when you want to author the document before committing to a tracked run.
+- `--path <dir>` / `--festival <root>`: target a festival phase instead of
+  standalone mode. Inside a festival phase, or with either of these flags
+  set, the command writes the phase's `WORKFLOW.md` with no standalone
+  runtime — do not pass these when you want a standalone workflow.
+
+## Step JSON Contract
+
+Workflow-level fields:
+
+- `title` (required)
+- `description` (optional)
+- `steps` (required, non-empty)
+
+Each step needs:
+
+- `name`
+- `goal`
+
+Useful optional step fields:
+
+- `actions`
+- `output`
+- `checkpoint`
+
+Valid checkpoint values:
+
+- `none`
+- `verification`
+- `documentation`
+- `approval_required`
+
+## Execution Loop
+
+```bash
+fest next
+# do the visible step
+fest workflow advance
+fest next
+```
+
+## Common Mistakes
+
+- Passing `--path` or `--festival` when creating a standalone workflow —
+  those target a festival phase instead.
+- Using `title` inside each step object. Step objects require `name` and
+  `goal`, not `title`.
+- Assuming `--no-init` is required before `fest next` will work. It is not —
+  the default (no flag) already initializes runtime state and starts a
+  tracked run in one step.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -9,7 +9,7 @@ See `survey/MATRIX.md` for the verified per-harness facts these decisions rest o
 
 `claude-plugin/` is canonical:
 - `claude-plugin/.claude-plugin/plugin.json`: name, version, description, author, repository, keywords.
-- `claude-plugin/skills/<name>/SKILL.md`: the 8 skills (portable nearly as-is across harnesses).
+- `claude-plugin/skills/<name>/SKILL.md`: the 9 skills (portable nearly as-is across harnesses).
 - `claude-plugin/commands/*.md`, `claude-plugin/agents/*.md`: carried where a harness supports them.
 - `claude-plugin/hooks/scripts/ensure-festival.sh`: the CLI install/update logic, reused by every
   harness's session-start hook.

--- a/plugins/festival/README.md
+++ b/plugins/festival/README.md
@@ -7,7 +7,7 @@ supports as plugin components, per `packaging/survey/codex.md` and `packaging/su
 
 ## Bundled
 
-- **Skills** (`skills: "./skills/"`), 8 skills:
+- **Skills** (`skills: "./skills/"`), 9 skills:
   - `camp-navigation`: Navigate campaign workspaces with `cgo` and `camp go`. Use when you need to move between projects/festivals/workflow directories, switch context quickly, or resolve script-safe paths with `camp go --print`.
   - `camp-projects`: Manage campaign submodule projects. Use when committing inside `projects/*`, deciding status/pull/push scope (root vs submodule vs all), or creating/removing project worktrees.
   - `campaign-commit`: Choose the correct commit command in a campaign workspace. Use when you are about to commit and need to select `camp p commit`, `fest commit`, root `git commit`, or intentional root pointer sync via `camp refs-sync`.
@@ -16,6 +16,7 @@ supports as plugin components, per `packaging/survey/codex.md` and `packaging/su
   - `fest-execution`: Execute active festival tasks. Use when finding the next task, marking tasks completed/blocked/reset, committing with festival traceability, advancing workflow steps, and validating sequence progress.
   - `fest-methodology`: Use when the user mentions festivals, the fest CLI, phases, sequences, or tasks, or when working inside a `festivals/` directory. Provides the core Festival methodology model so Claude understands the planning system.
   - `fest-planning`: Plan and scaffold festivals. Use when creating festival/phase/sequence/task structure, enforcing naming rules, linking festivals to projects, and promoting lifecycle states.
+  - `fest-standalone-workflows`: Create and run lightweight standalone `WORKFLOW.md` loops with `fest create workflow`, `fest next`, and `fest workflow advance`. Use when a user wants step-by-step workflow guidance inside any ordinary directory, explore/design work item, project folder, or thin-start workflow.
 - **Session-start hook** (`hooks: "./hooks/hooks.json"`) runs `ensure-festival.sh` to install
   and update the `fest` and `camp` CLIs on every session start (idempotent).
 

--- a/plugins/festival/skills/fest-planning/SKILL.md
+++ b/plugins/festival/skills/fest-planning/SKILL.md
@@ -84,6 +84,24 @@ fgo fest
 fest scaffold from-plan --plan STRUCTURE.md --name my-festival
 ```
 
+## Standalone WORKFLOW.md (Outside a Festival)
+
+For a short, repeatable step checklist that does not need a full festival
+(phases/sequences/tasks), scaffold a standalone `WORKFLOW.md` instead:
+
+```bash
+fest create workflow <name>
+# or, equivalently:
+fest workflow create <name>
+```
+
+Both accept `--steps '<json>'` / `--steps-file <file>` for agent mode,
+`--type` for the standalone workflow type, and `--no-init` for advanced mode
+(skip runtime init and lazily bootstrap a tracked run on first
+`fest workflow advance`). See the `fest-standalone-workflows` skill for the
+full step-JSON schema and execution loop. Reach for a full festival instead
+when the work needs multi-phase planning, sequencing, or quality gates.
+
 ## Common Mistakes
 
 - Using `fest link --project ...` (invalid flag).

--- a/plugins/festival/skills/fest-standalone-workflows/SKILL.md
+++ b/plugins/festival/skills/fest-standalone-workflows/SKILL.md
@@ -17,7 +17,7 @@ WORKFLOW.md -> fest next -> do step -> fest workflow advance -> repeat
 ## When to Use This vs. a Full Festival
 
 - **Standalone workflow**: a short, repeatable checklist that can live in any
-  directory — a code-review checklist, a release-cut runbook, a one-off
+  directory: a code-review checklist, a release-cut runbook, a one-off
   investigation. Minimal ceremony, no phases/sequences.
 - **Full festival**: multi-phase work that needs planning, sequencing, and
   quality gates over an extended effort. Use `fest create festival` instead
@@ -56,7 +56,7 @@ This scaffolds `WORKFLOW.md`, initializes `.workflow/` runtime state, and
 starts a tracked run, so `fest next` works immediately.
 
 `fest workflow create <name>` is an alias of `fest create workflow <name>`
-and accepts the same flags — use whichever noun you reach for first.
+and accepts the same flags. Use whichever noun you reach for first.
 
 For human interactive creation, run the command without `--steps` from a TTY:
 
@@ -80,7 +80,7 @@ It prompts for title, intent, and step lines in `Name|Goal` form.
 - `--path <dir>` / `--festival <root>`: target a festival phase instead of
   standalone mode. Inside a festival phase, or with either of these flags
   set, the command writes the phase's `WORKFLOW.md` with no standalone
-  runtime — do not pass these when you want a standalone workflow.
+  runtime, so do not pass these when you want a standalone workflow.
 
 ## Step JSON Contract
 
@@ -119,10 +119,10 @@ fest next
 
 ## Common Mistakes
 
-- Passing `--path` or `--festival` when creating a standalone workflow —
+- Passing `--path` or `--festival` when creating a standalone workflow;
   those target a festival phase instead.
 - Using `title` inside each step object. Step objects require `name` and
   `goal`, not `title`.
-- Assuming `--no-init` is required before `fest next` will work. It is not —
+- Assuming `--no-init` is required before `fest next` will work. It is not:
   the default (no flag) already initializes runtime state and starts a
   tracked run in one step.

--- a/plugins/festival/skills/fest-standalone-workflows/SKILL.md
+++ b/plugins/festival/skills/fest-standalone-workflows/SKILL.md
@@ -108,6 +108,10 @@ Valid checkpoint values:
 - `documentation`
 - `approval_required`
 
+`approval_required` is accepted when the file is created, but standalone
+execution cannot advance through blocking approval checkpoints. Use a festival
+phase when the workflow needs user-approval gates.
+
 ## Execution Loop
 
 ```bash
@@ -126,3 +130,6 @@ fest next
 - Assuming `--no-init` is required before `fest next` will work. It is not:
   the default (no flag) already initializes runtime state and starts a
   tracked run in one step.
+- Adding `approval_required` to a standalone workflow. The file will validate
+  at creation time, but `fest workflow advance` cannot cross that blocking
+  checkpoint outside a festival phase.

--- a/plugins/festival/skills/fest-standalone-workflows/SKILL.md
+++ b/plugins/festival/skills/fest-standalone-workflows/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: fest-standalone-workflows
+description: Create and run lightweight standalone `WORKFLOW.md` loops with `fest create workflow`, `fest next`, and `fest workflow advance`. Use when a user wants step-by-step workflow guidance inside any ordinary directory, explore/design work item, project folder, or thin-start workflow.
+---
+
+# Fest Standalone Workflows
+
+Use a standalone `WORKFLOW.md` when work needs a guided step loop in an ordinary
+directory, without setting up a full festival (phases/sequences/tasks).
+
+Thin-start loop:
+
+```text
+WORKFLOW.md -> fest next -> do step -> fest workflow advance -> repeat
+```
+
+## When to Use This vs. a Full Festival
+
+- **Standalone workflow**: a short, repeatable checklist that can live in any
+  directory — a code-review checklist, a release-cut runbook, a one-off
+  investigation. Minimal ceremony, no phases/sequences.
+- **Full festival**: multi-phase work that needs planning, sequencing, and
+  quality gates over an extended effort. Use `fest create festival` instead
+  (see the `fest-planning` skill).
+
+## Create
+
+Run from the directory that should own the workflow:
+
+```bash
+mkdir -p my-workflow && cd my-workflow
+
+fest create workflow my-workflow --steps '{
+  "title": "My Workflow",
+  "description": "A lightweight guided loop.",
+  "steps": [
+    {
+      "name": "PLAN",
+      "goal": "Decide what needs to happen.",
+      "actions": ["Write the goal.", "List the unknowns."],
+      "checkpoint": "none"
+    },
+    {
+      "name": "DO",
+      "goal": "Do the work.",
+      "actions": ["Make the change.", "Validate it."],
+      "checkpoint": "verification"
+    }
+  ]
+}'
+
+fest next
+```
+
+This scaffolds `WORKFLOW.md`, initializes `.workflow/` runtime state, and
+starts a tracked run, so `fest next` works immediately.
+
+`fest workflow create <name>` is an alias of `fest create workflow <name>`
+and accepts the same flags — use whichever noun you reach for first.
+
+For human interactive creation, run the command without `--steps` from a TTY:
+
+```bash
+fest create workflow my-workflow
+```
+
+It prompts for title, intent, and step lines in `Name|Goal` form.
+
+## Flags
+
+- `--steps '<json>'` / `--steps-file <file>`: agent mode, inline JSON or a
+  JSON file. See the step schema below.
+- `--agent`: strict agent mode (implies `--json`).
+- `--type <type>`: standalone workflow type (default `task`).
+- `--no-init`: advanced mode. Writes `WORKFLOW.md` only, without initializing
+  `.workflow/` runtime state or starting a run. `fest next` still works in
+  this mode, but reports the workflow as not-started; the first mutating
+  command (`fest workflow advance`) bootstraps a tracked run lazily. Use this
+  when you want to author the document before committing to a tracked run.
+- `--path <dir>` / `--festival <root>`: target a festival phase instead of
+  standalone mode. Inside a festival phase, or with either of these flags
+  set, the command writes the phase's `WORKFLOW.md` with no standalone
+  runtime — do not pass these when you want a standalone workflow.
+
+## Step JSON Contract
+
+Workflow-level fields:
+
+- `title` (required)
+- `description` (optional)
+- `steps` (required, non-empty)
+
+Each step needs:
+
+- `name`
+- `goal`
+
+Useful optional step fields:
+
+- `actions`
+- `output`
+- `checkpoint`
+
+Valid checkpoint values:
+
+- `none`
+- `verification`
+- `documentation`
+- `approval_required`
+
+## Execution Loop
+
+```bash
+fest next
+# do the visible step
+fest workflow advance
+fest next
+```
+
+## Common Mistakes
+
+- Passing `--path` or `--festival` when creating a standalone workflow —
+  those target a festival phase instead.
+- Using `title` inside each step object. Step objects require `name` and
+  `goal`, not `title`.
+- Assuming `--no-init` is required before `fest next` will work. It is not —
+  the default (no flag) already initializes runtime state and starts a
+  tracked run in one step.


### PR DESCRIPTION
## Summary

Part 3 of intent `make-standalone-workflowmd-creation-discoverable-20260617-092756`. Parts 1 (fest CLI `fest workflow create` alias) and 2 (canonical campaign skill) were already done outside this repo; this PR closes the remaining gap: the distributed plugin skill sets shipped no documentation for standalone `WORKFLOW.md` creation.

- Adds a `fest-standalone-workflows` skill, adapted from the private campaign's canonical skill but rewritten to be self-contained for external users (no references to personal campaigns or local paths).
- Adds a short "Standalone WORKFLOW.md (Outside a Festival)" pointer section to the `fest-planning` skill, cross-referencing the new skill and covering `fest create workflow` / `fest workflow create`, the `--steps`/`--steps-file` agent-mode JSON, `--type`, and `--no-init`.
- Every CLI claim in the new skill was verified against the actual `fest dev` binary on this machine (`fest create workflow --help`, `fest workflow create --help`), and by running `fest create workflow` end-to-end in a scratch directory. One correction versus the private canonical skill: `--no-init` is not required for `fest next` to work immediately — the default (no flag) already initializes `.workflow/` and starts a tracked run in one step. `--no-init` is the advanced/opt-out mode, so the plugin skill documents it that way instead of copying the canonical skill's "always pass `--no-init`" guidance verbatim.

## Sync mechanism finding

The four plugin skill sets are **not** hand-maintained copies. `claude-plugin/skills/` is the single source of truth, and `packaging/generate.mjs` (run via `just plugin generate`) reads it and regenerates every other surface:

- `.opencode/skills/`
- `.cursor-plugin/skills/`
- `plugins/festival/skills/` (the actual Codex target — there is no root-level `.codex-plugin/` directory; Codex's plugin root is `plugins/festival/`)
- `AGENTS.md`, `GEMINI.md`, and `gemini-extension.json` (skill list/imports, generated from the same source)

So this PR only hand-edits two files under `claude-plugin/skills/` (the new skill plus the `fest-planning` pointer) and lets `just plugin generate` produce the other 11 changed/added files. The diff is otherwise identical everywhere, as expected from a single source of truth.

## Gates run

- `just plugin check` — passed (commit-guard tests, CLI-reference check, plugin smoke all green).
- `just test plugin` — passed (same check, via the test recipe).
- `bash scripts/check-doc-sync.sh` — skipped by design (requires sibling `../camp`/`../fest` checkouts not present in this worktree layout); not applicable to this diff since it only checks README/doc mirrors unrelated to plugin skills.

## Files changed

- `claude-plugin/skills/fest-standalone-workflows/SKILL.md` (new, source of truth)
- `claude-plugin/skills/fest-planning/SKILL.md` (new pointer section)
- `.opencode/skills/fest-standalone-workflows/SKILL.md`, `.opencode/skills/fest-planning/SKILL.md`, `.opencode/INSTALL.md` (generated)
- `.cursor-plugin/skills/fest-standalone-workflows/SKILL.md`, `.cursor-plugin/skills/fest-planning/SKILL.md`, `.cursor-plugin/README.md` (generated)
- `plugins/festival/skills/fest-standalone-workflows/SKILL.md`, `plugins/festival/skills/fest-planning/SKILL.md`, `plugins/festival/README.md` (generated, Codex target)
- `AGENTS.md`, `GEMINI.md` (generated skill list/imports)

## Deviations from the task brief

- The brief listed `.codex-plugin/skills/fest-planning/` as a path to update. That directory does not exist at the repo root; the actual generated Codex target lives at `plugins/festival/skills/` (see `packaging/targets/codex.target.mjs`). Updated the real path instead.
- Did not modify the private campaign's canonical `fest-planning` skill (out of scope — this PR only touches the `festival` repo) but note for the record: as of this PR, that canonical skill still has no pointer to `fest-standalone-workflows`, and its `--no-init` guidance does not match verified current CLI behavior. Flagging as a possible follow-up outside this repo.

## Test plan

- [x] `just plugin generate` run cleanly against the new source files, producing exactly the expected file set
- [x] `just plugin check` / `just test plugin` pass
- [x] Manually verified `fest create workflow` / `fest workflow create` flags and default (non-`--no-init`) behavior against the real `fest dev` binary in a scratch directory
- [ ] Human review of skill wording/tone