### PR TITLE
chore: relicense to Apache License 2.0 (ADR-0002)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -76,6 +76,7 @@ archives:
     files:
       - README.md
       - LICENSE
+      - NOTICE
       - install.sh
       - completions/*
       - shell/*
@@ -93,7 +94,7 @@ nfpms:
     description: |-
       Festival Methodology CLI suite.
       AI-native project planning with fest and camp.
-    license: "FSL-1.1-ALv2"
+    license: "Apache-2.0"
     formats:
       - deb
       - rpm
@@ -105,6 +106,8 @@ nfpms:
     contents:
       - src: ./LICENSE
         dst: /usr/share/licenses/festival/LICENSE
+      - src: ./NOTICE
+        dst: /usr/share/licenses/festival/NOTICE
       - src: ./README.md
         dst: /usr/share/doc/festival/README.md
       - src: ./completions/fest.bash
@@ -134,7 +137,7 @@ aurs:
     description: "Festival Methodology CLI suite (fest + camp) - AI-native project planning"
     maintainers:
       - "Obedience Corp <contact@obediencecorp.com>"
-    license: "FSL-1.1-ALv2"
+    license: "Apache-2.0"
     private_key: "{{ .Env.AUR_SSH_KEY }}"
     git_url: "ssh://aur@aur.archlinux.org/festival-bin.git"
     skip_upload: auto
@@ -148,6 +151,7 @@ aurs:
       install -Dm755 "./fest" "${pkgdir}/usr/bin/fest"
       install -Dm755 "./camp" "${pkgdir}/usr/bin/camp"
       install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/festival/LICENSE"
+      install -Dm644 "./NOTICE" "${pkgdir}/usr/share/licenses/festival/NOTICE"
       install -Dm644 "./completions/fest.bash" "${pkgdir}/usr/share/bash-completion/completions/fest"
       install -Dm644 "./completions/_fest" "${pkgdir}/usr/share/zsh/site-functions/_fest"
       install -Dm644 "./completions/fest.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/fest.fish"
@@ -170,7 +174,7 @@ aurs:
 #       token: "{{ .Env.SCOOP_GITHUB_TOKEN }}"
 #     homepage: "https://fest.build"
 #     description: "Festival Methodology CLI suite (fest + camp) - AI-native project planning"
-#     license: "FSL-1.1-ALv2"
+#     license: "Apache-2.0"
 
 checksum:
   name_template: 'checksums.txt'
@@ -198,7 +202,7 @@ homebrew_casks:
       - festival-suite
     homepage: "https://github.com/Obedience-Corp/festival"
     description: "Festival Methodology CLI suite (fest + camp)"
-    license: "FSL-1.1-ALv2"
+    license: "Apache-2.0"
     skip_upload: auto
     directory: Casks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Contributions are welcome. By contributing you agree that your contribution is
+licensed under the [Apache License 2.0](LICENSE), the same license as the
+project.
+
+Most changes belong in the component repos rather than this bundle:
+[camp](https://github.com/Obedience-Corp/camp) and
+[fest](https://github.com/Obedience-Corp/fest). This repo owns the release
+bundle, packaging, docs site, and release tooling.
+
+## Developer Certificate of Origin
+
+Every commit must be signed off:
+
+```bash
+git commit -s
+```
+
+The sign-off certifies the [Developer Certificate of Origin 1.1](https://developercertificate.org/):
+that you wrote the change, or otherwise have the right to submit it under the
+project's license. Pull requests with unsigned commits will be asked to rebase
+with sign-offs before merge.
+
+## Practical notes
+
+- Run `just release preflight <mode>` and `just test release-operator` before
+  release-tooling PRs.
+- Match the surrounding code's conventions; see the README for layout.

--- a/LICENSE
+++ b/LICENSE
@@ -1,107 +1,202 @@
-# Functional Source License, Version 1.1, ALv2 Future License
 
-## Abbreviation
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-FSL-1.1-ALv2
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-## Notice
+   1. Definitions.
 
-Copyright 2026 Obedience Corp
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-Software: Festival (all versions)
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-## Terms and Conditions
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-### Licensor ("We")
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-The party offering the Software under these Terms and Conditions.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-### The Software
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-The "Software" is each version of the software that we make available under
-these Terms and Conditions, as indicated by our inclusion of these Terms and
-Conditions with the Software.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-### License Grant
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-Subject to your compliance with this License Grant and the Patents,
-Redistribution and Trademark clauses below, we hereby grant you the right to
-use, copy, modify, create derivative works, publicly perform, publicly display
-and redistribute the Software for any Permitted Purpose identified below.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-### Permitted Purpose
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
-means making the Software available to others in a commercial product or
-service that:
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-1. substitutes for the Software;
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-2. substitutes for any other product or service we offer using the Software
-   that exists as of the date we make the Software available; or
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-3. offers the same or substantially similar functionality as the Software.
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-Permitted Purposes specifically include using the Software:
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-1. for your internal use and access;
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-2. for non-commercial education;
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-3. for non-commercial research; and
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-4. in connection with professional services that you provide to a licensee
-   using the Software in accordance with these Terms and Conditions.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-### Patents
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-To the extent your use for a Permitted Purpose would necessarily infringe our
-patents, the license grant above includes a license under our patents. If you
-make a claim against any party that the Software infringes or contributes to
-the infringement of any patent, then your patent license to the Software ends
-immediately.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-### Redistribution
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-The Terms and Conditions apply to all copies, modifications and derivatives of
-the Software.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-If you redistribute any copies, modifications or derivatives of the Software,
-you must include a copy of or a link to these Terms and Conditions and not
-remove any copyright notices provided in or with the Software.
+   END OF TERMS AND CONDITIONS
 
-### Disclaimer
+   APPENDIX: How to apply the Apache License to your work.
 
-THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
-PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
-SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
-EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+   Copyright [yyyy] [name of copyright owner]
 
-### Trademarks
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-Except for displaying the License Details and identifying us as the origin of
-the Software, you have no right under these Terms and Conditions to use our
-trademarks, trade names, service marks or product names.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-## Grant of Future License
-
-We hereby irrevocably grant you an additional license to use the Software under
-the Apache License, Version 2.0 that is effective on the second anniversary of
-the date we make the Software available. On or after that date, you may use the
-Software under the Apache License, Version 2.0, in which case the following
-will apply:
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-this file except in compliance with the License.
-
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed
-under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-CONDITIONS OF ANY KIND, either express or implied. See the License for the
-specific language governing permissions and limitations under the License.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+Festival (camp + fest CLI bundle)
+Copyright 2026 Obedience Corp

--- a/README.md
+++ b/README.md
@@ -474,6 +474,6 @@ Repository entry points:
 
 ## License
 
-[Functional Source License 1.1 (FSL-1.1-ALv2)](LICENSE)
+[Apache License 2.0](LICENSE)
 
 Built by [Obedience Corp](https://obediencecorp.com). AI that does what you want, the way you want it done.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -119,6 +119,6 @@ Festival 把这些东西放进一个可审查、可提交、可恢复的工作�
 
 ## License
 
-[Functional Source License 1.1 (FSL-1.1-ALv2)](LICENSE)
+[Apache License 2.0](LICENSE)
 
 Built by [Obedience Corp](https://obediencecorp.com). AI that does what you want, the way you want it done.

--- a/npm/package.json
+++ b/npm/package.json
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/Obedience-Corp/festival/issues"
   },
-  "license": "FSL-1.1-ALv2",
+  "license": "Apache-2.0",
   "bin": {
     "camp": "bin/camp",
     "fest": "bin/fest"

--- a/tools/release-operator/internal/operator/marketplace.go
+++ b/tools/release-operator/internal/operator/marketplace.go
@@ -130,7 +130,7 @@ func BuildMarketplaceEntry(in MarketplaceEntryInput) ([]byte, error) {
 		Summary:       "The camp + fest CLI suite, released and versioned together.",
 		Description:   "Festival Methodology CLI suite. camp and fest are co-tested and shipped as one versioned product; both binaries report the festival release version.",
 		Homepage:      "https://fest.build",
-		Licenses:      []string{"FSL-1.1-ALv2"},
+		Licenses:      []string{"Apache-2.0"},
 		Aliases:       []string{"festival", "camp", "fest"},
 		Tags:          []string{"festival", "planning", "cli"},
 		SupportedScopes:  []string{"user"},

--- a/tools/release-operator/internal/operator/testdata/festival-v0.2.10.golden.json
+++ b/tools/release-operator/internal/operator/testdata/festival-v0.2.10.golden.json
@@ -7,7 +7,7 @@
   "description": "Festival Methodology CLI suite. camp and fest are co-tested and shipped as one versioned product; both binaries report the festival release version.",
   "homepage": "https://fest.build",
   "licenses": [
-    "FSL-1.1-ALv2"
+    "Apache-2.0"
   ],
   "aliases": [
     "festival",


### PR DESCRIPTION
## Relicense: FSL-1.1-ALv2 to Apache License 2.0

Executes [ADR-0002](https://github.com/Obedience-Corp/obey-campaign) (accepted 2026-07-20): the CLI distribution surface moves to Apache 2.0; the app and platform layers stay proprietary. The contributor audit in the ADR found copyright fully consolidated (sole human committer plus bots), so the relicense is legally frictionless.

Timed deliberately BEFORE the next stable release cut, so the first stable release of the guardrails line ships Apache-licensed and the announcement moment lands on a real release.

## Changes

- `LICENSE`: canonical Apache License 2.0 text (sourced from a canonical upstream copy, not retyped)
- `NOTICE`: product name + `Copyright 2026 Obedience Corp`
- `CONTRIBUTING.md` (new): DCO 1.1 sign-off requirement per ADR-0002 point 3, so copyright stays consolidated as outside contributions arrive
- README license section updated; every FSL mention in the repo audited and updated (grep for `FSL|functional source` is clean)

## Not in scope

- The announcement/launch content (ADR-0002 point 4) is a separate distribution event
- Historical releases keep the license they shipped with; FSL's own ALv2-after-two-years conversion continues to apply to them
