### PR TITLE
chore: pin camp to v0.3.0 stable and refresh camp CLI docs

### DIFF
--- a/docs/cli-reference/camp/camp_workitem.md
+++ b/docs/cli-reference/camp/camp_workitem.md
@@ -53,7 +53,7 @@ camp workitem [flags]
 ### SEE ALSO
 
 * [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
-* [camp workitem adopt](../camp_workitem_adopt/)	 - Adopt an existing directory as a workitem
+* [camp workitem adopt](../camp_workitem_adopt/)	 - Adopt an existing directory or file as a workitem
 * [camp workitem commit](../camp_workitem_commit/)	 - Commit changes scoped to a workitem
 * [camp workitem commits](../camp_workitem_commits/)	 - List commits referencing a workitem
 * [camp workitem create](../camp_workitem_create/)	 - Create workitem tracking metadata

--- a/docs/cli-reference/camp/camp_workitem_adopt.md
+++ b/docs/cli-reference/camp/camp_workitem_adopt.md
@@ -1,35 +1,42 @@
 ---
 title: "camp workitem adopt"
 linkTitle: "camp workitem adopt"
-description: "Adopt an existing directory as a workitem"
+description: "Adopt an existing directory or file as a workitem"
 ---
 
 ## camp workitem adopt
 
-Adopt an existing directory as a workitem
+Adopt an existing directory or file as a workitem
 
 ### Synopsis
 
-Attach workitem metadata to an existing campaign directory without moving it.
+Attach workitem metadata to an existing campaign directory or markdown file.
 
-The target directory must already exist and must not already contain a
-.workitem file. The command writes that .workitem metadata file with the
-selected type, title, generated or supplied id, and optional quest link. Use
-this when a workflow directory already exists and needs to become a tracked
-workitem.
+With a directory argument, writes a .workitem marker (the directory must exist
+and must not already contain a .workitem). With --file <path.md>, stamps a
+kind: workitem frontmatter block onto an existing markdown file without ever
+rewriting its body: it prepends a block when the file has none, merges camp's
+keys into a foreign block (refusing an ambiguous foreign tags: key without
+--force), and updates tags/projects when the file is already a workitem. In all
+cases it sets the selected type, title, generated or supplied id, optional quest
+link, optional tags, and optional related projects.
 
 ```
-camp workitem adopt <dir> [flags]
+camp workitem adopt [dir] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help           help for adopt
-      --id string      override the generated id
-      --quest string   quest ID to associate (requires dev-profile camp; forward-compatible flag)
-      --title string   human-readable title
-      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+      --file string           stamp kind: workitem frontmatter onto a markdown file instead of adopting a directory
+      --force                 with --file, take ownership of an existing foreign tags: key (union conforming values, drop and report non-conforming ones)
+  -h, --help                  help for adopt
+      --id string             override the generated id
+      --project stringArray   add a related project path (repeatable, e.g. projects/camp)
+      --quest string          quest ID to associate (requires dev-profile camp; forward-compatible flag)
+      --tag stringArray       add a tag (repeatable, normalized to lowercase kebab-case)
+      --title string          human-readable title
+      --type string           workitem type (feature, bug, chore, or custom) (default "feature")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp/camp_workitem_create.md
+++ b/docs/cli-reference/camp/camp_workitem_create.md
@@ -16,7 +16,8 @@ This command does NOT create the substantive work scaffold (no design docs,
 explore notes, or festival structure). It only:
 
   1. Creates workflow/<type>/<slug>/ (or --dir/<slug>/)
-  2. Writes a .workitem marker (id, type, title, ref, optional quest)
+  2. Writes a .workitem marker (id, type, title, ref, optional quest, optional
+     tags, optional related projects)
 
 Agents and humans must still add real content afterward. For explore/design
 types, the recommended structured-workflow scaffold is:
@@ -37,13 +38,16 @@ camp workitem create <slug> [flags]
 ### Options
 
 ```
-      --dir string     parent dir override (default: workflow/<type>)
-  -h, --help           help for create
-      --id string      override the generated id
-      --json           emit a structured JSON result
-      --quest string   quest ID to associate (requires dev-profile camp; forward-compatible flag)
-      --title string   human-readable title
-      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+      --dir string            parent dir override (default: workflow/<type>)
+      --file string           create a new markdown file with kind: workitem frontmatter instead of a directory workitem
+  -h, --help                  help for create
+      --id string             override the generated id
+      --json                  emit a structured JSON result
+      --project stringArray   add a related project path (repeatable, e.g. projects/camp)
+      --quest string          quest ID to associate (requires dev-profile camp; forward-compatible flag)
+      --tag stringArray       add a tag (repeatable, normalized to lowercase kebab-case)
+      --title string          human-readable title
+      --type string           workitem type (feature, bug, chore, or custom) (default "feature")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp/camp_workitem_link.md
+++ b/docs/cli-reference/camp/camp_workitem_link.md
@@ -21,6 +21,11 @@ A primary worktree link is how design/explore workitems under workflow/ get
 into camp p commit tags: when you commit from that worktree, the resolver
 matches the link and stamps WI-<ref> on the subject.
 
+Note: role:related links to a project scope are no longer accepted; a workitem's
+related projects live in its own projects: field. Use "camp workitem
+create/adopt --project <path>" (or edit the .workitem/frontmatter) instead of
+"--role related --project".
+
 Examples:
   camp workitem link WI-2a7950 --worktree fest/fest-list-watch
   camp workitem link workflow/design/fest-list-watch --worktree projects/worktrees/fest/fest-list-watch

--- a/docs/cli-reference/camp/camp_workitem_list.md
+++ b/docs/cli-reference/camp/camp_workitem_list.md
@@ -23,6 +23,7 @@ Examples:
   camp workitem list intent
   camp workitem list active
   camp workitem list --category research --query auth
+  camp workitem list --tag public-launch --tag schema
   camp workitem list festival --status ready --json
 
 ```
@@ -39,10 +40,12 @@ camp workitem list [type|status|category] [flags]
   -h, --help                          help for list
       --json                          Output as JSON
       --limit int                     Maximum number of items to return (non-interactive / --json only)
+      --project stringArray           Filter by related project (repeat for OR)
       --query string                  Search query to filter items
       --show-parked                   Include parked attention-stage workitems
       --stage stringArray             Filter by lifecycle stage (repeat for OR)
       --status stringArray            Filter by displayed status: current, next, active, parked, inbox, ready, plan, ritual, chains, none (repeat for OR)
+      --tag stringArray               Filter by tag (repeat; item must have ALL given tags)
       --type stringArray              Filter by workflow type (repeat for OR)
 ```
 


### PR DESCRIPTION
Pins the camp submodule to the **v0.3.0** stable release (tag target `b06ca18f`), the final blocking checkpoint of festival WS0001 (workitem schema v1alpha8).

What v0.3.0 ships (camp PRs #464, #468, #469, #471):
- Workitem marker schema `v1alpha8`: `tags:` and co-located `projects:` on the identity document
- Document-only workitems via `kind: workitem` frontmatter under `workflow/**`
- `list --tag` (AND within dimension) and `--project` (OR) filters
- `adopt --file` / `create --file` with deterministic frontmatter stamping
- File lifecycle verbs; links.yaml related+project rows rejected + doctor migration
- JSON contract `workitems/v1alpha9` with merged `{path, primary}` projects view
- Rollout contract verified by an integration test that builds the real pre-reader binary (v0.3.0-rc.2) and proves it hard-fails on a v1alpha8 campaign

Docs: only the five camp workitem CLI reference pages change (regenerated from the pinned binary).

fest pin intentionally untouched: a newer fest stable exists, but its refresh (new commands, config-path doc changes) is unrelated to this release and belongs to its own PR.

Verification: full camp gate + 515/515 containerized integration tests green at `b06ca18f`; GitHub release v0.3.0 published and marked latest; binary built from the tag reports `commit b06ca18f`.