### PR TITLE
ci: refresh pinned Go dependency snapshots

### DIFF
--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -17,8 +17,66 @@ permissions:
   contents: write
 
 jobs:
+  submit-fest:
+    name: Validate and submit Fest dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out pinned components
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: fest/go.mod
+          cache-dependency-path: fest/go.sum
+
+      - name: Verify repaired dependency graph
+        env:
+          GOWORK: "off"
+        run: |
+          modules="$RUNNER_TEMP/fest-modules.txt"
+          go -C fest list -m all | tee "$modules"
+
+          require_module_at_least() {
+            module="$1"
+            minimum="$2"
+            actual="$(awk -v module="$module" '$1 == module { print $2 }' "$modules")"
+
+            if [[ -z "$actual" ]]; then
+              echo "Required module $module is missing from the Fest graph." >&2
+              exit 1
+            fi
+
+            earliest="$(printf '%s\n%s\n' "$minimum" "$actual" | sort -V | head -n 1)"
+            if [[ "$earliest" != "$minimum" ]]; then
+              echo "$module must be at least $minimum; resolved $actual." >&2
+              exit 1
+            fi
+          }
+
+          require_module_at_least 'golang.org/x/crypto' 'v0.54.0'
+          require_module_at_least 'go.opentelemetry.io/otel' 'v1.43.0'
+          require_module_at_least 'go.opentelemetry.io/otel/sdk' 'v1.43.0'
+
+          if grep -Eq '^github\.com/docker/docker( |$)' "$modules"; then
+            echo 'Legacy github.com/docker/docker module remains in the Fest graph.' >&2
+            exit 1
+          fi
+
+      - name: Submit dependency snapshot
+        # Node 24 revision of GitHub's action; pinned until its next release.
+        uses: actions/go-dependency-submission@58a892e48687d602add5889d7aa09e32efeb19a7
+        env:
+          GOWORK: "off"
+        with:
+          go-mod-path: fest/go.mod
+
   submit-camp:
     name: Submit Camp dependencies
+    needs: submit-fest
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -40,27 +98,3 @@ jobs:
           GOWORK: "off"
         with:
           go-mod-path: camp/go.mod
-
-  submit-fest:
-    name: Submit Fest dependencies
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Check out pinned components
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: recursive
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: fest/go.mod
-          cache-dependency-path: fest/go.sum
-
-      - name: Submit dependency snapshot
-        # Node 24 revision of GitHub's action; pinned until its next release.
-        uses: actions/go-dependency-submission@58a892e48687d602add5889d7aa09e32efeb19a7
-        env:
-          GOWORK: "off"
-        with:
-          go-mod-path: fest/go.mod

--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -1,0 +1,66 @@
+name: Submit Go dependencies
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/dependency-submission.yaml
+      - .gitmodules
+      - camp
+      - fest
+  workflow_dispatch:
+
+# A user-submitted snapshot takes precedence over GitHub's stale automatic
+# analysis of the go.mod files behind the camp and fest gitlinks.
+permissions:
+  contents: write
+
+jobs:
+  submit-camp:
+    name: Submit Camp dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out pinned components
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: camp/go.mod
+          cache-dependency-path: camp/go.sum
+
+      - name: Submit dependency snapshot
+        # Node 24 revision of GitHub's action; pinned until its next release.
+        uses: actions/go-dependency-submission@58a892e48687d602add5889d7aa09e32efeb19a7
+        env:
+          GOWORK: "off"
+        with:
+          go-mod-path: camp/go.mod
+
+  submit-fest:
+    name: Submit Fest dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out pinned components
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: fest/go.mod
+          cache-dependency-path: fest/go.sum
+
+      - name: Submit dependency snapshot
+        # Node 24 revision of GitHub's action; pinned until its next release.
+        uses: actions/go-dependency-submission@58a892e48687d602add5889d7aa09e32efeb19a7
+        env:
+          GOWORK: "off"
+        with:
+          go-mod-path: fest/go.mod


### PR DESCRIPTION
## Summary
- submit resolved Go dependency snapshots for the pinned Camp and Fest submodules
- refresh the snapshots whenever either gitlink changes on `main`, with a manual recovery trigger
- pin every Actions dependency to an immutable commit and use the Node 24 dependency-submission revision

## Root cause
GitHub's dependency graph kept reporting `fest/go.mod` from an older submodule state (`golang.org/x/crypto v0.37.0`, OpenTelemetry v1.38.0, and `github.com/docker/docker v28.3.3+incompatible`) after Festival pinned Fest v0.5.1. The pinned module actually resolves `golang.org/x/crypto v0.54.0` and OpenTelemetry v1.43.0, and it no longer contains the legacy Docker module.

A user-submitted dependency snapshot takes precedence over the stale automatic graph. The first `main` run after merge should replace the stale manifest and allow GitHub to close all 23 false-positive alerts.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/dependency-submission.yaml`
- `just test bundled-module-resolution`
- `GOWORK=off go -C camp list -deps all`
- `GOWORK=off go -C camp mod graph`
- `GOWORK=off go -C fest list -deps all`
- `GOWORK=off go -C fest mod graph`
