### PR TITLE
chore(release): pin camp v0.3.1 and fest v0.4.11

### DIFF
--- a/docs/cli-reference/camp/camp_commit.md
+++ b/docs/cli-reference/camp/camp_commit.md
@@ -22,6 +22,10 @@ machines. Use --include-refs to stage them explicitly.
 Use --sub to commit in the submodule detected from your current directory.
 Use -p/--project to commit in a specific project (e.g., -p projects/camp).
 
+Commit tags use explicit --workitem or context from the current path. They do
+not inherit the per-machine current workitem selection, which can be stale;
+use 'camp workitem commit' when you want current.yaml scoping.
+
 Examples:
   camp commit -m "Add new feature"
   camp commit --amend -m "Fix typo"

--- a/docs/cli-reference/camp/camp_list.md
+++ b/docs/cli-reference/camp/camp_list.md
@@ -17,9 +17,15 @@ with 'camp register'. The registry lives at ~/.obey/campaign/registry.json.
 
 In a terminal, 'camp list' (with no flags) opens an interactive browser where you
 can deactivate/reactivate campaigns (cycle lifecycle status), reassign their org,
-and copy paths. Pass an org as a positional argument to open the browser filtered
-to that org. Piped, with --json/--count, or with any filter/sort flag it prints
-the table instead. Home paths display as '~'.
+and copy paths. When machines are configured in ~/.obey/machines.yaml, press 'r'
+to load remote campaigns into the browser (not on open). Pass an org as a
+positional argument to open the browser filtered to that org. Piped, with
+--json/--count, or with any filter/sort flag it prints the table instead. Home
+paths display as '~'.
+
+Shell integration (recommended for go/hop from the browser):
+  eval "$(camp shell-init zsh)"   # or bash / fish
+  camp list                       # interactive browser; g hops remote rows
 
 Output formats:
   table   - Aligned columns with headers (default)
@@ -47,6 +53,9 @@ Examples:
 (sh -lc) so PATH entries a login profile exports (~/.profile, etc.) are
 picked up. If camp still can't be found on a machine, set
 CAMP_REMOTE_CAMP_PATH to its exact path there.
+
+For interactive hop to a remote campaign from the picker, use csw after
+shell-init (see 'camp switch --help').
 
 ```
 camp list [org] [flags]

--- a/docs/cli-reference/camp/camp_machine.md
+++ b/docs/cli-reference/camp/camp_machine.md
@@ -16,9 +16,13 @@ and 'camp list --remote'.
 Machines are stored in ~/.obey/machines.yaml. The current machine is always
 implicitly available as "local" and is never written to that file.
 
-'camp machine diagnose' inspects the per-machine ssh ControlMaster sockets and
-can clear a stale one (the state a sleep or network flap can leave behind, which
-would otherwise hang the next hop until ControlPersist expires).
+Network vs login: Tailscale (or LAN) is how you reach the host; SSH auth is how
+you log in. Prefer OpenSSH keys/agent (auth_method=ssh-agent) by default;
+Tailscale SSH (auth_method=tailscale-ssh) is opt-in identity login. Terminal
+hops always use BatchMode (agents never hang on password prompts).
+
+'camp machine diagnose' reports auth mode, a copy-paste ssh probe, and
+ControlMaster socket state (and can clear a stale socket with --reset).
 
 Run without a subcommand in a terminal to manage the fleet interactively: add,
 discover, edit, and remove machines, and see each one's socket state. The
@@ -34,8 +38,10 @@ camp machine [flags]
 ```
   camp machine
   camp machine list
+  camp machine add buildbox --host 10.0.0.12 --auth ssh-agent --user ci
   camp machine add devbox --host devbox.tailnet.ts.net --auth tailscale-ssh
   camp machine add --discover
+  camp machine add --discover --auth tailscale-ssh --user lance
   camp machine remove devbox
   camp machine diagnose
   camp machine diagnose devbox --reset
@@ -57,6 +63,6 @@ camp machine [flags]
 
 * [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
 * [camp machine add](../camp_machine_add/)	 - Add or update a machine
-* [camp machine diagnose](../camp_machine_diagnose/)	 - Inspect (and optionally clear) ssh ControlMaster sockets
+* [camp machine diagnose](../camp_machine_diagnose/)	 - Inspect machine auth, probe line, and ssh ControlMaster sockets
 * [camp machine list](../camp_machine_list/)	 - List configured machines
 * [camp machine remove](../camp_machine_remove/)	 - Remove a machine

--- a/docs/cli-reference/camp/camp_machine_add.md
+++ b/docs/cli-reference/camp/camp_machine_add.md
@@ -15,10 +15,11 @@ Add a machine to ~/.obey/machines.yaml, or update it if the id already exists
 than duplicating it).
 
 With --discover, camp runs 'tailscale status --json' and lets you pick a
-tailnet device instead of specifying --host/--auth by hand; the chosen device
-is saved with auth_method=tailscale-ssh. Pass an id positionally with
---discover to select that device by its derived id non-interactively (skips
-the picker), or use --yes to take the first discovered device.
+tailnet device (network identity only). Default auth is OpenSSH keys/agent
+(ssh-agent); pass --auth tailscale-ssh for Tailscale identity login. --user and
+--identity are honored with --discover. Pass an id positionally with --discover
+to select that device by its derived id non-interactively (skips the picker),
+or use --yes to take the first discovered device.
 
 ```
 camp machine add [id] [flags]
@@ -27,9 +28,10 @@ camp machine add [id] [flags]
 ### Examples
 
 ```
-  camp machine add devbox --host devbox.tailnet.ts.net --auth tailscale-ssh
   camp machine add buildbox --host 10.0.0.12 --auth ssh-agent --user ci
+  camp machine add devbox --host devbox.tailnet.ts.net --auth tailscale-ssh
   camp machine add --discover
+  camp machine add --discover --auth tailscale-ssh --user lance
   camp machine add devbox --discover
   camp machine add --discover --yes
 ```

--- a/docs/cli-reference/camp/camp_machine_diagnose.md
+++ b/docs/cli-reference/camp/camp_machine_diagnose.md
@@ -1,21 +1,24 @@
 ---
 title: "camp machine diagnose"
 linkTitle: "camp machine diagnose"
-description: "Inspect (and optionally clear) ssh ControlMaster sockets"
+description: "Inspect machine auth, probe line, and ssh ControlMaster sockets"
 ---
 
 ## camp machine diagnose
 
-Inspect (and optionally clear) ssh ControlMaster sockets
+Inspect machine auth, probe line, and ssh ControlMaster sockets
 
 ### Synopsis
 
-Report the ssh ControlMaster multiplex socket state for each configured machine
-(or one machine if an id is given):
+Report how each configured machine is set up to hop (or one machine if an id
+is given):
 
-  none   no socket — the next hop opens a fresh master
-  live   socket present and the master answers 'ssh -O check'
-  stale  socket present but the master no longer answers
+  auth     OpenSSH (keys/agent) or Tailscale SSH (identity)
+  probe    copy-paste BatchMode ssh line to test outside camp
+  socket   ControlMaster multiplex state:
+             none   no socket — the next hop opens a fresh master
+             live   socket present and the master answers 'ssh -O check'
+             stale  socket present but the master no longer answers
 
 A stale socket is what a sleep or network flap can leave behind; until it is
 removed (or ControlPersist expires) the next 'camp switch machine:...' or

--- a/docs/cli-reference/camp/camp_project_commit.md
+++ b/docs/cli-reference/camp/camp_project_commit.md
@@ -15,6 +15,10 @@ Commit changes within a project submodule.
 Auto-detects the current project from your working directory,
 or use --project to specify a project by name.
 
+Commit tags use explicit --workitem or context from the current path. They do
+not inherit the per-machine current workitem selection, which can be stale;
+use 'camp workitem commit' when you want current.yaml scoping.
+
 Examples:
   # From within a project directory
   cd projects/my-api

--- a/docs/cli-reference/camp/camp_skills.md
+++ b/docs/cli-reference/camp/camp_skills.md
@@ -13,8 +13,15 @@ Manage campaign skill directory links
 Manage campaign skill bundle projection for tool interoperability.
 
 Skills are centralized in .campaign/skills/ and projected into tool ecosystems
-(Claude, agents, etc.) as per-bundle symlinks. This keeps a single source of
-truth while preserving existing provider-native skills directories.
+(Claude, agents, Grok, etc.) as per-bundle symlinks. This keeps a single source
+of truth while preserving existing provider-native skills directories.
+
+Project worktrees under projects/worktrees/<project>/<name>/ are also supported:
+'camp project worktree add' projects skills into each new worktree automatically,
+and 'camp skills link --worktrees' repairs all of them. That way harnesses whose
+git root is the worktree (not the campaign root) still discover campaign skills.
+Only git checkouts are projected (directory must contain .git). A loose git root
+at projects/worktrees/<name>/ is accepted; package subdirs under it are not.
 
 Commands:
   link     Project per-skill symlinks into a tool-specific skills directory
@@ -24,6 +31,8 @@ Commands:
 Examples:
   camp skills link --tool claude    Project skills into .claude/skills/
   camp skills link --tool agents    Project skills into .agents/skills/
+  camp skills link --worktrees      Project into tools and every project worktree
+  camp skills link --worktrees-only Project into project worktrees only
   camp skills status                Show all skill projection states
   camp skills unlink --tool claude  Remove projected symlinks from .claude/skills/
 

--- a/docs/cli-reference/camp/camp_skills_link.md
+++ b/docs/cli-reference/camp/camp_skills_link.md
@@ -17,9 +17,20 @@ This command creates one symlink per skill bundle. It does not replace entire
 provider skills directories, so existing user skills remain intact.
 
 With neither --tool nor --path, skills are projected into every registered tool.
+Pass --worktrees with no --tool/--path to also project into every
+projects/worktrees/<project>/<name> git checkout (so Grok/Claude sessions
+opened inside a worktree still see campaign skills). Use --worktrees-only to
+project into worktrees without touching campaign-root tool directories.
+
+Worktree discovery only includes directories with a .git file/dir. The normal
+layout is projects/worktrees/<project>/<name>/. A loose git root at
+projects/worktrees/<name>/ is also accepted; nested dirs under that root are
+not scanned as separate worktrees.
 
 Examples:
   camp skills link                     Project skills into all registered tools
+  camp skills link --worktrees         Project into tools and every project worktree
+  camp skills link --worktrees-only    Project into every project worktree only
   camp skills link --tool claude       Project skills into .claude/skills/
   camp skills link --tool agents       Project skills into .agents/skills/
   camp skills link --path custom/dir   Project skills into custom/dir
@@ -33,11 +44,13 @@ camp skills link [flags]
 ### Options
 
 ```
-  -n, --dry-run       Show what would happen without making changes
-  -f, --force         Replace conflicting symlink entries (never files/directories)
-  -h, --help          help for link
-  -p, --path string   Custom destination directory
-  -t, --tool string   Tool to link: claude, agents
+  -n, --dry-run          Show what would happen without making changes
+  -f, --force            Replace conflicting symlink entries (never files/directories)
+  -h, --help             help for link
+  -p, --path string      Custom destination directory
+  -t, --tool string      Tool to link: claude, agents
+      --worktrees        Also project into every projects/worktrees/*/* worktree
+      --worktrees-only   Project only into project worktrees (skip campaign tool dirs)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp/camp_switch.md
+++ b/docs/cli-reference/camp/camp_switch.md
@@ -16,13 +16,15 @@ Without arguments, opens an interactive picker to select a campaign.
 With an argument, looks up the campaign by name or ID prefix.
 Use --org or org/campaign to resolve inside one organization.
 
-Use with the cgo shell function for instant navigation:
-  cgo switch                 # Interactive campaign picker
-  cgo switch my-campaign     # Switch by name
-  cgo switch a1b2             # Switch by ID prefix
-  cgo switch obey/platform    # Switch by org-scoped selector
+Use with the shell-init wrappers for instant navigation (recommended):
+  eval "$(camp shell-init zsh)"   # or bash / fish — once per shell
+  csw                            # Interactive picker (local + remote machines)
+  csw my-campaign                # Switch by name
+  csw a1b2                       # Switch by ID prefix
+  csw obey/platform              # Switch by org-scoped selector
+  csw archdtop:lance-arch        # Hop to a remote campaign over ssh
 
-The --print flag outputs just the path for shell integration:
+The --print flag outputs just the path for shell integration (local only):
   cd "$(camp switch --print)"
 
 Use campaign@tab to navigate to a specific location in the target campaign:
@@ -30,8 +32,10 @@ Use campaign@tab to navigate to a specific location in the target campaign:
   camp switch obey/platform@f    # Switch inside org and navigate to festivals/
 
 Use machine:campaign to resolve a campaign on a machine registered in
-~/.obey/machines.yaml (via the csw shell wrapper, which hops there over ssh):
-  csw devbox:obey-campaign       # Resolve and hop to obey-campaign on devbox
+~/.obey/machines.yaml. The interactive picker also lists remote campaigns when
+machines are configured (locals open instantly; remotes append as they load).
+Bare 'command camp switch machine:…' resolves without hopping — use the csw
+shell wrapper (or --shell-connect under shell-init) to hop.
 
 Remote resolution runs the far machine's own 'camp switch' through a login
 shell (sh -lc) so PATH entries a login profile exports (~/.profile, etc.) are
@@ -45,12 +49,14 @@ camp switch [campaign] [flags]
 ### Examples
 
 ```
-  camp switch                        # Interactive picker
-  camp switch obey-campaign          # Switch by name
+  eval "$(camp shell-init zsh)"
+  csw                                # Interactive picker (local + remotes)
+  csw obey-campaign                  # Switch by name
+  csw archdtop:lance-arch            # Hop to remote campaign
   camp switch --org obey platform    # Switch by name within an org
   camp switch obey/platform          # Switch by scoped selector
   camp switch a1b2                   # Switch by ID prefix
-  camp switch --print                # Picker, output path only
+  camp switch --print                # Picker, output path only (local)
   camp switch obey-campaign@p        # Switch and navigate to projects/
   camp switch --all old-reference    # Include inactive/reference campaigns
   camp switch --org obey platform --json

--- a/docs/cli-reference/camp/camp_workitem.md
+++ b/docs/cli-reference/camp/camp_workitem.md
@@ -60,14 +60,17 @@ camp workitem [flags]
 * [camp workitem current](../camp_workitem_current/)	 - Get, set, or clear the current workitem
 * [camp workitem doctor](../camp_workitem_doctor/)	 - Report link-registry health issues
 * [camp workitem group](../camp_workitem_group/)	 - Set or clear the group
+* [camp workitem id](../camp_workitem_id/)	 - Print the identifier of a workitem
 * [camp workitem link](../camp_workitem_link/)	 - Create a workitem link
 * [camp workitem links](../camp_workitem_links/)	 - List workitem links
 * [camp workitem list](../camp_workitem_list/)	 - List or browse filtered workitems
 * [camp workitem priority](../camp_workitem_priority/)	 - Set or clear the manual priority
 * [camp workitem promote](../camp_workitem_promote/)	 - Promote a workitem to a festival, doc, or dungeon
+* [camp workitem rename](../camp_workitem_rename/)	 - Rename a workitem and repair references
 * [camp workitem repair](../camp_workitem_repair/)	 - Repair a workflow directory into a workitem
 * [camp workitem resolve](../camp_workitem_resolve/)	 - Print the workitem for the current context
 * [camp workitem stage](../camp_workitem_stage/)	 - Set or clear the attention stage
+* [camp workitem sweep](../camp_workitem_sweep/)	 - Promote workitems with completed runs
 * [camp workitem unlink](../camp_workitem_unlink/)	 - Remove workitem links
 * [camp workitem validate](../camp_workitem_validate/)	 - Validate workitem directories
 * [camp workitem worktree](../camp_workitem_worktree/)	 - Create a project worktree from a workitem

--- a/docs/cli-reference/camp/camp_workitem_id.md
+++ b/docs/cli-reference/camp/camp_workitem_id.md
@@ -1,0 +1,54 @@
+---
+title: "camp workitem id"
+linkTitle: "camp workitem id"
+description: "Print the identifier of a workitem"
+---
+
+## camp workitem id
+
+Print the identifier of a workitem
+
+### Synopsis
+
+Print the stable identifier of a workitem.
+
+With no argument, the workitem is detected from the current context using the
+same tiered resolution as `camp workitem resolve` (explicit selector, cwd
+ancestor, linked scope, festival, current-workitem pointer). With an argument,
+the workitem is resolved through the shared selector family: workitem ref,
+stable id, key, campaign-relative path, directory slug, or festival id. A
+filesystem path (absolute or relative to the current directory) is accepted and
+translated to the campaign-relative form the selector expects.
+
+The bare stable id is written to stdout for shell scripting; it is the id sibling
+of `camp workitem --print`, which prints a path. Use --key for the
+path-derived key instead, or --json for a structured object.
+
+Examples:
+  camp workitem id                       # id of the workitem for the cwd
+  camp workitem id design-x-2026-05-24   # echoes back the stable id
+  camp workitem id ./workflow/design/x   # resolves a filesystem path
+  camp workitem id --key                 # print the <type>:<path> key form
+  camp workitem id --json SC0001         # structured object for a festival
+
+```
+camp workitem id [selector-or-path] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for id
+      --json   emit a structured JSON result
+      --key    print the path-derived key instead of the stable id
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_rename.md
+++ b/docs/cli-reference/camp/camp_workitem_rename.md
@@ -1,0 +1,49 @@
+---
+title: "camp workitem rename"
+linkTitle: "camp workitem rename"
+description: "Rename a workitem and repair references"
+---
+
+## camp workitem rename
+
+Rename a workitem and repair references
+
+### Synopsis
+
+Rename the workitem matched by <selector> so its directory (or file)
+basename becomes <new-name>. Identity is preserved: the stable id, ref, title,
+type, and lifecycle status do not change; only the path basename moves.
+
+References are repaired in the same commit as the move:
+  - relative markdown links pointing at the workitem are rewritten
+  - the workitem link registry (links.yaml) key and any scope paths under the
+    renamed directory are updated
+  - manual priority and attention-stage entries are re-keyed on disk
+  - the current-workitem pointer is updated when it referenced the old path key
+
+Festivals and intents are managed by their own tooling and cannot be renamed
+here. For file workitems, pass the full new filename; the original extension is
+kept when omitted.
+
+```
+camp workitem rename <selector> <new-name> [flags]
+```
+
+### Options
+
+```
+      --dry-run     Print the planned rename, change nothing
+  -h, --help        help for rename
+      --json        Output result as a single JSON object
+      --no-commit   Skip the auto-commit
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_sweep.md
+++ b/docs/cli-reference/camp/camp_workitem_sweep.md
@@ -1,0 +1,47 @@
+---
+title: "camp workitem sweep"
+linkTitle: "camp workitem sweep"
+description: "Promote workitems with completed runs"
+---
+
+## camp workitem sweep
+
+Promote workitems with completed runs
+
+### Synopsis
+
+Promote every workitem whose active workflow run has completed to its
+local dungeon (tier-1 evidence-driven completion).
+
+Only loop-completion evidence (workflow_run_completed) drives this sweep, and it
+only ever auto-promotes; merged-branch evidence is handled separately by camp
+fresh, which prompts. Festivals and intents are excluded.
+
+Each eligible item moves independently: a failure on one (dirty git state, a
+path collision at its destination) is reported and the sweep continues to the
+next. Use --dry-run to see the plan without moving anything, and --json for a
+structured result. In table mode any per-item failure yields a non-zero exit,
+matching camp fresh; --json reports failures in the payload (failed count and
+per-item error) and stays exit 0 so the structured result is the contract.
+
+```
+camp workitem sweep [flags]
+```
+
+### Options
+
+```
+      --dry-run   Print the sweep plan, change nothing
+  -h, --help      help for sweep
+      --json      Output result as a single JSON object
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/fest/fest.md
+++ b/docs/cli-reference/fest/fest.md
@@ -60,6 +60,7 @@ Run 'fest understand' to learn the methodology before executing tasks.
 * [fest feedback](../fest_feedback/)	 - Manage structured feedback collection
 * [fest gates](../fest_gates/)	 - Manage quality gates - validation steps at sequence end
 * [fest go](../fest_go/)	 - Navigate to festivals/ - use 'fgo' after shell-init setup
+* [fest hooks](../fest_hooks/)	 - Inspect resolved lifecycle hooks
 * [fest id](../fest_id/)	 - Show the festival ID for the current context
 * [fest index](../fest_index/)	 - Manage festival indices
 * [fest init](../fest_init/)	 - Initialize a new festival directory structure

--- a/docs/cli-reference/fest/fest_hooks.md
+++ b/docs/cli-reference/fest/fest_hooks.md
@@ -1,0 +1,36 @@
+---
+title: "fest hooks"
+linkTitle: "fest hooks"
+description: "Inspect resolved lifecycle hooks"
+---
+
+## fest hooks
+
+Inspect resolved lifecycle hooks
+
+### Synopsis
+
+Inspect the hooks resolved from the machine, festivals, and festival layers.
+
+Available Commands:
+  list   Show the effective resolved hook set with source layers and shadow diffs
+
+### Options
+
+```
+  -h, --help   help for hooks
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest](../fest/)	 - Festival Methodology CLI - goal-oriented project management for AI agents
+* [fest hooks list](../fest_hooks_list/)	 - Show the effective resolved hook set

--- a/docs/cli-reference/fest/fest_hooks_list.md
+++ b/docs/cli-reference/fest/fest_hooks_list.md
@@ -1,0 +1,40 @@
+---
+title: "fest hooks list"
+linkTitle: "fest hooks list"
+description: "Show the effective resolved hook set"
+---
+
+## fest hooks list
+
+Show the effective resolved hook set
+
+```
+fest hooks list [flags]
+```
+
+### Examples
+
+```
+  fest hooks list
+  fest hooks list --json
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   Output in JSON format
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest hooks](../fest_hooks/)	 - Inspect resolved lifecycle hooks

--- a/docs/cli-reference/fest/fest_progress.md
+++ b/docs/cli-reference/fest/fest_progress.md
@@ -12,25 +12,25 @@ Track and display festival execution progress
 
 Track and display progress for festival execution.
 
-When run without flags, shows an overview of festival progress.
-Use flags to update task progress, report blockers, or mark tasks complete.
+When run without flags, shows an overview of festival progress. 'fest progress'
+is the display surface; task state mutations live under 'fest task'.
 
 PROGRESS OVERVIEW:
 ```bash
   fest progress              Show festival progress summary
   fest progress --json       Output progress in JSON format
+  fest progress --watch      Continuously refresh the display
 ```
 
-TASK UPDATES:
+DEPRECATED TASK MUTATIONS (use 'fest task' instead):
 ```bash
-  fest progress --task <id> --update 50%     Update task progress
-  fest progress --task <id> --complete       Mark task as complete
-  fest progress --task <id> --in-progress    Mark task as in progress
-  fest progress --task <id> --blocker "msg"  Report a blocker
-  fest progress --task <id> --clear          Clear blocker
-  fest progress --path <task_path> --complete
-  fest progress --phase <phase> --sequence <seq> --task <id> --complete
+  fest progress --task <id> --complete   -> fest task completed --yes
+  fest progress --task <id> --update 50% -> fest task update 50%
+  fest progress --task <id> --blocker "msg" -> fest task blocked --reason "msg" --yes
+  fest progress --task <id> --clear      -> fest task unblock
 ```
+
+These flags still work for one release and print a deprecation notice.
 
 Task IDs can be festival-relative paths (e.g. 002_FOUNDATION/01_project_scaffold/01_design.md)
 or absolute paths. Use --path or --phase/--sequence to disambiguate duplicates.
@@ -44,12 +44,9 @@ fest progress [flags]
 
 ```
   fest progress                          # Show overall progress
-  fest progress --task 01_setup.md --update 75%
-  fest progress --path 002_FOUNDATION/01_project_scaffold/01_design.md --complete
-  fest progress --phase 002_FOUNDATION --sequence 01_project_scaffold --task 01_design.md --complete
-  fest progress --festival festivals/active/guild-chat-GC0001 --task 01_setup.md --update 75%
-  fest progress --task 02_impl.md --blocker "Waiting on API spec"
-  fest progress --task 02_impl.md --clear
+  fest progress --json                   # Overall progress as JSON
+  fest progress --watch                  # Live-refreshing progress display
+  fest progress --task 01_setup.md       # Show a single task's progress
 ```
 
 ### Options

--- a/docs/cli-reference/fest/fest_show.md
+++ b/docs/cli-reference/fest/fest_show.md
@@ -47,6 +47,7 @@ fest show [festival-name] [flags]
       --inprogress        expand only in-progress phases and sequences
       --json              output in JSON format
       --roadmap           show full execution roadmap with task statuses
+      --show-feedback     show blocked-step feedback
       --summary           show aggregate summary instead of tree view
       --watch             continuously refresh display
 ```

--- a/docs/cli-reference/fest/fest_task.md
+++ b/docs/cli-reference/fest/fest_task.md
@@ -12,9 +12,11 @@ Manage task status (show, edit, complete, block, reset)
 
 Commands for managing individual task status within a festival.
 
-These commands provide a simpler interface for viewing, editing, marking
-tasks complete, blocked, or resetting them. Each mutation requires
-interactive confirmation to ensure agents verify their work before proceeding.
+This is the single home for task state mutations. Consequential changes
+(completed, blocked, reset) prompt for confirmation to ensure agents verify
+their work; pass --yes to skip the prompt for non-interactive or agent use, and
+--json to emit a structured result (--json requires --yes). Progress signals
+(update, unblock) are frictionless and never prompt.
 
 Task Resolution:
   When [task] is omitted, the command auto-detects the current task:
@@ -32,8 +34,12 @@ Examples:
   fest task show 01_design.md             # Show specific task
   fest task edit                          # Open current task in editor
   fest task completed                     # Mark current task complete (Y/n)
+  fest task completed --yes               # Mark complete, no prompt (agents)
+  fest task completed --yes --json        # Mark complete, structured output
   fest task blocked --reason "need API"   # Mark task blocked (Y/n)
   fest task reset                         # Reset task to pending (Y/n)
+  fest task update 50%                    # Set progress to 50%
+  fest task unblock                       # Clear a blocker, resume work
 ```
 
 ### Options
@@ -54,8 +60,10 @@ Examples:
 ### SEE ALSO
 
 * [fest](../fest/)	 - Festival Methodology CLI - goal-oriented project management for AI agents
-* [fest task blocked](../fest_task_blocked/)	 - Mark a task as blocked (requires confirmation)
-* [fest task completed](../fest_task_completed/)	 - Mark a task as complete (requires confirmation)
+* [fest task blocked](../fest_task_blocked/)	 - Mark a task as blocked
+* [fest task completed](../fest_task_completed/)	 - Mark a task as complete
 * [fest task edit](../fest_task_edit/)	 - Open the current task in your editor
-* [fest task reset](../fest_task_reset/)	 - Reset a task to pending (requires confirmation)
+* [fest task reset](../fest_task_reset/)	 - Reset a task to pending
 * [fest task show](../fest_task_show/)	 - Show task details and status
+* [fest task unblock](../fest_task_unblock/)	 - Clear a task's blocker and resume work
+* [fest task update](../fest_task_update/)	 - Update a task's progress percentage

--- a/docs/cli-reference/fest/fest_task_blocked.md
+++ b/docs/cli-reference/fest/fest_task_blocked.md
@@ -1,12 +1,20 @@
 ---
 title: "fest task blocked"
 linkTitle: "fest task blocked"
-description: "Mark a task as blocked (requires confirmation)"
+description: "Mark a task as blocked"
 ---
 
 ## fest task blocked
 
-Mark a task as blocked (requires confirmation)
+Mark a task as blocked
+
+### Synopsis
+
+Mark a task as blocked, pausing work and notifying the user.
+
+By default a confirmation prompt is shown; pass --yes to skip it for
+non-interactive or agent use. --json emits a structured result and requires
+--yes.
 
 ```
 fest task blocked [task] [flags]
@@ -16,8 +24,9 @@ fest task blocked [task] [flags]
 
 ```
   -h, --help            help for blocked
-      --json            output as JSON (blocks: interactive confirmation required)
+      --json            output as JSON (requires --yes)
       --reason string   reason for the blocker (required)
+  -y, --yes             skip the interactive confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest/fest_task_completed.md
+++ b/docs/cli-reference/fest/fest_task_completed.md
@@ -1,12 +1,20 @@
 ---
 title: "fest task completed"
 linkTitle: "fest task completed"
-description: "Mark a task as complete (requires confirmation)"
+description: "Mark a task as complete"
 ---
 
 ## fest task completed
 
-Mark a task as complete (requires confirmation)
+Mark a task as complete
+
+### Synopsis
+
+Mark a task as complete.
+
+Quality gates are evaluated first and block completion on failure. By default a
+confirmation prompt is shown; pass --yes to skip it for non-interactive or agent
+use. --json emits a structured result and requires --yes.
 
 ```
 fest task completed [task] [flags]
@@ -16,7 +24,8 @@ fest task completed [task] [flags]
 
 ```
   -h, --help   help for completed
-      --json   output as JSON (blocks: interactive confirmation required)
+      --json   output as JSON (requires --yes)
+  -y, --yes    skip the interactive confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest/fest_task_reset.md
+++ b/docs/cli-reference/fest/fest_task_reset.md
@@ -1,12 +1,20 @@
 ---
 title: "fest task reset"
 linkTitle: "fest task reset"
-description: "Reset a task to pending (requires confirmation)"
+description: "Reset a task to pending"
 ---
 
 ## fest task reset
 
-Reset a task to pending (requires confirmation)
+Reset a task to pending
+
+### Synopsis
+
+Reset a task to pending, clearing all progress, time, and blocker data.
+
+By default a confirmation prompt is shown; pass --yes to skip it for
+non-interactive or agent use. --json emits a structured result and requires
+--yes.
 
 ```
 fest task reset [task] [flags]
@@ -16,7 +24,8 @@ fest task reset [task] [flags]
 
 ```
   -h, --help   help for reset
-      --json   output as JSON (blocks: interactive confirmation required)
+      --json   output as JSON (requires --yes)
+  -y, --yes    skip the interactive confirmation prompt
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest/fest_task_unblock.md
+++ b/docs/cli-reference/fest/fest_task_unblock.md
@@ -1,0 +1,40 @@
+---
+title: "fest task unblock"
+linkTitle: "fest task unblock"
+description: "Clear a task's blocker and resume work"
+---
+
+## fest task unblock
+
+Clear a task's blocker and resume work
+
+### Synopsis
+
+Clear a task's blocker, returning it to in_progress.
+
+This is a frictionless forward-motion signal and does not prompt for
+confirmation. When [task] is omitted the current task is auto-detected.
+
+```
+fest task unblock [task] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for unblock
+      --json   output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest task](../fest_task/)	 - Manage task status (show, edit, complete, block, reset)

--- a/docs/cli-reference/fest/fest_task_update.md
+++ b/docs/cli-reference/fest/fest_task_update.md
@@ -1,0 +1,42 @@
+---
+title: "fest task update"
+linkTitle: "fest task update"
+description: "Update a task's progress percentage"
+---
+
+## fest task update
+
+Update a task's progress percentage
+
+### Synopsis
+
+Update a task's progress percentage (0-100).
+
+This is a frictionless forward-motion signal and does not prompt for
+confirmation. Progress must stay below 100%; use 'fest task completed' at
+100% so quality gates are evaluated. When [task] is omitted the current task
+is auto-detected.
+
+```
+fest task update [task] <percent> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for update
+      --json   output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest task](../fest_task/)	 - Manage task status (show, edit, complete, block, reset)

--- a/docs/cli-reference/fest/fest_understand.md
+++ b/docs/cli-reference/fest/fest_understand.md
@@ -25,6 +25,7 @@ QUICK REFERENCE:
   fest understand checklist      Validation checklist before starting
   fest understand rules          Naming conventions for automation
   fest understand workflow       Just-in-time reading + workflow/gates
+  fest understand hooks          Lifecycle hooks schema, bindings, human gates
 ```
 
 The understand command helps you grasp WHEN and WHY to use specific
@@ -60,6 +61,7 @@ fest understand [flags]
 * [fest understand context](../fest_understand_context/)	 - CONTEXT.md - session memory for AI agents (CREATE FIRST)
 * [fest understand extensions](../fest_understand_extensions/)	 - Show loaded extensions
 * [fest understand gates](../fest_understand_gates/)	 - Show quality gate configuration
+* [fest understand hooks](../fest_understand_hooks/)	 - Lifecycle hooks schema, bindings, and human gates
 * [fest understand lifecycle](../fest_understand_lifecycle/)	 - Festival lifecycle: planning -> ready -> active -> dungeon
 * [fest understand loop](../fest_understand_loop/)	 - The fest next loop: festivals and standalone WORKFLOW.md as work loops
 * [fest understand methodology](../fest_understand_methodology/)	 - Core principles - START HERE for new agents

--- a/docs/cli-reference/fest/fest_understand_hooks.md
+++ b/docs/cli-reference/fest/fest_understand_hooks.md
@@ -1,0 +1,40 @@
+---
+title: "fest understand hooks"
+linkTitle: "fest understand hooks"
+description: "Lifecycle hooks schema, bindings, and human gates"
+---
+
+## fest understand hooks
+
+Lifecycle hooks schema, bindings, and human gates
+
+### Synopsis
+
+Learn how fest resolves hooks across machine, festivals, and festival
+layers; how step bindings fire; and non-bypassable human gates
+(approval: human-required).
+
+See also docs/concepts/hooks.md and docs/concepts/hook-evidence-contract.md.
+
+```
+fest understand hooks [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for hooks
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest understand](../fest_understand/)	 - Learn methodology FIRST - run before executing festival tasks

--- a/docs/cli-reference/fest/fest_watch.md
+++ b/docs/cli-reference/fest/fest_watch.md
@@ -36,10 +36,11 @@ fest watch [festival-selector] [flags]
 ### Options
 
 ```
-      --collapsed   show collapsed tree with counters only
-      --goals       show goals for phases and sequences
-  -h, --help        help for watch
-      --summary     show aggregate summary instead of tree view
+      --collapsed       show collapsed tree with counters only
+      --goals           show goals for phases and sequences
+  -h, --help            help for watch
+      --show-feedback   show blocked-step feedback
+      --summary         show aggregate summary instead of tree view
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest/fest_workflow.md
+++ b/docs/cli-reference/fest/fest_workflow.md
@@ -58,6 +58,7 @@ Examples:
   fest workflow advance             # Complete current step and move to next
   fest workflow skip --reason "already completed externally" # Operator override
   fest workflow approve             # Approve a blocking checkpoint
+  fest workflow judge               # Run or re-run the configured approval judge
   fest workflow reject              # Reject checkpoint with feedback
   fest workflow reset               # Reset workflow or gate to step 1
   fest workflow show                # Display the current step details
@@ -86,6 +87,7 @@ Examples:
 * [fest workflow approve](../fest_workflow_approve/)	 - Approve a blocking checkpoint
 * [fest workflow create](../fest_workflow_create/)	 - Scaffold a new standalone WORKFLOW.md (alias of 'fest create workflow')
 * [fest workflow init](../fest_workflow_init/)	 - Initialize standalone workflow runtime
+* [fest workflow judge](../fest_workflow_judge/)	 - Run the approval judge for the current checkpoint
 * [fest workflow reject](../fest_workflow_reject/)	 - Reject checkpoint with feedback
 * [fest workflow renumber](../fest_workflow_renumber/)	 - Renumber step headings in a WORKFLOW.md to a contiguous 1-indexed sequence
 * [fest workflow reset](../fest_workflow_reset/)	 - Reset workflow to step 1

--- a/docs/cli-reference/fest/fest_workflow_approve.md
+++ b/docs/cli-reference/fest/fest_workflow_approve.md
@@ -20,12 +20,31 @@ After approval:
   - The workflow advances to the next step
 
 Auto approval:
-  Manual approval is the default. Use --auto only when an operator has explicitly
-  delegated this checkpoint decision to an external judge command.
+  Configuring hooks.definitions.approval_judge is the operator opt-in that
+  delegates blocking checkpoints away from human review. With that hook set,
+```bash
+  fest next auto-invokes the judge on blocking WORKFLOW.md / GATES.md steps.
 
-  Agents must not clear checkpoints themselves: --as agent is rejected. An
-  agent-actor decision is recorded only when the operator delegates via --auto
-  and the judge returns a verdict.
+  Use 'fest workflow judge' to re-run the judge explicitly after a rejection;
+  '--auto' remains a backwards-compatible alias. Agents must not clear checkpoints with --as agent;
+  agent-actor decisions are recorded only via the judge path.
+
+  Checkpoint classes:
+    artifact_review         — deliverables can be auto-judged when evidence is ready
+    operator_attestation    — human must approve; --auto is refused and plain
+                              manual approval requires an interactive TTY
+
+  Presentation-like steps require non-empty evidence (e.g. output_specs/PRESENTATION.md)
+  before the judge is invoked. Missing evidence blocks deterministically without a model call.
+
+  After a judge reject, re-submit with: fest workflow judge
+  Operator override: run --override-judge --summary "..." from a real terminal
+  and type APPROVE when prompted; records decision_actor=user_override.
+
+  When an approval judge is configured, non-interactive manual approve is
+  refused, including --override-judge and --judge-command, so agents cannot
+  mint decision_actor=user or user_override. Use a real terminal and type
+  APPROVE.
 
   The judge command receives JSON on stdin using schema fest.approval.judge/v1
   and must return JSON on stdout with decision "approve" or "reject" and a
@@ -33,12 +52,20 @@ Auto approval:
   decisions, and empty reasons fail closed and do not approve the checkpoint.
 
   The judge command is resolved as: --judge-command flag, else the
-  hooks.approval_judge.command hook in .festival/config.yaml. If neither is
+  hooks.definitions.approval_judge hook in .festival/config.yaml. If neither is
   set, --auto fails closed and leaves the checkpoint unchanged.
 
       hooks:
-        approval_judge:
-          command: ob judge
+        definitions:
+          approval_judge:
+            command: ob judge
+            timeout: 0
+
+  By default --auto launches the judge in the background and returns
+  immediately; the checkpoint stays blocked until the verdict lands, and
+  'fest show' renders the waiting-on-judge state while it runs. Use --wait
+  to block until the judge returns instead.
+```
 
 ```
 fest workflow approve [flags]
@@ -49,9 +76,11 @@ fest workflow approve [flags]
 ```
       --auto                     delegate this checkpoint decision to the configured approval judge command
   -h, --help                     help for approve
-      --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.approval_judge.command hook)
+      --judge-command string     approval judge command for --auto (overrides the .festival/config.yaml hooks.definitions.approval_judge hook; requires an interactive TTY)
       --judge-timeout duration   maximum time to wait for the approval judge (0 waits until it returns)
-      --summary string           approval summary or rationale
+      --override-judge           operator override of a judge/readiness reject (requires --summary and an interactive TTY)
+      --summary string           approval summary or rationale (required with --override-judge)
+      --wait                     block until the judge returns instead of launching it in the background
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest/fest_workflow_judge.md
+++ b/docs/cli-reference/fest/fest_workflow_judge.md
@@ -1,0 +1,48 @@
+---
+title: "fest workflow judge"
+linkTitle: "fest workflow judge"
+description: "Run the approval judge for the current checkpoint"
+---
+
+## fest workflow judge
+
+Run the approval judge for the current checkpoint
+
+### Synopsis
+
+Run the configured approval judge for the current blocking checkpoint.
+
+Use this after revising evidence following a judge rejection. A judge-owned
+rejection is reopened automatically; ordinary operator rejections still
+require 'fest workflow approve'. By default the judge runs in the background;
+use --wait when this command should wait for the verdict.
+
+The judge command is resolved from --judge-command or the
+hooks.definitions.approval_judge workspace configuration hook.
+
+```
+fest workflow judge [flags]
+```
+
+### Options
+
+```
+  -h, --help                     help for judge
+      --judge-command string     approval judge command (overrides hooks.definitions.approval_judge; requires an interactive TTY)
+      --judge-timeout duration   maximum time to wait for the approval judge (0 waits until it returns)
+      --wait                     block until the judge returns instead of launching it in the background
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --phase string    specify phase directory (e.g., 001_INGEST)
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest workflow](../fest_workflow/)	 - Manage workflow-based phase execution


### PR DESCRIPTION
## Summary

- pin the bundled Camp submodule to stable v0.3.1
- pin the bundled Fest submodule to stable v0.4.11
- regenerate the stable-profile CLI reference for both components
- add documentation for the newly released Camp workitem and Fest hooks/task/workflow commands

## Why

Festival still bundled Camp v0.3.0 and Fest v0.5.0-rc.1. The component stable releases are now available, so the distribution repo must pin those exact tags and publish documentation generated from the same release binaries before the next Festival release.

## Impact

After merge, Festival main will be ready to create the next stable bundle from Camp v0.3.1 and Fest v0.4.11. The release operator currently derives Festival v0.2.13 from the existing stable history.

## Validation

- just release preflight stable
  - exact stable pin check passed
  - Homebrew and AUR credentials detected
  - clean-cache module resolution passed
  - stable/dev docs-profile check passed
  - release-operator tests passed
  - stable Camp and Fest builds passed
  - beginner-path smoke reached the first ingest workflow successfully
- git diff --check