### PR TITLE
chore(release): pin camp v0.4.0-rc.3 and fest v0.5.0-rc.3 (guardrails bundle + defect wave)

### DIFF
--- a/.justfiles/build.just
+++ b/.justfiles/build.just
@@ -31,7 +31,10 @@ camp:
     #!/usr/bin/env bash
     set -euo pipefail
     case "{{cli_profile}}" in
-        stable) cd camp && just build quick-stable ;;
+        # VERSION stamps the pinned tag into the binary; camp's own recipe
+        # defaults it to "dev", which would make a correctly pinned bundle
+        # binary report the wrong version.
+        stable) cd camp && VERSION="$(git describe --tags --always)" just build quick-stable ;;
         dev) cd camp && just build quick-dev ;;
         *)
             echo "ERROR: CLI_PROFILE must be 'stable' or 'dev' (got: {{cli_profile}})"

--- a/docs/cli-reference/camp/camp.md
+++ b/docs/cli-reference/camp/camp.md
@@ -67,13 +67,16 @@ camp [flags]
 * [camp id](../camp_id/)	 - Print the current campaign ID
 * [camp idea](../camp_idea/)	 - Manage campaign ideas
 * [camp init](../camp_init/)	 - Initialize a new campaign
+* [camp jobs](../camp_jobs/)	 - Inspect and run camp's deferred commit queue
 * [camp leverage](../camp_leverage/)	 - Compute leverage scores for campaign projects
 * [camp lifecycle](../camp_lifecycle/)	 - Manage campaign lifecycle status
 * [camp list](../camp_list/)	 - List all registered campaigns
 * [camp log](../camp_log/)	 - Show git log of the campaign
 * [camp machine](../camp_machine/)	 - Manage remote machines (~/.obey/machines.yaml)
 * [camp move](../camp_move/)	 - Move a file or directory within the campaign
+* [camp notify](../camp_notify/)	 - Manage campaign state notices
 * [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp pack](../camp_pack/)	 - Pack a directory into a portable .festival bundle
 * [camp pin](../camp_pin/)	 - Pin a directory
 * [camp pins](../camp_pins/)	 - List all pinned directories
 * [camp plugins](../camp_plugins/)	 - List discovered camp plugins on PATH
@@ -95,7 +98,8 @@ camp [flags]
 * [camp switch](../camp_switch/)	 - Switch to a different campaign
 * [camp sync](../camp_sync/)	 - Safely synchronize submodules
 * [camp tag](../camp_tag/)	 - Label campaigns with tags
-* [camp transfer](../camp_transfer/)	 - Copy files between campaigns
+* [camp transfer](../camp_transfer/)	 - Copy files between campaigns (and machines)
+* [camp unbundle](../camp_unbundle/)	 - Unbundle a .festival archive into a directory
 * [camp unpin](../camp_unpin/)	 - Remove a saved pin
 * [camp unregister](../camp_unregister/)	 - Remove campaign from registry
 * [camp version](../camp_version/)	 - Show version information

--- a/docs/cli-reference/camp/camp_artifacts_add.md
+++ b/docs/cli-reference/camp/camp_artifacts_add.md
@@ -23,7 +23,9 @@ camp artifacts add <path> [flags]
 ### Options
 
 ```
+      --dry-run         Report what declaring this root would cover; write nothing
   -h, --help            help for add
+      --no-gitignore    Declare the root without adding its .gitignore rule
       --policy string   Sync policy: always (every peer sync) or on-demand (--artifacts-only) (default "always")
 ```
 

--- a/docs/cli-reference/camp/camp_commit.md
+++ b/docs/cli-reference/camp/camp_commit.md
@@ -44,9 +44,12 @@ camp commit [flags]
   -a, --all                   Stage all changes before committing (default true)
       --amend                 Amend the previous commit
       --auto-write            Run configured commit message writer
+      --commit-large          Commit over-threshold files instead of keeping them out of git
   -h, --help                  help for commit
       --include-refs          Include submodule ref changes when staging at campaign root
+      --json                  Emit a JSON result on stdout; human output goes to stderr
   -m, --message stringArray   Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)
+      --no-drain              Do not wait for camp's queued commits first
       --no-edit               Amend without editing the commit message (requires --amend)
   -p, --project string        Operate on a specific project/submodule path
       --sub                   Operate on the submodule detected from current directory

--- a/docs/cli-reference/camp/camp_doctor.md
+++ b/docs/cli-reference/camp/camp_doctor.md
@@ -20,6 +20,7 @@ CHECKS PERFORMED:
   working     Working directory cleanliness
   commits     Parent-submodule commit alignment
   lock        Stale git index.lock files
+  jobs        Failed, stuck, or lost deferred commits
 
 EXIT CODES:
   0  All checks passed (no warnings or errors)
@@ -50,10 +51,11 @@ camp doctor [flags]
 ### Options
 
 ```
-  -c, --check strings     Run specific check(s) only (orphan, url, integrity, head, working, commits, lock)
+  -c, --check strings     Run specific check(s) only (orphan, url, integrity, head, working, commits, lock, artifacts, jobs, bigfiles)
   -f, --fix               Attempt automatic fixes for detected issues
   -h, --help              help for doctor
       --json              Output results as JSON
+      --no-drain          Do not wait for camp's queued commits first
       --submodules-only   Only check submodule health
   -v, --verbose           Show detailed information for each check
 ```

--- a/docs/cli-reference/camp/camp_fresh.md
+++ b/docs/cli-reference/camp/camp_fresh.md
@@ -26,6 +26,21 @@ follow-up command workflows (install, build, bootstrap, ...) to run once the
 cycle succeeds. Manage those with 'camp fresh configure'. Inspect the resolved
 sequence with 'camp fresh show-workflow [project-name]'.
 
+WORKITEM COMPLETION
+
+Two fresh.yaml settings decide what happens to workitems whose work looks done:
+
+  completed_runs     Tier 1, once per run, campaign-root scoped. "sweep"
+                     (default) promotes every workitem whose workflow run
+                     completed, "report" prints a read-only banner, "off" skips
+                     it. This is the same sweep 'camp workitem sweep' performs.
+  merged_workitems   Tier 2, per project. A workitem whose branch merged is
+                     inferred evidence, so it never auto-promotes: "prompt"
+                     asks on a TTY and reports otherwise, "report" prints the
+                     exact promote commands to run, "off" skips it.
+
+Both are configured in fresh.yaml, not by flags. See 'camp fresh configure'.
+
 Examples:
   camp fresh                            # Sync current project (checkout default, fetch, prune)
   camp fresh --branch develop           # Sync and create develop branch

--- a/docs/cli-reference/camp/camp_fresh.md
+++ b/docs/cli-reference/camp/camp_fresh.md
@@ -12,8 +12,9 @@ Post-merge branch cycling: sync to default branch and optionally create a new wo
 
 Reset one or more projects to a fresh state after merging a PR.
 
-Performs the post-merge cycle: checkout default branch, pull latest,
-prune merged branches, and optionally create a new working branch.
+Performs the post-merge cycle: checkout the default branch, fetch origin,
+sync to the remote default while preserving local-only commits, prune merged
+branches, and optionally create a new working branch.
 
 Auto-detects the current project from your working directory, or accepts a
 single project name. Use --list to cycle a specific set of projects in one
@@ -26,7 +27,7 @@ cycle succeeds. Manage those with 'camp fresh configure'. Inspect the resolved
 sequence with 'camp fresh show-workflow [project-name]'.
 
 Examples:
-  camp fresh                            # Sync current project (checkout default, pull, prune)
+  camp fresh                            # Sync current project (checkout default, fetch, prune)
   camp fresh --branch develop           # Sync and create develop branch
   camp fresh camp -b feat/new-thing     # Sync camp project, create feature branch
   camp fresh --list camp,fest,festival  # Sync a specific set of projects
@@ -46,6 +47,7 @@ camp fresh [project-name] [flags]
   -h, --help             help for fresh
       --list strings     Comma-separated set of projects to cycle in one run
       --no-branch        Skip branch creation even if configured
+      --no-drain         Do not wait for camp's queued commits first
       --no-follow-up     Skip configured follow-up command workflows
       --no-prune         Skip pruning merged branches
       --no-push          Skip pushing the new branch upstream

--- a/docs/cli-reference/camp/camp_fresh_all.md
+++ b/docs/cli-reference/camp/camp_fresh_all.md
@@ -10,7 +10,7 @@ Run fresh across all project submodules
 
 ### Synopsis
 
-Run the fresh cycle (checkout default, pull, prune, optional branch)
+Run the fresh cycle (fetch and safely sync default, prune, optional branch)
 across every project submodule in the campaign.
 
 Examples:
@@ -26,7 +26,8 @@ camp fresh all [flags]
 ### Options
 
 ```
-  -h, --help   help for all
+  -h, --help       help for all
+      --no-drain   Do not wait for camp's queued commits first
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp/camp_fresh_configure.md
+++ b/docs/cli-reference/camp/camp_fresh_configure.md
@@ -17,7 +17,7 @@ per-project overrides.
 Run without a subcommand to open the interactive setup for humans, which
 groups the fresh sequence by what you can change about each step:
 
-  Sync        checkout, pull, and safety checks; always runs
+  Sync        checkout, fetch, and safe default-branch realignment; always runs
   Settings    branch, push_upstream, prune, and prune_remote
   Follow-ups  your own commands, run after a successful cycle
 

--- a/docs/cli-reference/camp/camp_jobs.md
+++ b/docs/cli-reference/camp/camp_jobs.md
@@ -1,0 +1,53 @@
+---
+title: "camp jobs"
+linkTitle: "camp jobs"
+description: "Inspect and run camp's deferred commit queue"
+---
+
+## camp jobs
+
+Inspect and run camp's deferred commit queue
+
+### Synopsis
+
+Inspect and run the deferred commit queue.
+
+Camp defers its own bookkeeping commits so they do not hold your terminal. The
+queue lives under .campaign/cache/jobs and is machine-local and disposable:
+git is the record, this is only the work still on its way there.
+
+Run bare to see what is queued, running, or failed. Nothing here is required in
+normal use: workers start themselves, and every command that touches git
+history waits for the queue before it runs.
+
+Examples:
+  camp jobs                    # what is queued, running, or failed
+  camp jobs --json             # the same, for scripts and agents
+  camp jobs retry all          # requeue everything that failed
+  camp jobs drop <id>          # give up on one job, keeping its content
+  camp jobs drain              # wait for every lane, then exit
+
+```
+camp jobs [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for jobs
+      --json   Emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp jobs drain](../camp_jobs_drain/)	 - Wait until every lane is empty
+* [camp jobs drop](../camp_jobs_drop/)	 - Give up on failed jobs, keeping their content
+* [camp jobs retry](../camp_jobs_retry/)	 - Requeue failed jobs
+* [camp jobs run](../camp_jobs_run/)	 - Serve every lane with pending work, then exit

--- a/docs/cli-reference/camp/camp_jobs_drain.md
+++ b/docs/cli-reference/camp/camp_jobs_drain.md
@@ -1,0 +1,40 @@
+---
+title: "camp jobs drain"
+linkTitle: "camp jobs drain"
+description: "Wait until every lane is empty"
+---
+
+## camp jobs drain
+
+Wait until every lane is empty
+
+### Synopsis
+
+Block until no queued commit is outstanding anywhere in the campaign.
+
+Commands that touch git history already do this for the repo they act on, so
+this is for the cases that are not one command: before archiving a machine,
+before a manual git operation camp does not wrap, or to watch the queue finish.
+
+Artifact manifest jobs are exempt here as everywhere: they carry the commit
+they describe, so they are correct whenever they land.
+
+```
+camp jobs drain [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for drain
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp jobs](../camp_jobs/)	 - Inspect and run camp's deferred commit queue

--- a/docs/cli-reference/camp/camp_jobs_drop.md
+++ b/docs/cli-reference/camp/camp_jobs_drop.md
@@ -1,0 +1,38 @@
+---
+title: "camp jobs drop"
+linkTitle: "camp jobs drop"
+description: "Give up on failed jobs, keeping their content"
+---
+
+## camp jobs drop
+
+Give up on failed jobs, keeping their content
+
+### Synopsis
+
+Discard failed jobs without discarding what they were going to commit.
+
+Only the job file is removed. The intent, manifest, or marker the job was going
+to commit stays in your working tree, uncommitted, for the next ordinary commit
+to pick up. Dropping a job means "stop trying to commit this for me", never
+"throw away my work".
+
+```
+camp jobs drop <id|all> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for drop
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp jobs](../camp_jobs/)	 - Inspect and run camp's deferred commit queue

--- a/docs/cli-reference/camp/camp_jobs_retry.md
+++ b/docs/cli-reference/camp/camp_jobs_retry.md
@@ -1,0 +1,37 @@
+---
+title: "camp jobs retry"
+linkTitle: "camp jobs retry"
+description: "Requeue failed jobs"
+---
+
+## camp jobs retry
+
+Requeue failed jobs
+
+### Synopsis
+
+Move failed jobs back to pending and start a worker for them.
+
+Attempts reset, because a retry is you deciding the cause is gone. Keeping the
+count would let a job that failed three times for a reason you have since fixed
+be parked again on its first new attempt.
+
+```
+camp jobs retry <id|all> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for retry
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp jobs](../camp_jobs/)	 - Inspect and run camp's deferred commit queue

--- a/docs/cli-reference/camp/camp_jobs_run.md
+++ b/docs/cli-reference/camp/camp_jobs_run.md
@@ -1,0 +1,43 @@
+---
+title: "camp jobs run"
+linkTitle: "camp jobs run"
+description: "Serve every lane with pending work, then exit"
+---
+
+## camp jobs run
+
+Serve every lane with pending work, then exit
+
+### Synopsis
+
+Serve every lane with pending work and exit when none is left.
+
+This is both the entrypoint camp spawns detached after enqueuing work, and the
+way to run the queue in the foreground when something looks wrong. Running it
+by hand is safe at any time: lanes are locked per repo, so a second worker
+finds the lanes taken and exits rather than duplicating anything.
+
+It prints nothing on success. Per-job transitions go to
+.campaign/cache/jobs/worker.log, which is where a detached worker's story is;
+'camp jobs' is the surface for looking at what is still outstanding.
+
+```
+camp jobs run [flags]
+```
+
+### Options
+
+```
+      --campaign string   Campaign root to serve (defaults to the detected campaign)
+  -h, --help              help for run
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp jobs](../camp_jobs/)	 - Inspect and run camp's deferred commit queue

--- a/docs/cli-reference/camp/camp_machine.md
+++ b/docs/cli-reference/camp/camp_machine.md
@@ -24,6 +24,21 @@ hops always use BatchMode (agents never hang on password prompts).
 'camp machine diagnose' reports auth mode, a copy-paste ssh probe, and
 ControlMaster socket state (and can clear a stale socket with --reset).
 
+The mesh model, in one paragraph: hopping exports CAMP_HOP_ORIGIN into the
+remote login shell, a single v1 line naming where the shell came from, which is
+what lets 'camp switch -' return without either machine storing state about the
+other. A payload does not register anything: if the origin is unknown here,
+camp names 'camp machine adopt', which previews and asks, requires a TTY, and
+remembers a decline. Reachability need not be symmetric -- a machine you cannot
+dial still appears in completion, because visibility travels as a snapshot
+pushed during a successful enumerate rather than as a live query. Camp will
+never install a key, register a machine unattended, or claim a host is reachable
+on the strength of tailnet membership alone.
+
+See docs/machine-mesh.md for the reachability matrix (notably: the Tailscale SSH
+server does not run in sandboxed macOS GUI builds, so a mac accepts OpenSSH keys
+instead) and docs/transfer.md for the machine-first transfer grammar.
+
 Run without a subcommand in a terminal to manage the fleet interactively: add,
 discover, edit, and remove machines, and see each one's socket state. The
 subcommands stay the interface for scripts and agents, and remain what a
@@ -63,6 +78,7 @@ camp machine [flags]
 
 * [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
 * [camp machine add](../camp_machine_add/)	 - Add or update a machine
+* [camp machine adopt](../camp_machine_adopt/)	 - Register the machine this session was hopped from
 * [camp machine diagnose](../camp_machine_diagnose/)	 - Inspect machine auth, probe line, and ssh ControlMaster sockets
 * [camp machine list](../camp_machine_list/)	 - List configured machines
 * [camp machine remove](../camp_machine_remove/)	 - Remove a machine

--- a/docs/cli-reference/camp/camp_machine_adopt.md
+++ b/docs/cli-reference/camp/camp_machine_adopt.md
@@ -1,0 +1,47 @@
+---
+title: "camp machine adopt"
+linkTitle: "camp machine adopt"
+description: "Register the machine this session was hopped from"
+---
+
+## camp machine adopt
+
+Register the machine this session was hopped from
+
+### Synopsis
+
+Register the machine this session was hopped from, after showing you exactly
+what will be written.
+
+A hop carries its origin in CAMP_HOP_ORIGIN. This reads that value and offers to
+add the origin to your machines file so hops and completion work in the other
+direction too. The hop itself never registers anything: adopting is an explicit,
+interactive act, and there is no flag that skips the confirmation.
+
+Adopting records how to REACH a machine. It does not make that machine reachable:
+that depends on its own sshd or tailnet policy. Verify with 'camp machine diagnose'.
+
+Answering No is remembered, so hints stay quiet until you ask again. Esc/cancel
+aborts without writing decline memory. Re-running this command always works;
+--force only skips the reminder that you declined before.
+
+```
+camp machine adopt [flags]
+```
+
+### Options
+
+```
+      --force   Skip the reminder that you declined this origin before (never skips the confirmation)
+  -h, --help    help for adopt
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp machine](../camp_machine/)	 - Manage remote machines (~/.obey/machines.yaml)

--- a/docs/cli-reference/camp/camp_notify.md
+++ b/docs/cli-reference/camp/camp_notify.md
@@ -1,0 +1,39 @@
+---
+title: "camp notify"
+linkTitle: "camp notify"
+description: "Manage campaign state notices"
+---
+
+## camp notify
+
+Manage campaign state notices
+
+### Synopsis
+
+Manage the advisory notices camp surfaces on commands you already run.
+
+Notices describe campaign state you may not know is true, such as a declared
+artifact root that has never synced. Each one carries its own dismiss command.
+
+Dismissals are stored in .campaign/notices.yaml, which is committed: a
+dismissal you make on one machine travels to your others, the same way the
+artifact declarations it concerns do.
+
+### Options
+
+```
+  -h, --help   help for notify
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp notify dismiss](../camp_notify_dismiss/)	 - Stop showing a notice
+* [camp notify list](../camp_notify_list/)	 - List dismissed notices
+* [camp notify restore](../camp_notify_restore/)	 - Show a dismissed notice again

--- a/docs/cli-reference/camp/camp_notify_dismiss.md
+++ b/docs/cli-reference/camp/camp_notify_dismiss.md
@@ -1,0 +1,37 @@
+---
+title: "camp notify dismiss"
+linkTitle: "camp notify dismiss"
+description: "Stop showing a notice"
+---
+
+## camp notify dismiss
+
+Stop showing a notice
+
+### Synopsis
+
+Dismiss a notice by id.
+
+Dismissal is per signature, not per kind. Dismissing the notice for one
+artifact root does not silence a root you declare later: that one has its own
+id and notifies on its own terms.
+
+```
+camp notify dismiss <notice-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for dismiss
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp notify](../camp_notify/)	 - Manage campaign state notices

--- a/docs/cli-reference/camp/camp_notify_list.md
+++ b/docs/cli-reference/camp/camp_notify_list.md
@@ -1,0 +1,29 @@
+---
+title: "camp notify list"
+linkTitle: "camp notify list"
+description: "List dismissed notices"
+---
+
+## camp notify list
+
+List dismissed notices
+
+```
+camp notify list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp notify](../camp_notify/)	 - Manage campaign state notices

--- a/docs/cli-reference/camp/camp_notify_restore.md
+++ b/docs/cli-reference/camp/camp_notify_restore.md
@@ -1,0 +1,29 @@
+---
+title: "camp notify restore"
+linkTitle: "camp notify restore"
+description: "Show a dismissed notice again"
+---
+
+## camp notify restore
+
+Show a dismissed notice again
+
+```
+camp notify restore <notice-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for restore
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp notify](../camp_notify/)	 - Manage campaign state notices

--- a/docs/cli-reference/camp/camp_pack.md
+++ b/docs/cli-reference/camp/camp_pack.md
@@ -1,0 +1,40 @@
+---
+title: "camp pack"
+linkTitle: "camp pack"
+description: "Pack a directory into a portable .festival bundle"
+---
+
+## camp pack
+
+Pack a directory into a portable .festival bundle
+
+### Synopsis
+
+Pack a work-unit directory into a compressed .festival archive using the Festival Bundle format.
+
+```
+camp pack [flags]
+```
+
+### Options
+
+```
+      --creator string   bundle.creator identity (default "camp")
+  -h, --help             help for pack
+      --json             emit info.json as JSON on stdout
+      --kind string      bundle kind (explore, design, intent, note, …); inferred from path when empty
+      --name string      human-readable bundle name (default: directory name)
+      --no-sent-record   do not write .bundles/sent on the source tree
+  -o, --output string    output .festival path (required)
+      --strict           fail if out-of-root linked files are missing
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces

--- a/docs/cli-reference/camp/camp_project_commit.md
+++ b/docs/cli-reference/camp/camp_project_commit.md
@@ -37,8 +37,10 @@ camp project commit [flags]
   -a, --all                   Stage all changes (default true)
       --amend                 Amend the previous commit
       --auto-write            Run configured commit message writer
+      --commit-large          Commit over-threshold files instead of keeping them out of git
   -h, --help                  help for commit
   -m, --message stringArray   Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)
+      --no-drain              Do not wait for camp's queued commits first
       --no-sync               Do not sync submodule ref even if settings enable it
   -p, --project string        Project name (auto-detected from cwd if not specified)
       --sync                  Sync submodule ref at campaign root after commit (also enabled by commit.sync_project_refs setting)

--- a/docs/cli-reference/camp/camp_stage.md
+++ b/docs/cli-reference/camp/camp_stage.md
@@ -39,6 +39,7 @@ camp stage [flags]
 ```
   -h, --help             help for stage
       --include-refs     Include submodule ref changes when staging at campaign root
+      --no-drain         Do not wait for camp's queued commits first
   -p, --project string   Operate on a specific project/submodule path
       --sub              Operate on the submodule detected from current directory
 ```

--- a/docs/cli-reference/camp/camp_status.md
+++ b/docs/cli-reference/camp/camp_status.md
@@ -36,6 +36,7 @@ camp status [flags] [-- <git-flags>]
 
 ```
   -h, --help             help for status
+      --no-drain         Do not wait for camp's queued commits first
   -p, --project string   Status of a specific project path
   -s, --short            Give output in short format
       --show-refs        Show campaign root submodule ref changes

--- a/docs/cli-reference/camp/camp_switch.md
+++ b/docs/cli-reference/camp/camp_switch.md
@@ -23,6 +23,13 @@ Use with the shell-init wrappers for instant navigation (recommended):
   csw a1b2                       # Switch by ID prefix
   csw obey/platform              # Switch by org-scoped selector
   csw archdtop:lance-arch        # Hop to a remote campaign over ssh
+  csw -                          # Hop back to the machine/campaign this session came from
+
+'camp switch -' (csw -) is the hop-back gesture: it returns to the origin
+encoded in CAMP_HOP_ORIGIN by the outbound hop. It is registration-independent
+— the origin need not be in this machine's machines.yaml. Like other remote
+targets it refuses --print/--json. '-' is reserved and is no longer a fuzzy
+campaign query.
 
 The --print flag outputs just the path for shell integration (local only):
   cd "$(camp switch --print)"
@@ -53,6 +60,7 @@ camp switch [campaign] [flags]
   csw                                # Interactive picker (local + remotes)
   csw obey-campaign                  # Switch by name
   csw archdtop:lance-arch            # Hop to remote campaign
+  csw -                              # Hop back via CAMP_HOP_ORIGIN
   camp switch --org obey platform    # Switch by name within an org
   camp switch obey/platform          # Switch by scoped selector
   camp switch a1b2                   # Switch by ID prefix

--- a/docs/cli-reference/camp/camp_sync.md
+++ b/docs/cli-reference/camp/camp_sync.md
@@ -84,6 +84,7 @@ camp sync [submodule...] [flags]
       --git-only           With --from: move git objects only, skip artifact roots
   -h, --help               help for sync
       --json               Output results as JSON for scripting
+      --no-drain           Do not wait for camp's queued commits first
       --no-fetch           Skip fetching from remote (use local refs only)
   -p, --parallel int       Number of parallel git operations (git guards superproject ops with repo lockfiles that fail fast on contention; lower this if a slow disk surfaces transient lock errors) (default 4)
   -v, --verbose            Show detailed output for each submodule

--- a/docs/cli-reference/camp/camp_transfer.md
+++ b/docs/cli-reference/camp/camp_transfer.md
@@ -1,24 +1,35 @@
 ---
 title: "camp transfer"
 linkTitle: "camp transfer"
-description: "Copy files between campaigns"
+description: "Copy files between campaigns (and machines)"
 ---
 
 ## camp transfer
 
-Copy files between campaigns
+Copy files between campaigns (and machines)
 
 ### Synopsis
 
-Copy files between different campaigns using campaign:path syntax.
+Copy files between campaigns, and between this machine and a registered
+fleet machine.
 
 Transfer always copies — it never moves or deletes the source.
-Either the source or destination (or both) can use "campaign:path"
-notation to reference a different registered campaign. Paths without
-a campaign prefix resolve relative to the current campaign root.
 
-At least one side must reference a different campaign. For copies
-within the same campaign, use 'camp copy' instead.
+Local forms:
+  campaign:path     another registered campaign on this machine
+  path              relative to the current campaign root
+  local:campaign:path
+                    force the campaign reading when campaign name collides
+                    with a registered machine id
+
+Machine forms (one side only; both-remote is refused):
+  machine:campaign:path
+                    file on a machine registered in ~/.obey/machines.yaml
+
+See docs/transfer.md for the full grammar, transport, and skew guidance.
+
+At least one side must reference a different campaign or machine. For copies
+within the same campaign on this machine, use 'camp copy' instead.
 
 ```
 camp transfer <src> <dest> [flags]
@@ -27,9 +38,12 @@ camp transfer <src> <dest> [flags]
 ### Examples
 
 ```
-  camp transfer docs/my-doc.md other-campaign:docs/my-doc.md     # push
-  camp transfer other-campaign:docs/my-doc.md docs/              # pull
+  camp transfer docs/my-doc.md other-campaign:docs/my-doc.md     # local push
+  camp transfer other-campaign:docs/my-doc.md docs/              # local pull
   camp transfer other:festivals/plan.md festivals/planned/       # pull into dir
+  camp transfer docs/x.md archdtop:obey-campaign:docs/x.md       # push to machine
+  camp transfer archdtop:obey-campaign:docs/x.md docs/x.md       # pull from machine
+  camp transfer local:other:docs/x.md archdtop:camp:docs/x.md    # local: escape hatch
 ```
 
 ### Options

--- a/docs/cli-reference/camp/camp_unbundle.md
+++ b/docs/cli-reference/camp/camp_unbundle.md
@@ -1,0 +1,38 @@
+---
+title: "camp unbundle"
+linkTitle: "camp unbundle"
+description: "Unbundle a .festival archive into a directory"
+---
+
+## camp unbundle
+
+Unbundle a .festival archive into a directory
+
+### Synopsis
+
+Extract a Festival Bundle into a live work-unit directory. Does not execute festivals or rituals.
+
+```
+camp unbundle [flags]
+```
+
+### Options
+
+```
+  -d, --dest string          destination directory (required)
+      --force                allow non-empty destination
+  -h, --help                 help for unbundle
+      --json                 emit info.json as JSON on stdout
+      --no-received-record   do not write .bundles/received
+      --no-verify            skip bundle.id content-hash verification
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces

--- a/docs/cli-reference/camp/camp_workitem.md
+++ b/docs/cli-reference/camp/camp_workitem.md
@@ -58,6 +58,7 @@ camp workitem [flags]
 * [camp workitem commits](../camp_workitem_commits/)	 - List commits referencing a workitem
 * [camp workitem create](../camp_workitem_create/)	 - Create workitem tracking metadata
 * [camp workitem current](../camp_workitem_current/)	 - Get, set, or clear the current workitem
+* [camp workitem demote](../camp_workitem_demote/)	 - Move a rail resident back to its type root
 * [camp workitem doctor](../camp_workitem_doctor/)	 - Report link-registry health issues
 * [camp workitem group](../camp_workitem_group/)	 - Set or clear the group
 * [camp workitem id](../camp_workitem_id/)	 - Print the identifier of a workitem

--- a/docs/cli-reference/camp/camp_workitem.md
+++ b/docs/cli-reference/camp/camp_workitem.md
@@ -65,7 +65,7 @@ camp workitem [flags]
 * [camp workitem links](../camp_workitem_links/)	 - List workitem links
 * [camp workitem list](../camp_workitem_list/)	 - List or browse filtered workitems
 * [camp workitem priority](../camp_workitem_priority/)	 - Set or clear the manual priority
-* [camp workitem promote](../camp_workitem_promote/)	 - Promote a workitem to a festival, doc, or dungeon
+* [camp workitem promote](../camp_workitem_promote/)	 - Promote a workitem: festival, doc, rail, dungeon
 * [camp workitem rename](../camp_workitem_rename/)	 - Rename a workitem and repair references
 * [camp workitem repair](../camp_workitem_repair/)	 - Repair a workflow directory into a workitem
 * [camp workitem resolve](../camp_workitem_resolve/)	 - Print the workitem for the current context

--- a/docs/cli-reference/camp/camp_workitem_demote.md
+++ b/docs/cli-reference/camp/camp_workitem_demote.md
@@ -1,0 +1,45 @@
+---
+title: "camp workitem demote"
+linkTitle: "camp workitem demote"
+description: "Move a rail resident back to its type root"
+---
+
+## camp workitem demote
+
+Move a rail resident back to its type root
+
+### Synopsis
+
+Take the workitem identified by [id], by cwd, or by the current pointer off the
+festival rail and back to its original workflow type root.
+
+A resident in festivals/ready or festivals/active returns to
+workflow/<type>/<slug>, where the type comes from its own .workitem marker. Every
+reference is repaired in the same commit, exactly as the rail move does.
+
+This is the escape hatch from the rail, not backward motion along it. It is
+rejected from a dungeon, because restoring a shelved workitem is not a demote,
+and from a workitem already at its type root.
+
+```
+camp workitem demote [id] [flags]
+```
+
+### Options
+
+```
+      --dry-run     Print the planned move, change nothing
+  -h, --help        help for demote
+      --json        Output result as a single JSON object
+      --no-commit   Skip the auto-commit
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_promote.md
+++ b/docs/cli-reference/camp/camp_workitem_promote.md
@@ -23,7 +23,12 @@ TARGETS:
 
 The rail is forward-only: root -> ready -> active. A workitem already on a
 stage cannot move backward, and moving one out of a dungeon is a restore
-rather than a promote.
+rather than a promote. To leave the rail entirely, use 'camp workitem demote',
+which returns the workitem to its original workflow type root.
+
+A workitem on the rail keeps its original type: a design item promoted to
+active is still a design item, now living at festivals/active/<slug>, and
+'camp wi --type design' still finds it.
 
 ```
 camp workitem promote [id] --target <target> [flags]

--- a/docs/cli-reference/camp/camp_workitem_promote.md
+++ b/docs/cli-reference/camp/camp_workitem_promote.md
@@ -1,12 +1,12 @@
 ---
 title: "camp workitem promote"
 linkTitle: "camp workitem promote"
-description: "Promote a workitem to a festival, doc, or dungeon"
+description: "Promote a workitem: festival, doc, rail, dungeon"
 ---
 
 ## camp workitem promote
 
-Promote a workitem to a festival, doc, or dungeon
+Promote a workitem: festival, doc, rail, dungeon
 
 ### Synopsis
 
@@ -15,9 +15,15 @@ Promote the workitem identified by [id], by cwd, or by the current pointer.
 TARGETS:
   festival    Create a festival from the workitem and shelve the source
   doc         Copy the workitem doc into docs/ and shelve the source
+  ready       Move the workitem onto the festival rail at festivals/ready
+  active      Move the workitem onto the festival rail at festivals/active
   completed   Move the workitem to its local dungeon/completed
   archived    Move the workitem to its local dungeon/archived
   someday     Move the workitem to its local dungeon/someday
+
+The rail is forward-only: root -> ready -> active. A workitem already on a
+stage cannot move backward, and moving one out of a dungeon is a restore
+rather than a promote.
 
 ```
 camp workitem promote [id] --target <target> [flags]
@@ -34,7 +40,7 @@ camp workitem promote [id] --target <target> [flags]
       --json            Output result as a single JSON object
       --keep            On festival/doc, do not move the source workitem to the dungeon
       --no-commit       Skip the auto-commit
-      --target string   Promotion target: festival, doc, completed, archived, someday
+      --target string   Promotion target: festival, doc, ready, active, completed, archived, someday
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest/fest.md
+++ b/docs/cli-reference/fest/fest.md
@@ -73,6 +73,7 @@ Run 'fest understand' to learn the methodology before executing tasks.
 * [fest migrate](../fest_migrate/)	 - Migrate festival documents
 * [fest move](../fest_move/)	 - Move files between festival and linked project
 * [fest next](../fest_next/)	 - Find the next task to work on
+* [fest pack](../fest_pack/)	 - Pack a festival or ritual directory into a .festival bundle
 * [fest parse](../fest_parse/)	 - Parse festival documents into structured output
 * [fest plugins](../fest_plugins/)	 - List discovered fest plugins
 * [fest progress](../fest_progress/)	 - Track and display festival execution progress
@@ -91,7 +92,8 @@ Run 'fest understand' to learn the methodology before executing tasks.
 * [fest system](../fest_system/)	 - Manage fest tool configuration and templates
 * [fest task](../fest_task/)	 - Manage task status (show, edit, complete, block, reset)
 * [fest templates](../fest_templates/)	 - Manage agent-created templates within a festival
-* [fest types](../fest_types/)	 - Discover and explore template types
+* [fest types](../fest_types/)	 - Discover types for fest create
+* [fest unbundle](../fest_unbundle/)	 - Unbundle a .festival archive into a directory
 * [fest understand](../fest_understand/)	 - Learn methodology FIRST - run before executing festival tasks
 * [fest unlink](../fest_unlink/)	 - Remove festival-project link (context-aware)
 * [fest validate](../fest_validate/)	 - Check festival structure - find missing task files and issues

--- a/docs/cli-reference/fest/fest_commit.md
+++ b/docs/cli-reference/fest/fest_commit.md
@@ -29,8 +29,7 @@ with only festival-scoped files staged (not git add -A).
 
 Use --no-root to skip the campaign root commit.
 
-Reference format: [OBEY-FE-{id}]
-  - OBEY: Obey workflow tool prefix
+Reference format: [FE-{id}]
   - FE: Festival component identifier
   - {id}: Task ref (FEST-xxxxxx) or festival ID (e.g., CS0001)
 
@@ -43,14 +42,14 @@ Detection priority:
 Examples:
 ```bash
   fest commit -m "Implement feature"
-  # In linked project → [OBEY-FE-CS0001] Implement feature
-  # In festival task  → [OBEY-FE-FEST-a3b2c1] Implement feature
+  # In linked project → [FE-CS0001] Implement feature
+  # In festival task  → [FE-FEST-a3b2c1] Implement feature
 
   fest commit --task FEST-b4c5d6 -m "Related work"
-  # → [OBEY-FE-FEST-b4c5d6] Related work
+  # → [FE-FEST-b4c5d6] Related work
 
   fest commit --festival OA0001 -m "Work from unlinked dir"
-  # → [OBEY-FE-OA0001] Work from unlinked dir
+  # → [FE-OA0001] Work from unlinked dir
 
   fest commit --no-tag -m "No reference"
   # → No reference
@@ -70,6 +69,7 @@ fest commit [flags]
 
 ```
       --auto-write        run configured commit message writer
+      --commit-large      commit over-threshold files instead of keeping them out of git
       --festival string   festival name or ID (overrides auto-detection)
   -h, --help              help for commit
       --json              output result as JSON

--- a/docs/cli-reference/fest/fest_create_festival.md
+++ b/docs/cli-reference/fest/fest_create_festival.md
@@ -29,7 +29,7 @@ fest create festival [flags]
       --seed-file string      File whose contents seed the ingest phase input_specs/ (mutually exclusive with --seed)
       --skip-markers          Skip REPLACE marker processing
       --tags string           Comma-separated tags
-      --type string           Festival type (standard, implementation, research, quick, ritual)
+      --type string           Festival type (standard, implementation, research, ritual); see 'fest types list --level festival'
       --vars-file string      JSON file with variables
 ```
 

--- a/docs/cli-reference/fest/fest_list.md
+++ b/docs/cli-reference/fest/fest_list.md
@@ -20,8 +20,8 @@ dungeon, dungeon/completed, dungeon/archived, dungeon/someday
 By default, shows active, ready, planning, and ritual festivals.
 Use 'fest list all' (or --all) to include completed and dungeon festivals.
 
-Use --watch to continuously refresh the multi-festival status board in place
-(similar to fest watch, but without cycling between festivals). Ctrl+C to quit.
+Use --watch to refresh the multi-festival status board when festival progress
+or lifecycle status changes (similar to fest watch, but without cycling). Ctrl+C to quit.
 
 ```
 fest list [status] [flags]
@@ -55,7 +55,7 @@ fest list [status] [flags]
       --sort string             sort by: date|status|progress|name|created|updated
       --status string           filter by status: active|planning|completed|dungeon
       --until string            show festivals created on or before this date (YYYY-MM-DD or RFC3339)
-  -w, --watch                   continuously refresh the list in place until Ctrl+C
+  -w, --watch                   refresh the list when festival progress or lifecycle status changes
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest/fest_pack.md
+++ b/docs/cli-reference/fest/fest_pack.md
@@ -1,0 +1,48 @@
+---
+title: "fest pack"
+linkTitle: "fest pack"
+description: "Pack a festival or ritual directory into a .festival bundle"
+---
+
+## fest pack
+
+Pack a festival or ritual directory into a .festival bundle
+
+### Synopsis
+
+Pack a festival/ritual tree into a portable .festival ZIP.
+
+Does not execute or promote the festival. Out-of-root file links are vendored
+into .artifacts/; in-root links are left unchanged.
+
+Works from any directory (global scope); source path is explicit.
+
+```
+fest pack [source-dir] [flags]
+```
+
+### Options
+
+```
+      --creator string   bundle.creator (default "fest")
+  -h, --help             help for pack
+      --json             print info.json on stdout
+      --kind string      bundle kind (festival|ritual); inferred when empty
+      --name string      bundle name
+      --no-sent-record   skip .bundles/sent on source
+  -o, --output string    output .festival path (required)
+      --strict           fail if out-of-root links are missing
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest](../fest/)	 - Festival Methodology CLI - goal-oriented project management for AI agents

--- a/docs/cli-reference/fest/fest_types.md
+++ b/docs/cli-reference/fest/fest_types.md
@@ -1,26 +1,33 @@
 ---
 title: "fest types"
 linkTitle: "fest types"
-description: "Discover and explore template types"
+description: "Discover types for fest create"
 ---
 
 ## fest types
 
-Discover and explore template types
+Discover types for fest create
 
 ### Synopsis
 
-Explore available template types at each festival level.
+List festival, phase, sequence, and task types available for create.
 
-Template types define the structure and purpose of festivals, phases,
-sequences, and tasks. Custom types can be added in .festival/templates/.
+Festival workflow types (standard, implementation, research, ritual) come from
+festival_types.yaml. Phase scaffold types come from the methodology templates
+tree under festivals/.festival/templates/phases/.
 
 Examples:
 ```bash
-  fest types list                        # List all available types
-  fest types list --level task           # List task-level types only
-  fest types show feature                # Show details about a type
+  fest types                             # Same as fest types list
+  fest types list --level festival       # Values for create festival --type
+  fest types list --level phase          # Values for create phase --type
+  fest types show standard               # Festival workflow type details
   fest types show implementation --level phase
+  fest types festival                    # Festival workflow types (alias)
+```
+
+```
+fest types [flags]
 ```
 
 ### Options

--- a/docs/cli-reference/fest/fest_types_festival.md
+++ b/docs/cli-reference/fest/fest_types_festival.md
@@ -10,14 +10,13 @@ Discover festival types
 
 ### Synopsis
 
-Discover available festival types and their phase structures.
+Discover available festival workflow types and their phase structures.
 
-Festival types define the workflow structure for different kinds of projects:
-  - standard: Full planning and implementation phases
+These are the values for 'fest create festival --type'. Built-in types:
+  - standard: Full planning and implementation phases (default)
   - implementation: Direct implementation without planning
   - research: Research-focused workflow
-  - quick: Fast, minimal overhead workflow
-  - ritual: Simple repeating patterns
+  - ritual: Custom structure defined by the festival
 
 Examples:
 ```bash
@@ -52,6 +51,6 @@ fest types festival [type-name] [flags]
 
 ### SEE ALSO
 
-* [fest types](../fest_types/)	 - Discover and explore template types
+* [fest types](../fest_types/)	 - Discover types for fest create
 * [fest types festival list](../fest_types_festival_list/)	 - List all festival types
 * [fest types festival show](../fest_types_festival_show/)	 - Show details for a festival type

--- a/docs/cli-reference/fest/fest_types_festival_show.md
+++ b/docs/cli-reference/fest/fest_types_festival_show.md
@@ -20,7 +20,7 @@ Examples:
   fest types festival show standard           # Show standard type details
   fest types festival show implementation     # Show implementation type
   fest types festival show standard --phases  # Show only phases
-  fest types festival show quick --json       # JSON output
+  fest types festival show research --json    # JSON output
 ```
 
 ```

--- a/docs/cli-reference/fest/fest_types_list.md
+++ b/docs/cli-reference/fest/fest_types_list.md
@@ -10,19 +10,20 @@ List available template types
 
 ### Synopsis
 
-List all template types available at each festival level.
+List types you can pass to fest create, grouped by level.
 
-Types are discovered from:
-  - Built-in templates (~/.obey/fest/templates/)
-  - Custom templates (.festival/templates/ in a festival)
+Sources:
+  - Festival workflow types from festival_types.yaml (create festival --type)
+  - Phase/sequence/task scaffold packages under the methodology templates tree
+    (~/.obey/fest/festivals/.festival/templates or campaign festivals/.festival/templates)
+  - Custom overrides in a festival's .festival/templates/
 
 Examples:
 ```bash
-  fest types list                  # List all types grouped by level
-  fest types list --level task     # List task-level types only
-  fest types list --custom         # Show only custom types
-  fest types list --all            # Include marker counts
-  fest types list --json           # Machine-readable output
+  fest types list                      # All levels
+  fest types list --level festival     # create festival --type values
+  fest types list --level phase        # create phase --type values
+  fest types list --json               # Machine-readable output
 ```
 
 ```
@@ -50,4 +51,4 @@ fest types list [flags]
 
 ### SEE ALSO
 
-* [fest types](../fest_types/)	 - Discover and explore template types
+* [fest types](../fest_types/)	 - Discover types for fest create

--- a/docs/cli-reference/fest/fest_types_show.md
+++ b/docs/cli-reference/fest/fest_types_show.md
@@ -10,16 +10,15 @@ Show details about a template type
 
 ### Synopsis
 
-Display detailed information about a specific template type.
+Display detailed information about a specific type.
 
-Shows the type's level, description, number of markers, template files,
-and example usage.
+Shows the type's level, description, markers, template files, and example usage.
 
 Examples:
 ```bash
-  fest types show feature                   # Show feature type details
-  fest types show implementation --level phase  # Show phase-level implementation
-  fest types show simple --level task --json    # JSON output
+  fest types show standard                      # Festival workflow type
+  fest types show implementation --level phase  # Phase scaffold type
+  fest types show default --level task --json   # Task package
 ```
 
 ```
@@ -46,4 +45,4 @@ fest types show <type-name> [flags]
 
 ### SEE ALSO
 
-* [fest types](../fest_types/)	 - Discover and explore template types
+* [fest types](../fest_types/)	 - Discover types for fest create

--- a/docs/cli-reference/fest/fest_unbundle.md
+++ b/docs/cli-reference/fest/fest_unbundle.md
@@ -1,0 +1,49 @@
+---
+title: "fest unbundle"
+linkTitle: "fest unbundle"
+description: "Unbundle a .festival archive into a directory"
+---
+
+## fest unbundle
+
+Unbundle a .festival archive into a directory
+
+### Synopsis
+
+Extract a Festival Bundle into a live directory.
+
+Does NOT run, promote, or activate the festival. Use fest ritual run or normal
+fest workflow separately after unbundle if execution is desired.
+
+Optional --validate runs in-process festival validation on the destination
+(this binary's validator, not a PATH-installed fest). Validation diagnostics
+go to stderr so --json still emits a single JSON document on stdout.
+
+```
+fest unbundle [path.festival] [flags]
+```
+
+### Options
+
+```
+  -d, --dest string          destination directory (required)
+      --force                allow non-empty destination
+  -h, --help                 help for unbundle
+      --json                 print info.json on stdout
+      --no-received-record   skip .bundles/received
+      --no-verify            skip content-hash verification
+      --validate             run in-process fest validate on destination after unbundle
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest](../fest/)	 - Festival Methodology CLI - goal-oriented project management for AI agents


### PR DESCRIPTION
## What

RC-channel bundle refresh carrying the commit-guardrails release (festival CA0004, phase 003):

- **camp pinned to `v0.4.0-rc.2`** (1a98ab61): staging guards (large-file auto-handling, bulk block), artifact root auto-declaration, committed per-machine artifact manifests, deferred bookkeeping commits with per-repo lanes, `camp commit --json`, `--commit-large`, doctor `artifacts`/`bigfiles`/jobs checks, and the `StageAllWithOptions` commitkit export.
- **fest pinned to `v0.5.0-rc.2`** (329cd2f): staging and commits routed through camp commitkit (fest inherits the guard, lock retry, and the deferred-queue drain), `fest commit --json` emits pure JSON, `fest commit --commit-large`, plus the read-only lifecycle-resident work from WF0001.
- RC-channel CLI docs regenerated.
- Build fix: the bundled camp build now stamps the pinned tag (`VERSION="$(git describe --tags)"`); camp's own quick recipe defaults the string to "dev", so a correctly pinned binary reported the wrong version.

## Verification

- `camp --version` -> `v0.4.0-rc.2 (commit 1a98ab61)`; `fest --version` -> `v0.5.0-rc.2 (commit 329cd2f)`: exact tag matches.
- Stable build profile only: `camp quest` and `fest explore` (dev-gated) are absent from both binaries.
- `just test release-pins rc` passes.
- Repo smoke suite: doc-sync, docs-profile, release-pins, and both CLI suites ran; the camp integration portion showed 2/706 failures on the first pass and a full clean rerun of the entire suite in the pinned submodule (706 tests, ~13 min) passed, matching the campaign's documented Docker-load flake pattern (mass or spot failures under overlapping container activity; rerun before believing).

## First-run walkthrough (scratch HOME, bundle binaries)

`camp init` 3.3 s -> baseline commit -> `fest create festival --name ... --goal ...` (the wizard needs a TTY; flags work headless) -> `fest next` correctly STOPS on unfilled template markers with an actionable list -> `fest commit`.

- **Deferral behaves exactly as designed and is a visible first-run win**: `camp intent add` returns in 0.1 s printing `queued (my first idea)`, and ~2 s later the bookkeeping commit has landed at HEAD with `camp jobs` empty. Snappy return, nothing lost.
- **Known first-run defect reproduces on this bundle** (pre-existing, intent filed in the campaign, not introduced by these pins): in a campaign where fest has never run, `fest commit` from a festival fails with `pathspec '.campaign/fest' did not match any files` because `festivalScopedPaths` lists state dirs that do not exist yet. Workaround: `mkdir -p .campaign/fest festivals/.festival/.state` (or any fest navigation that creates them). Worth a fest patch before the launch push; flagged rather than papered over per the refresh checklist.

## Traceability

Festival: `camp-artifact-commit-guardrails-CA0004`, phase 003_INTEGRATE, sequence 03_bundle_refresh.
