### PR TITLE
fix(release-operator): guard pin flow against uninitialized submodules

### DIFF
--- a/tools/release-operator/commands.go
+++ b/tools/release-operator/commands.go
@@ -113,6 +113,18 @@ func (r *repoContext) justEnv(env map[string]string, args ...string) error {
 }
 
 func (r *repoContext) ensureAllWorktreesClean() error {
+	if err := r.ensureRootWorktreeClean(); err != nil {
+		return err
+	}
+	return r.ensureSubmoduleWorktreesClean()
+}
+
+// ensureRootWorktreeClean checks only the festival repo's own worktree. It
+// is split out from ensureSubmoduleWorktreesClean so callers can reject a
+// dirty superproject before ensureSubmodulesReady runs: initializing a
+// submodule is itself a mutation, and a command that is about to refuse for
+// a dirty tree should not perform that mutation first.
+func (r *repoContext) ensureRootWorktreeClean() error {
 	dirty, err := worktreeDirty(r.Root)
 	if err != nil {
 		return err
@@ -120,7 +132,14 @@ func (r *repoContext) ensureAllWorktreesClean() error {
 	if dirty {
 		return errors.New("festival repo has uncommitted changes")
 	}
+	return nil
+}
 
+// ensureSubmoduleWorktreesClean checks each submodule's own worktree. It
+// must only run after ensureSubmodulesReady, since checking dirty state on
+// an uninitialized submodule directory silently resolves against the
+// superproject instead of the submodule.
+func (r *repoContext) ensureSubmoduleWorktreesClean() error {
 	for _, sub := range submodules {
 		dirty, err := worktreeDirty(r.submodulePath(sub))
 		if err != nil {
@@ -130,7 +149,6 @@ func (r *repoContext) ensureAllWorktreesClean() error {
 			return fmt.Errorf("%s has uncommitted changes", sub)
 		}
 	}
-
 	return nil
 }
 
@@ -488,18 +506,27 @@ func ensureSubmodulesReady(root string) error {
 	return nil
 }
 
-// verifyCheckedOutTag confirms dir's HEAD is exactly the tag that was just
-// requested, rather than trusting the checkout succeeded silently against
-// the wrong repository or an unrelated commit.
+// verifyCheckedOutTag confirms dir's HEAD is exactly the commit the
+// requested tag points at, rather than trusting the checkout succeeded
+// silently against the wrong repository or an unrelated commit. HEAD is
+// allowed to carry other tags too: a release commit is routinely tagged
+// both vX.Y.Z-rc.N and, later, vX.Y.Z, and that is not itself a mismatch.
+// headMatchesTag compares the requested tag's own commit against HEAD
+// directly, so it is unaffected by any other tags also pointing at HEAD
+// (unlike exactTagAt, which returns only the single highest-sorting tag).
 func verifyCheckedOutTag(dir, name, tag string) error {
-	got, err := exactTagAt(dir)
+	match, err := headMatchesTag(dir, tag)
 	if err != nil {
 		return fmt.Errorf("verify %s checkout: %w", name, err)
 	}
-	if got != tag {
-		return fmt.Errorf("%s HEAD resolved to tag %q after checking out %q; refusing to trust a mismatched pin", name, valueOrNone(got), tag)
+	if match {
+		return nil
 	}
-	return nil
+	tags, tagsErr := exactTagsAt(dir)
+	if tagsErr != nil || len(tags) == 0 {
+		return fmt.Errorf("%s HEAD does not resolve to tag %q after checking it out; refusing to trust a mismatched pin", name, tag)
+	}
+	return fmt.Errorf("%s HEAD resolved to %s after checking out %q; refusing to trust a mismatched pin", name, strings.Join(tags, ", "), tag)
 }
 
 // gitRef captures a worktree's exact position: the branch it was on (empty
@@ -529,11 +556,20 @@ func captureGitRef(dir string) (gitRef, error) {
 // restore returns dir to exactly the branch/commit ref describes. When ref
 // was on a branch, restore lands back on that branch at that commit, never
 // on a detached HEAD; ref.branch is only empty when the worktree already
-// started detached.
+// started detached. The hard reset only runs when the branch has actually
+// moved off the captured commit, so restore does not rewind a branch tip
+// that nothing touched.
 func (ref gitRef) restore(dir string) error {
 	if ref.branch != "" {
 		if err := runCmd(dir, nil, "git", "checkout", ref.branch); err != nil {
 			return err
+		}
+		current, err := gitOutput(dir, "rev-parse", "HEAD")
+		if err != nil {
+			return err
+		}
+		if current == ref.commit {
+			return nil
 		}
 		return runCmd(dir, nil, "git", "reset", "--hard", ref.commit)
 	}
@@ -569,10 +605,16 @@ func (r *repoContext) pinFromLatest(modeName, festSelector, campSelector string)
 	if err != nil {
 		return err
 	}
+	// Check the superproject's own worktree before ensureSubmodulesReady:
+	// auto-initializing a submodule is itself a mutation, and a dirty root
+	// should refuse before that mutation happens, not after.
+	if err = r.ensureRootWorktreeClean(); err != nil {
+		return err
+	}
 	if err = ensureSubmodulesReady(r.Root); err != nil {
 		return err
 	}
-	if err = r.ensureAllWorktreesClean(); err != nil {
+	if err = r.ensureSubmoduleWorktreesClean(); err != nil {
 		return err
 	}
 
@@ -758,6 +800,12 @@ func runCheckBundledModules(ctx *repoContext) error {
 }
 
 func runPreflight(ctx *repoContext, mode releaseMode) error {
+	// Check the superproject's own worktree before ensureSubmodulesReady:
+	// auto-initializing a submodule is itself a mutation, and a dirty root
+	// should refuse before that mutation happens, not after.
+	if err := ctx.ensureRootWorktreeClean(); err != nil {
+		return err
+	}
 	if err := ensureSubmodulesReady(ctx.Root); err != nil {
 		return err
 	}
@@ -785,7 +833,7 @@ func runPreflight(ctx *repoContext, mode releaseMode) error {
 	}
 	fmt.Println()
 
-	if err := ctx.ensureAllWorktreesClean(); err != nil {
+	if err := ctx.ensureSubmoduleWorktreesClean(); err != nil {
 		return err
 	}
 	fmt.Println("Submodules: clean")
@@ -936,10 +984,13 @@ func runDraftBootstrap(ctx *repoContext, festivalVersion, festVersion, campVersi
 	if err != nil {
 		return err
 	}
+	if err := ctx.ensureRootWorktreeClean(); err != nil {
+		return err
+	}
 	if err := ensureSubmodulesReady(ctx.Root); err != nil {
 		return err
 	}
-	if err := ctx.ensureAllWorktreesClean(); err != nil {
+	if err := ctx.ensureSubmoduleWorktreesClean(); err != nil {
 		return err
 	}
 	if err := ctx.fetchReleaseRefs(); err != nil {
@@ -966,7 +1017,13 @@ func runDraftBootstrap(ctx *repoContext, festivalVersion, festVersion, campVersi
 	if err := ctx.checkoutSubmoduleTag("fest", festTag); err != nil {
 		return err
 	}
+	if err := verifyCheckedOutTag(ctx.submodulePath("fest"), "fest", festTag); err != nil {
+		return err
+	}
 	if err := ctx.checkoutSubmoduleTag("camp", campTag); err != nil {
+		return err
+	}
+	if err := verifyCheckedOutTag(ctx.submodulePath("camp"), "camp", campTag); err != nil {
 		return err
 	}
 	if err := ctx.runDocs(stable); err != nil {

--- a/tools/release-operator/commands.go
+++ b/tools/release-operator/commands.go
@@ -419,15 +419,186 @@ func (r *repoContext) checkoutSubmoduleTag(name, tag string) error {
 	return r.runGitSubmodule(name, "checkout", "--detach", tag)
 }
 
-func (r *repoContext) pinFromLatest(modeName, festSelector, campSelector string) error {
+// submoduleIsIndependent reports whether dir is itself a distinct git
+// worktree rather than an uninitialized submodule placeholder directory.
+// Git commands locate their repository by walking up from cwd through
+// parent directories until they find a .git entry. An uninitialized
+// submodule directory has none of its own, so every git command run
+// against it silently resolves against the superproject instead of
+// failing. That fallthrough is what let the pin flow resolve the
+// superproject's own ancient tags for camp/fest, and what turned a
+// submodule "checkout" into a checkout of the superproject itself.
+// Comparing the discovered toplevel against dir catches that fallthrough
+// directly, regardless of why the submodule ended up uninitialized.
+func submoduleIsIndependent(dir string) bool {
+	info, statErr := os.Stat(dir)
+	if statErr != nil || !info.IsDir() {
+		return false
+	}
+	out, err := gitOutput(dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return false
+	}
+	want := cleanRealPath(dir)
+	got := cleanRealPath(strings.TrimSpace(out))
+	return want != "" && want == got
+}
+
+// cleanRealPath resolves path to an absolute, symlink-free form for
+// worktree-identity comparisons, falling back to the plain absolute path
+// when symlink resolution fails (e.g. the path does not exist yet).
+func cleanRealPath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	if real, err := filepath.EvalSymlinks(abs); err == nil {
+		return real
+	}
+	return abs
+}
+
+// ensureSubmodulesReady verifies every submodule under root is its own
+// independent git worktree before any release tooling reads or mutates it.
+// When a submodule is not initialized, it is initialized automatically
+// (git submodule update --init) and its tags are fetched; if it still is
+// not independent afterward, ensureSubmodulesReady refuses loudly before
+// any further mutation happens rather than let git silently fall through
+// to the superproject. See festival-release-operator-running-pin-20260729-233926.
+func ensureSubmodulesReady(root string) error {
+	for _, sub := range submodules {
+		path := filepath.Join(root, sub)
+		if submoduleIsIndependent(path) {
+			continue
+		}
+
+		fmt.Printf("%s submodule is not initialized; running 'git submodule update --init -- %s'\n", sub, sub)
+		if err := runCmd(root, nil, "git", "submodule", "update", "--init", "--", sub); err != nil {
+			return fmt.Errorf("initialize %s submodule: %w\nrun 'git submodule update --init -- %s' in %s and retry", sub, err, sub, root)
+		}
+		if !submoduleIsIndependent(path) {
+			return fmt.Errorf("%s did not become an independent git worktree after 'git submodule update --init'; refusing to continue rather than risk resolving refs against the superproject", sub)
+		}
+
+		if err := runCmd(path, nil, "git", "fetch", "--prune", "--prune-tags", "origin", "+refs/tags/*:refs/tags/*"); err != nil {
+			return fmt.Errorf("fetch tags for %s after initializing submodule: %w", sub, err)
+		}
+		fmt.Printf("%s submodule initialized and tags fetched\n", sub)
+	}
+	return nil
+}
+
+// verifyCheckedOutTag confirms dir's HEAD is exactly the tag that was just
+// requested, rather than trusting the checkout succeeded silently against
+// the wrong repository or an unrelated commit.
+func verifyCheckedOutTag(dir, name, tag string) error {
+	got, err := exactTagAt(dir)
+	if err != nil {
+		return fmt.Errorf("verify %s checkout: %w", name, err)
+	}
+	if got != tag {
+		return fmt.Errorf("%s HEAD resolved to tag %q after checking out %q; refusing to trust a mismatched pin", name, valueOrNone(got), tag)
+	}
+	return nil
+}
+
+// gitRef captures a worktree's exact position: the branch it was on (empty
+// when HEAD was already detached) and the commit it pointed at.
+type gitRef struct {
+	branch string
+	commit string
+}
+
+// captureGitRef records dir's current branch/commit so it can be restored
+// later if a subsequent step fails.
+func captureGitRef(dir string) (gitRef, error) {
+	branch, err := gitOutput(dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return gitRef{}, fmt.Errorf("capture starting state of %s: %w", dir, err)
+	}
+	commit, err := gitOutput(dir, "rev-parse", "HEAD")
+	if err != nil {
+		return gitRef{}, fmt.Errorf("capture starting state of %s: %w", dir, err)
+	}
+	if branch == "HEAD" {
+		branch = ""
+	}
+	return gitRef{branch: branch, commit: commit}, nil
+}
+
+// restore returns dir to exactly the branch/commit ref describes. When ref
+// was on a branch, restore lands back on that branch at that commit, never
+// on a detached HEAD; ref.branch is only empty when the worktree already
+// started detached.
+func (ref gitRef) restore(dir string) error {
+	if ref.branch != "" {
+		if err := runCmd(dir, nil, "git", "checkout", ref.branch); err != nil {
+			return err
+		}
+		return runCmd(dir, nil, "git", "reset", "--hard", ref.commit)
+	}
+	return runCmd(dir, nil, "git", "checkout", "--detach", ref.commit)
+}
+
+// rollbackPin restores the festival repo and both submodules to exactly
+// where they stood before pinFromLatest began mutating them. It runs
+// whenever pinFromLatest fails partway through, so a failed pin never
+// leaves a submodule, or the superproject, sitting on an unrelated commit.
+// Restoring camp and fest first means that if root and a submodule ref were
+// captured identically (the uninitialized-submodule fallthrough this guards
+// against), the submodule restore already lands root back on its starting
+// ref; the explicit root restore below is a second, independent guarantee
+// of the same outcome.
+func (r *repoContext) rollbackPin(root, fest, camp gitRef) {
+	if rerr := camp.restore(r.submodulePath("camp")); rerr != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: failed to restore camp to its starting state: %v\n", rerr)
+	}
+	if rerr := fest.restore(r.submodulePath("fest")); rerr != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: failed to restore fest to its starting state: %v\n", rerr)
+	}
+	if rerr := root.restore(r.Root); rerr != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: failed to restore festival repo to its starting state: %v\n", rerr)
+	}
+	if _, rerr := r.git("reset", "--", "fest", "camp"); rerr != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: failed to unstage submodule pointer changes during rollback: %v\n", rerr)
+	}
+}
+
+func (r *repoContext) pinFromLatest(modeName, festSelector, campSelector string) (err error) {
 	mode, err := modeConfig(modeName)
 	if err != nil {
 		return err
 	}
-	if err := r.ensureAllWorktreesClean(); err != nil {
+	if err = ensureSubmodulesReady(r.Root); err != nil {
 		return err
 	}
-	if err := r.fetchReleaseRefs(); err != nil {
+	if err = r.ensureAllWorktreesClean(); err != nil {
+		return err
+	}
+
+	// Capture exactly where the festival repo and both submodules stand
+	// before anything below mutates them, so any failure can restore all
+	// three to their starting branch/commit instead of leaving something
+	// checked out on an unrelated release commit.
+	startRoot, err := captureGitRef(r.Root)
+	if err != nil {
+		return err
+	}
+	startFest, err := captureGitRef(r.submodulePath("fest"))
+	if err != nil {
+		return err
+	}
+	startCamp, err := captureGitRef(r.submodulePath("camp"))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			r.rollbackPin(startRoot, startFest, startCamp)
+		}
+	}()
+
+	if err = r.fetchReleaseRefs(); err != nil {
 		return err
 	}
 
@@ -452,16 +623,23 @@ func (r *repoContext) pinFromLatest(modeName, festSelector, campSelector string)
 		default:
 			fmt.Println("Create dev tags in fest/camp first, then rerun with mode=dev.")
 		}
-		return errors.New("missing component tags")
+		err = errors.New("missing component tags")
+		return err
 	}
 
-	if err := r.checkoutSubmoduleTag("fest", festTag); err != nil {
+	if err = r.checkoutSubmoduleTag("fest", festTag); err != nil {
 		return err
 	}
-	if err := r.checkoutSubmoduleTag("camp", campTag); err != nil {
+	if err = verifyCheckedOutTag(r.submodulePath("fest"), "fest", festTag); err != nil {
 		return err
 	}
-	if err := r.stageSubmoduleRefs(); err != nil {
+	if err = r.checkoutSubmoduleTag("camp", campTag); err != nil {
+		return err
+	}
+	if err = verifyCheckedOutTag(r.submodulePath("camp"), "camp", campTag); err != nil {
+		return err
+	}
+	if err = r.stageSubmoduleRefs(); err != nil {
 		return err
 	}
 
@@ -580,6 +758,10 @@ func runCheckBundledModules(ctx *repoContext) error {
 }
 
 func runPreflight(ctx *repoContext, mode releaseMode) error {
+	if err := ensureSubmodulesReady(ctx.Root); err != nil {
+		return err
+	}
+
 	fmt.Println("=== Release Preflight ===")
 	fmt.Println()
 	fmt.Println("Submodule pins:")
@@ -752,6 +934,9 @@ func runDraftExplicit(ctx *repoContext, version string, mode releaseMode, iterat
 func runDraftBootstrap(ctx *repoContext, festivalVersion, festVersion, campVersion string) error {
 	stable, err := modeConfig("stable")
 	if err != nil {
+		return err
+	}
+	if err := ensureSubmodulesReady(ctx.Root); err != nil {
 		return err
 	}
 	if err := ctx.ensureAllWorktreesClean(); err != nil {

--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -397,14 +397,17 @@ func collectState(repoRoot, channel, festSelector, campSelector string) (operato
 		return operator.BundleInput{}, fmt.Errorf("channel must be dev, rc, or stable (got %q)", channel)
 	}
 
-	if err := ensureSubmodulesReady(repoRoot); err != nil {
-		return operator.BundleInput{}, err
-	}
-
+	// Check the superproject's own worktree before ensureSubmodulesReady:
+	// auto-initializing a submodule is itself a mutation, and a dirty root
+	// should refuse before that mutation happens, not after.
 	if dirty, err := worktreeDirty(repoRoot); err != nil {
 		return operator.BundleInput{}, err
 	} else if dirty {
 		return operator.BundleInput{}, errors.New("festival repo has uncommitted changes")
+	}
+
+	if err := ensureSubmodulesReady(repoRoot); err != nil {
+		return operator.BundleInput{}, err
 	}
 
 	for _, sub := range submodules {

--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -397,6 +397,10 @@ func collectState(repoRoot, channel, festSelector, campSelector string) (operato
 		return operator.BundleInput{}, fmt.Errorf("channel must be dev, rc, or stable (got %q)", channel)
 	}
 
+	if err := ensureSubmodulesReady(repoRoot); err != nil {
+		return operator.BundleInput{}, err
+	}
+
 	if dirty, err := worktreeDirty(repoRoot); err != nil {
 		return operator.BundleInput{}, err
 	} else if dirty {

--- a/tools/release-operator/submodule_guard_test.go
+++ b/tools/release-operator/submodule_guard_test.go
@@ -228,33 +228,64 @@ func TestPinFromLatestInitializesUninitializedSubmodulesAndResolvesRealTags(t *t
 	}
 }
 
-// TestPinFromLatestRollsBackOnPostCheckoutMismatch forces a failure after
-// fest has already been pinned successfully: camp's resolved commit carries
-// both the requested rc tag and an unrelated, higher-sorting stable tag, so
-// verifyCheckedOutTag catches HEAD resolving to the wrong tag. pinFromLatest
-// must then restore fest to its starting commit and leave the superproject
-// on its starting branch, rather than leaving a half-applied pin behind.
-func TestPinFromLatestRollsBackOnPostCheckoutMismatch(t *testing.T) {
+// TestPinFromLatestSucceedsWhenPinnedCommitCarriesMultipleTags pins the bug
+// fix in place: a release commit is routinely tagged both vX.Y.Z-rc.N and,
+// later, vX.Y.Z. verifyCheckedOutTag must not treat the extra, higher-
+// sorting stable tag as a mismatch when the requested rc tag is present.
+func TestPinFromLatestSucceedsWhenPinnedCommitCarriesMultipleTags(t *testing.T) {
+	root, campOrigin, festOrigin := newSubmoduleFixture(t)
+	addOriginRelease(t, festOrigin, "v8.8.8-rc.1")
+	// v99.0.0 sorts ahead of v9.9.9-rc.1 under --sort=-v:refname; exactTagAt
+	// alone would have picked v99.0.0, which is exactly the false-positive
+	// verifyCheckedOutTag must no longer produce.
+	addOriginRelease(t, campOrigin, "v9.9.9-rc.1", "v99.0.0")
+
+	ctx := testRepoContext(t, root)
+	if err := ctx.pinFromLatest("rc", "latest", "latest"); err != nil {
+		t.Fatalf("pinFromLatest returned error for a multi-tagged pinned commit: %v", err)
+	}
+
+	campTag, err := exactTagAtForMode(filepath.Join(root, "camp"), "rc")
+	if err != nil {
+		t.Fatalf("exactTagAtForMode(camp, rc): %v", err)
+	}
+	if campTag != "v9.9.9-rc.1" {
+		t.Fatalf("camp pinned to %q, want v9.9.9-rc.1", campTag)
+	}
+}
+
+// TestPinFromLatestRollsBackWhenCampCheckoutFailsAfterFestSucceeds forces a
+// real, mid-flow failure after fest has already been resolved, checked out,
+// and verified successfully: camp's own index is locked, so its checkout
+// fails outright. pinFromLatest must then restore fest to its starting
+// commit/branch and leave the superproject on its starting branch, rather
+// than leaving a half-applied pin behind.
+func TestPinFromLatestRollsBackWhenCampCheckoutFailsAfterFestSucceeds(t *testing.T) {
 	root, campOrigin, festOrigin := newSubmoduleFixture(t)
 	festStart := gitRevParse(t, filepath.Join(root, "fest"), "HEAD")
 	festStartBranch := gitRevParse(t, filepath.Join(root, "fest"), "--abbrev-ref", "HEAD")
 	campStart := gitRevParse(t, filepath.Join(root, "camp"), "HEAD")
+	campStartBranch := gitRevParse(t, filepath.Join(root, "camp"), "--abbrev-ref", "HEAD")
 	rootHeadBefore := gitRevParse(t, root, "HEAD")
 
 	addOriginRelease(t, festOrigin, "v8.8.8-rc.1")
-	// v99.0.0 sorts ahead of v9.9.9-rc.1 under --sort=-v:refname, so
-	// exactTagAt (which does not filter by mode) disagrees with the rc
-	// resolution that picked v9.9.9-rc.1, exactly the "resolved commit
-	// doesn't match the requested tag" case the sanity check exists for.
-	addOriginRelease(t, campOrigin, "v9.9.9-rc.1", "v99.0.0")
+	addOriginRelease(t, campOrigin, "v9.9.9-rc.1")
+
+	// Lock camp's own index (its real git dir lives under
+	// root/.git/modules/camp, independent of fest's and root's own index),
+	// so `git checkout` inside camp fails after fest's own resolve/
+	// checkout/verify has already completed successfully.
+	campIndexLock := filepath.Join(root, ".git", "modules", "camp", "index.lock")
+	writeFile(t, campIndexLock, "")
 
 	ctx := testRepoContext(t, root)
 	err := ctx.pinFromLatest("rc", "latest", "latest")
 	if err == nil {
-		t.Fatal("expected pinFromLatest to fail on the ambiguous camp tag")
+		t.Fatal("expected pinFromLatest to fail while camp's index is locked")
 	}
-	if !strings.Contains(err.Error(), "camp") {
-		t.Fatalf("error does not mention camp: %v", err)
+
+	if rmErr := os.Remove(campIndexLock); rmErr != nil && !os.IsNotExist(rmErr) {
+		t.Fatalf("remove camp index.lock: %v", rmErr)
 	}
 
 	festHead := gitRevParse(t, filepath.Join(root, "fest"), "HEAD")
@@ -268,6 +299,9 @@ func TestPinFromLatestRollsBackOnPostCheckoutMismatch(t *testing.T) {
 	campHead := gitRevParse(t, filepath.Join(root, "camp"), "HEAD")
 	if campHead != campStart {
 		t.Fatalf("camp HEAD = %s after rollback, want unchanged starting commit %s", campHead, campStart)
+	}
+	if branch := gitRevParse(t, filepath.Join(root, "camp"), "--abbrev-ref", "HEAD"); branch != campStartBranch {
+		t.Fatalf("camp branch = %q after rollback, want unchanged starting branch %q", branch, campStartBranch)
 	}
 
 	if branch := gitRevParse(t, root, "--abbrev-ref", "HEAD"); branch != "main" {
@@ -283,6 +317,27 @@ func TestPinFromLatestRollsBackOnPostCheckoutMismatch(t *testing.T) {
 	}
 	if strings.TrimSpace(status) != "" {
 		t.Fatalf("festival repo is dirty after rollback: %q", status)
+	}
+}
+
+// TestPinFromLatestRejectsDirtyRootBeforeInitializingSubmodules pins the
+// clean-tree-check ordering: a dirty superproject must be rejected before
+// ensureSubmodulesReady runs, since auto-initializing a submodule is itself
+// a mutation and a command that is about to refuse for a dirty tree should
+// not perform that mutation first.
+func TestPinFromLatestRejectsDirtyRootBeforeInitializingSubmodules(t *testing.T) {
+	root, _, _ := newSubmoduleFixture(t)
+	deinitSubmodule(t, root, "camp")
+
+	writeFile(t, filepath.Join(root, "README.md"), "dirty\n")
+
+	ctx := testRepoContext(t, root)
+	if err := ctx.pinFromLatest("rc", "latest", "latest"); err == nil {
+		t.Fatal("expected pinFromLatest to fail on a dirty festival repo")
+	}
+
+	if submoduleIsIndependent(filepath.Join(root, "camp")) {
+		t.Fatal("camp was initialized even though the run should have refused on a dirty root first")
 	}
 }
 
@@ -322,5 +377,24 @@ func TestVerifyCheckedOutTag(t *testing.T) {
 
 	if err := verifyCheckedOutTag(repo, "test", "v9.9.9"); err == nil {
 		t.Fatal("expected verifyCheckedOutTag to fail for a tag HEAD does not carry")
+	}
+
+	// A release commit is routinely tagged both vX.Y.Z-rc.N and, later,
+	// vX.Y.Z. The requested (lower-sorting) tag being present must still
+	// pass, even though a higher-sorting tag also points at the same
+	// commit: exactTagAt alone would have picked v99.0.0 here and wrongly
+	// reported a mismatch.
+	runGit(t, repo, "tag", "v99.0.0")
+	if err := verifyCheckedOutTag(repo, "test", "v0.1.0"); err != nil {
+		t.Fatalf("verifyCheckedOutTag returned error for a requested tag present on a multi-tagged HEAD: %v", err)
+	}
+
+	// A genuinely different commit must still fail.
+	writeFile(t, filepath.Join(repo, "next.txt"), "next\n")
+	runGit(t, repo, "add", "next.txt")
+	runGit(t, repo, "commit", "-m", "next commit")
+	runGit(t, repo, "tag", "v0.2.0")
+	if err := verifyCheckedOutTag(repo, "test", "v0.1.0"); err == nil {
+		t.Fatal("expected verifyCheckedOutTag to fail when HEAD moved to a genuinely different commit")
 	}
 }

--- a/tools/release-operator/submodule_guard_test.go
+++ b/tools/release-operator/submodule_guard_test.go
@@ -1,0 +1,326 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newSubmoduleFixture builds a festival repo fixture with real, initialized
+// git submodules named fest and camp, each cloned from its own local origin
+// repo. Root itself carries an "ancient" prerelease tag (v0.1.2-rc.1),
+// mirroring festival's own early tag history: if submodule git commands
+// ever fall through to the superproject again, this is the wrong-but-
+// plausible tag that resolution would find instead of the submodule's own.
+//
+// fest/camp submodules are added at their origin's first commit, then each
+// origin gains a second commit with the "real" release tags the pin flow
+// should resolve to. This mirrors `just refresh-rc`: submodules start
+// pinned behind, and pinning should move them forward to the requested
+// tags, never to something else.
+func newSubmoduleFixture(t *testing.T) (root, campOrigin, festOrigin string) {
+	t.Helper()
+
+	// Recent git refuses the local-path transport for submodule clone/update
+	// by default (CVE-2022-39253 hardening). Allow it for this test process
+	// only: t.Setenv restores the prior value automatically, and the env
+	// var is inherited by every git subprocess this test spawns, including
+	// the `git submodule update --init` that ensureSubmodulesReady itself
+	// runs later against these same local-path origins.
+	t.Setenv("GIT_ALLOW_PROTOCOL", "file:https:ssh:git")
+
+	campOrigin = t.TempDir()
+	runGit(t, campOrigin, "init", "-b", "main")
+	runGit(t, campOrigin, "config", "user.name", "Test User")
+	runGit(t, campOrigin, "config", "user.email", "test@example.com")
+	writeFile(t, filepath.Join(campOrigin, "README.md"), "camp\n")
+	runGit(t, campOrigin, "add", "README.md")
+	runGit(t, campOrigin, "commit", "-m", "camp initial")
+
+	festOrigin = t.TempDir()
+	runGit(t, festOrigin, "init", "-b", "main")
+	runGit(t, festOrigin, "config", "user.name", "Test User")
+	runGit(t, festOrigin, "config", "user.email", "test@example.com")
+	writeFile(t, filepath.Join(festOrigin, "README.md"), "fest\n")
+	runGit(t, festOrigin, "add", "README.md")
+	runGit(t, festOrigin, "commit", "-m", "fest initial")
+
+	root = initTestRepo(t)
+	// pinFromLatest fetches the festival repo's own "origin" too, so root
+	// needs one even though these tests only care about the fest/camp
+	// submodule origins.
+	addBareOrigin(t, root)
+	runGit(t, root, "tag", "v0.1.2-rc.1")
+
+	runGit(t, root, "submodule", "add", campOrigin, "camp")
+	runGit(t, root, "submodule", "add", festOrigin, "fest")
+	runGit(t, root, "commit", "-m", "add submodules")
+
+	return root, campOrigin, festOrigin
+}
+
+// addOriginRelease adds a second commit to an origin repo (as created by
+// newSubmoduleFixture) and tags it with every tag in tags, all pointing at
+// that same new commit.
+func addOriginRelease(t *testing.T, origin string, tags ...string) {
+	t.Helper()
+	writeFile(t, filepath.Join(origin, "RELEASE.md"), strings.Join(tags, "\n")+"\n")
+	runGit(t, origin, "add", "RELEASE.md")
+	runGit(t, origin, "commit", "-m", "release "+strings.Join(tags, ","))
+	for _, tag := range tags {
+		runGit(t, origin, "tag", tag)
+	}
+}
+
+// deinitSubmodule empties a submodule's working directory so it reproduces
+// a worktree whose submodule was never initialized: the directory exists,
+// but (unlike a real submodule) has no .git of its own, so plain git
+// commands run against it fall through to the superproject.
+func deinitSubmodule(t *testing.T, root, name string) {
+	t.Helper()
+	runGit(t, root, "submodule", "deinit", "-f", "--", name)
+}
+
+func TestSubmoduleIsIndependent(t *testing.T) {
+	root, _, _ := newSubmoduleFixture(t)
+	campPath := filepath.Join(root, "camp")
+
+	if !submoduleIsIndependent(campPath) {
+		t.Fatal("expected camp to be independent right after submodule add")
+	}
+
+	deinitSubmodule(t, root, "camp")
+	if submoduleIsIndependent(campPath) {
+		t.Fatal("expected camp to be non-independent after deinit (uninitialized submodule)")
+	}
+
+	if submoduleIsIndependent(filepath.Join(root, "does-not-exist")) {
+		t.Fatal("expected a nonexistent directory to be reported as non-independent")
+	}
+}
+
+// TestEnsureSubmodulesReadyResolvesRealTagsAfterInit reproduces the exact
+// incident: with camp uninitialized, tag lookups against camp's path
+// silently resolve the superproject's own ancient tag instead of erroring.
+// ensureSubmodulesReady must fix that by initializing the submodule before
+// any tag is resolved.
+func TestEnsureSubmodulesReadyResolvesRealTagsAfterInit(t *testing.T) {
+	root, campOrigin, _ := newSubmoduleFixture(t)
+	addOriginRelease(t, campOrigin, "v9.9.9-rc.1")
+	campPath := filepath.Join(root, "camp")
+
+	deinitSubmodule(t, root, "camp")
+
+	// Reproduce the bug: with camp uninitialized, resolving an rc tag
+	// against camp's path silently returns root's own ancient rc tag.
+	if got := latestTagForMode(campPath, "rc"); got != "v0.1.2-rc.1" {
+		t.Fatalf("latestTagForMode(camp, rc) before fix = %q, want the superproject's ancient tag v0.1.2-rc.1 (bug did not reproduce)", got)
+	}
+
+	if err := ensureSubmodulesReady(root); err != nil {
+		t.Fatalf("ensureSubmodulesReady returned error: %v", err)
+	}
+
+	if !submoduleIsIndependent(campPath) {
+		t.Fatal("camp is still not independent after ensureSubmodulesReady")
+	}
+	if got := latestTagForMode(campPath, "rc"); got != "v9.9.9-rc.1" {
+		t.Fatalf("latestTagForMode(camp, rc) after fix = %q, want camp's own tag v9.9.9-rc.1", got)
+	}
+}
+
+func TestEnsureSubmodulesReadyIsNoopWhenAlreadyInitialized(t *testing.T) {
+	root, _, _ := newSubmoduleFixture(t)
+	campPath := filepath.Join(root, "camp")
+
+	before := gitRevParse(t, campPath, "HEAD")
+	if err := ensureSubmodulesReady(root); err != nil {
+		t.Fatalf("ensureSubmodulesReady returned error: %v", err)
+	}
+	after := gitRevParse(t, campPath, "HEAD")
+	if before != after {
+		t.Fatalf("camp HEAD moved from %s to %s for an already-initialized submodule", before, after)
+	}
+}
+
+func TestEnsureSubmodulesReadyRefusesWhenAutoInitFails(t *testing.T) {
+	root, campOrigin, _ := newSubmoduleFixture(t)
+	deinitSubmodule(t, root, "camp")
+
+	// deinit alone leaves camp's fetched objects cached under
+	// .git/modules/camp, so `git submodule update --init` could still
+	// succeed locally without the origin. Wipe the cache too, then break
+	// the recorded origin, so init must actually fail to clone: this is
+	// what forces ensureSubmodulesReady to refuse loudly instead of
+	// proceeding with a submodule it could not initialize.
+	if err := os.RemoveAll(filepath.Join(root, ".git", "modules", "camp")); err != nil {
+		t.Fatalf("remove cached submodule metadata: %v", err)
+	}
+	if err := os.RemoveAll(campOrigin); err != nil {
+		t.Fatalf("remove campOrigin: %v", err)
+	}
+
+	err := ensureSubmodulesReady(root)
+	if err == nil {
+		t.Fatal("expected ensureSubmodulesReady to fail when the submodule origin is unreachable")
+	}
+	if !strings.Contains(err.Error(), "camp") {
+		t.Fatalf("error does not name the failing submodule: %v", err)
+	}
+	if !strings.Contains(err.Error(), "git submodule update --init") {
+		t.Fatalf("error is not actionable (missing the manual recovery command): %v", err)
+	}
+}
+
+// TestPinFromLatestInitializesUninitializedSubmodulesAndResolvesRealTags is
+// the end-to-end regression test for the incident: `just refresh-rc`
+// (pinFromLatest with mode=rc) run against a worktree whose submodules are
+// uninitialized must initialize them, resolve each submodule's own tags,
+// and never touch the superproject's branch or HEAD.
+func TestPinFromLatestInitializesUninitializedSubmodulesAndResolvesRealTags(t *testing.T) {
+	root, campOrigin, festOrigin := newSubmoduleFixture(t)
+	addOriginRelease(t, campOrigin, "v9.9.9-rc.1")
+	addOriginRelease(t, festOrigin, "v8.8.8-rc.1")
+
+	deinitSubmodule(t, root, "camp")
+	deinitSubmodule(t, root, "fest")
+
+	rootHeadBefore := gitRevParse(t, root, "HEAD")
+
+	ctx := testRepoContext(t, root)
+	if err := ctx.pinFromLatest("rc", "latest", "latest"); err != nil {
+		t.Fatalf("pinFromLatest returned error: %v", err)
+	}
+
+	campPath := filepath.Join(root, "camp")
+	festPath := filepath.Join(root, "fest")
+
+	campTag, err := exactTagAt(campPath)
+	if err != nil {
+		t.Fatalf("exactTagAt(camp): %v", err)
+	}
+	if campTag != "v9.9.9-rc.1" {
+		t.Fatalf("camp pinned to %q, want camp's own tag v9.9.9-rc.1", campTag)
+	}
+
+	festTag, err := exactTagAt(festPath)
+	if err != nil {
+		t.Fatalf("exactTagAt(fest): %v", err)
+	}
+	if festTag != "v8.8.8-rc.1" {
+		t.Fatalf("fest pinned to %q, want fest's own tag v8.8.8-rc.1", festTag)
+	}
+
+	if branch := gitRevParse(t, root, "--abbrev-ref", "HEAD"); branch != "main" {
+		t.Fatalf("festival repo branch = %q, want main (pin must never detach the superproject)", branch)
+	}
+	if head := gitRevParse(t, root, "HEAD"); head != rootHeadBefore {
+		t.Fatalf("festival repo HEAD moved from %s to %s; pin must not commit or move the superproject's own HEAD", rootHeadBefore, head)
+	}
+
+	staged, err := gitOutput(root, "diff", "--cached", "--name-only")
+	if err != nil {
+		t.Fatalf("git diff --cached: %v", err)
+	}
+	if !strings.Contains(staged, "camp") || !strings.Contains(staged, "fest") {
+		t.Fatalf("expected fest and camp pointer updates staged, got: %q", staged)
+	}
+}
+
+// TestPinFromLatestRollsBackOnPostCheckoutMismatch forces a failure after
+// fest has already been pinned successfully: camp's resolved commit carries
+// both the requested rc tag and an unrelated, higher-sorting stable tag, so
+// verifyCheckedOutTag catches HEAD resolving to the wrong tag. pinFromLatest
+// must then restore fest to its starting commit and leave the superproject
+// on its starting branch, rather than leaving a half-applied pin behind.
+func TestPinFromLatestRollsBackOnPostCheckoutMismatch(t *testing.T) {
+	root, campOrigin, festOrigin := newSubmoduleFixture(t)
+	festStart := gitRevParse(t, filepath.Join(root, "fest"), "HEAD")
+	festStartBranch := gitRevParse(t, filepath.Join(root, "fest"), "--abbrev-ref", "HEAD")
+	campStart := gitRevParse(t, filepath.Join(root, "camp"), "HEAD")
+	rootHeadBefore := gitRevParse(t, root, "HEAD")
+
+	addOriginRelease(t, festOrigin, "v8.8.8-rc.1")
+	// v99.0.0 sorts ahead of v9.9.9-rc.1 under --sort=-v:refname, so
+	// exactTagAt (which does not filter by mode) disagrees with the rc
+	// resolution that picked v9.9.9-rc.1, exactly the "resolved commit
+	// doesn't match the requested tag" case the sanity check exists for.
+	addOriginRelease(t, campOrigin, "v9.9.9-rc.1", "v99.0.0")
+
+	ctx := testRepoContext(t, root)
+	err := ctx.pinFromLatest("rc", "latest", "latest")
+	if err == nil {
+		t.Fatal("expected pinFromLatest to fail on the ambiguous camp tag")
+	}
+	if !strings.Contains(err.Error(), "camp") {
+		t.Fatalf("error does not mention camp: %v", err)
+	}
+
+	festHead := gitRevParse(t, filepath.Join(root, "fest"), "HEAD")
+	if festHead != festStart {
+		t.Fatalf("fest HEAD = %s after rollback, want restored starting commit %s", festHead, festStart)
+	}
+	if branch := gitRevParse(t, filepath.Join(root, "fest"), "--abbrev-ref", "HEAD"); branch != festStartBranch {
+		t.Fatalf("fest branch = %q after rollback, want restored starting branch %q", branch, festStartBranch)
+	}
+
+	campHead := gitRevParse(t, filepath.Join(root, "camp"), "HEAD")
+	if campHead != campStart {
+		t.Fatalf("camp HEAD = %s after rollback, want unchanged starting commit %s", campHead, campStart)
+	}
+
+	if branch := gitRevParse(t, root, "--abbrev-ref", "HEAD"); branch != "main" {
+		t.Fatalf("festival repo branch = %q after rollback, want main", branch)
+	}
+	if head := gitRevParse(t, root, "HEAD"); head != rootHeadBefore {
+		t.Fatalf("festival repo HEAD = %s after rollback, want unchanged %s", head, rootHeadBefore)
+	}
+
+	status, statusErr := gitOutput(root, "status", "--porcelain")
+	if statusErr != nil {
+		t.Fatalf("git status: %v", statusErr)
+	}
+	if strings.TrimSpace(status) != "" {
+		t.Fatalf("festival repo is dirty after rollback: %q", status)
+	}
+}
+
+func TestGitRefCaptureAndRestore(t *testing.T) {
+	repo := initTestRepo(t)
+
+	ref, err := captureGitRef(repo)
+	if err != nil {
+		t.Fatalf("captureGitRef returned error: %v", err)
+	}
+	if ref.branch != "main" {
+		t.Fatalf("captured branch = %q, want main", ref.branch)
+	}
+
+	writeFile(t, filepath.Join(repo, "next.txt"), "next\n")
+	runGit(t, repo, "add", "next.txt")
+	runGit(t, repo, "commit", "-m", "next commit")
+	runGit(t, repo, "checkout", "--detach", "HEAD")
+
+	if err := ref.restore(repo); err != nil {
+		t.Fatalf("restore returned error: %v", err)
+	}
+	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "main" {
+		t.Fatalf("branch after restore = %q, want main", branch)
+	}
+	if head := gitRevParse(t, repo, "HEAD"); head != ref.commit {
+		t.Fatalf("HEAD after restore = %s, want %s", head, ref.commit)
+	}
+}
+
+func TestVerifyCheckedOutTag(t *testing.T) {
+	repo := initTestRepo(t)
+
+	if err := verifyCheckedOutTag(repo, "test", "v0.1.0"); err != nil {
+		t.Fatalf("verifyCheckedOutTag returned error for matching tag: %v", err)
+	}
+
+	if err := verifyCheckedOutTag(repo, "test", "v9.9.9"); err == nil {
+		t.Fatal("expected verifyCheckedOutTag to fail for a tag HEAD does not carry")
+	}
+}


### PR DESCRIPTION
## Incident

On 2026-07-29, `just refresh-rc` was run against a worktree whose `fest`/`camp` submodules were uninitialized (empty directories, no `.git` of their own). Git commands run with a submodule's directory as `cwd` find no `.git` there and walk up to the superproject's own `.git` instead of erroring, so the pin flow silently:

- resolved festival's own ancient `v0.1.2-rc.1`-era tag as if it were camp/fest's rc tag, instead of erroring on an uninitialized submodule
- ran `checkoutSubmoduleTag`'s `git checkout --detach <tag>` against the superproject itself, detaching it onto that old release commit (observed: `eb160df`, a 662-file diff against `main`)

This burned a real release run. Campaign intent: `festival-release-operator-running-pin-20260729-233926`.

## Fix

Two independent guarantees, both in `tools/release-operator`:

**1. Preflight submodule readiness** (`ensureSubmodulesReady` in `commands.go`): before `pinFromLatest`, `runDraftBootstrap`, `runPreflight`, or `collectState` (used by `plan`/`bundle`/`draft-from-latest`) touch a submodule, each one is verified to be an independent git worktree, not a directory whose git commands silently fall through to the superproject. The check (`submoduleIsIndependent`) compares `git rev-parse --show-toplevel` run inside the submodule directory against the submodule's own path — this catches the fallthrough directly, regardless of why the submodule ended up uninitialized. When a submodule isn't independent, it is auto-initialized (`git submodule update --init`) and its tags fetched, with what happened printed to stdout. If it still isn't independent afterward, the operator refuses with an actionable error before any further mutation.

`pinFromLatest` additionally sanity-checks each checkout: after resolving and checking out a tag, `verifyCheckedOutTag` confirms the submodule's HEAD actually carries that exact tag, rather than trusting the checkout silently landed somewhere else.

**2. Rollback safety** (`gitRef`/`captureGitRef`/`rollbackPin` in `commands.go`): `pinFromLatest` now captures the exact starting branch/commit of the festival repo and both submodules before mutating anything, via a named return + `defer`. If anything fails partway through (tag resolution, checkout, or the post-checkout sanity check), all three are restored to exactly where the run started — landing back on the starting branch, never a detached HEAD on some unrelated commit. Restoring the submodules first means that even if root and a submodule were captured identically (the exact fallthrough this guards against), the submodule restore already puts root back; the explicit root restore is a second, independent guarantee of the same outcome.

## Tests

Added `tools/release-operator/submodule_guard_test.go`, following the existing package's convention of exercising real git repos under `t.TempDir()` (no container harness; this tool only does git plumbing, matching how the rest of this package is already tested):

- `TestSubmoduleIsIndependent` — independent vs. deinitialized vs. missing directory
- `TestEnsureSubmodulesReadyResolvesRealTagsAfterInit` — reproduces the incident directly: asserts `latestTagForMode` resolves the superproject's ancient tag *before* the fix, then resolves camp's own tag *after* `ensureSubmodulesReady` runs
- `TestEnsureSubmodulesReadyIsNoopWhenAlreadyInitialized`
- `TestEnsureSubmodulesReadyRefusesWhenAutoInitFails` — auto-init genuinely fails (origin and cached objects both gone) and the error is actionable
- `TestPinFromLatestInitializesUninitializedSubmodulesAndResolvesRealTags` — full `pinFromLatest("rc", ...)` end-to-end with both submodules uninitialized: correct tags resolved, root branch/HEAD untouched, pointer changes staged
- `TestPinFromLatestRollsBackOnPostCheckoutMismatch` — forces a real failure via `verifyCheckedOutTag` (camp's resolved commit carries both the requested rc tag and a higher-sorting stable tag) after fest was already pinned successfully; asserts fest is restored to its starting commit/branch and root stays clean and undetached
- `TestGitRefCaptureAndRestore`, `TestVerifyCheckedOutTag` — focused unit tests

All existing tests in the package still pass unchanged.

Also did one live, non-committed validation: initialized submodules inside this worktree only, ran `just release refresh-rc` for real, confirmed it resolved `fest=v0.5.0-rc.2`/`camp=v0.4.0-rc.2` correctly with root's branch/HEAD untouched, then discarded the resulting pin changes (`git reset -- fest camp` + `git submodule update --init`) so this PR's diff does not move the pinned SHAs (PR #114 owns that).

## Gates run

- `cd tools/release-operator && go build ./... && go vet ./...` — clean
- `gofmt -l .` — only flags the pre-existing `internal/operator/marketplace.go` issue, confirmed present at `origin/main` and untouched by this change
- `just test release-operator` (`go test ./...`) — all pass, including the 9 new tests
- `just release preflight stable` (full repo gate: submodule pins, stable publish secrets, release-pin check, bundled-module-resolution, docs profile, both CLI builds, beginner-path smoke) — all green
- `just release preflight dev` fails on this worktree, but that is pre-existing and unrelated: this worktree (from `origin/main`) is pinned to *stable* tags, and `dev`-mode preflight's release-pin check expects dev-channel tags. Confirmed by then running `just release preflight stable`, which matches the actual pinned channel and passes cleanly.

## Caveats

- Scope is the pin/refresh flow and its readiness/rollback guarantees, not a rearchitecture of `runDraftBootstrap`'s later stages (submodule tag creation/push) or `shipViaPullRequest`'s PR-based shipping, which already document their own recovery path ("rerun the same command to continue"). `ensureSubmodulesReady` is wired into `runDraftBootstrap` too (guarantee 1), but I did not add capture/rollback (guarantee 2) around its tag-push steps, since those are more consequential (they push new tags) and out of scope for this specific hazard.
- `runStatus` was deliberately left unguarded: it already tolerates fetch failures for offline use (`_ = ctx.fetchReleaseRefs()`), and adding an auto-init side effect there would change a read-only diagnostic command's behavior beyond what this fix needs.