### PR TITLE
docs: explain how to find camp/fest binary paths after shell-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ source ~/.local/share/festival/shell/festival.zsh
 eval "$(camp shell-init zsh)"
 eval "$(fest shell-init zsh)"
 
+# Finding the installed binaries:
+# After shell-init, `camp` and `fest` are shell functions so they can `cd`.
+# Plain `which camp` / `which fest` prints the function, not a path.
+# Use:  whence -p camp   # zsh external binary
+#       whence -p fest
+#       type -P camp     # bash
+#       type -a camp     # function + every PATH binary
+#       realpath "$(whence -p camp)"
+# Or run the binary directly: command camp version
+
 # Create a campaign
 camp init my-project && cd my-project
 
@@ -274,6 +284,34 @@ For bash, use `festival.bash`; for fish, use `festival.fish`. If no helper file 
 eval "$(camp shell-init zsh)"   # gives you: cgo, cr, csw, cint
 eval "$(fest shell-init zsh)"   # gives you: fgo, fls
 ```
+
+### Finding the installed binaries
+
+Shell integration defines `camp` and `fest` as **shell functions** so navigation
+commands can `cd` in your current shell. Because of that, plain `which camp` /
+`which fest` usually prints the function body, not a filesystem path.
+
+```bash
+# zsh — path of the external binary (skips shell functions)
+whence -p camp
+whence -p fest
+# or: which -p camp / which -p fest
+
+# bash
+type -P camp
+type -P fest
+
+# show the function plus every binary on PATH
+type -a camp
+type -a fest
+
+# resolve symlinks to the real install
+realpath "$(whence -p camp)"   # zsh
+realpath "$(type -P camp)"     # bash
+```
+
+To run a binary without the wrapper (scripts, debugging): `command camp version`
+or `command fest version`.
 
 ### cgo: jump anywhere in your workspace
 

--- a/docs/getting-started/shell-setup.md
+++ b/docs/getting-started/shell-setup.md
@@ -49,3 +49,32 @@ fest shell-init fish | source
 ### camp shell functions
 
 - `cgo` - Navigate between campaign projects with fuzzy finding
+
+## Finding the installed binaries
+
+Shell integration defines `camp` and `fest` as **shell functions** so
+navigation commands can `cd` in your current shell. Because of that, plain
+`which camp` / `which fest` usually prints the function body, not a filesystem
+path.
+
+```bash
+# zsh — path of the external binary (skips shell functions)
+whence -p camp
+whence -p fest
+# or: which -p camp / which -p fest
+
+# bash
+type -P camp
+type -P fest
+
+# show the function plus every binary on PATH
+type -a camp
+type -a fest
+
+# resolve symlinks to the real install
+realpath "$(whence -p camp)"   # zsh
+realpath "$(type -P camp)"     # bash
+```
+
+To run a binary without the wrapper (scripts, debugging): `command camp version`
+or `command fest version`.


### PR DESCRIPTION
## Summary
- Document that shell integration defines `camp` and `fest` as shell functions, so plain `which` prints the function body instead of a path.
- Show the correct discovery commands in the main README (quick start + navigation) and shell-setup docs.
- Cover zsh (`whence -p` / `which -p`), bash (`type -P`), `type -a`, and `realpath`.

## Test plan
- [ ] Read the new README and shell-setup sections for clarity
- [ ] After Festival shell setup, confirm `whence -p camp` and `whence -p fest` return binary paths while plain `which` shows functions