### PR TITLE
Pin fest v0.6.1 for the stable channel

### DIFF
--- a/docs/cli-reference/fest/fest_create_festival.md
+++ b/docs/cli-reference/fest/fest_create_festival.md
@@ -17,7 +17,7 @@ fest create festival [flags]
 ```
       --agent                 Strict mode: process markers, auto-validate, rollback on blocking errors, JSON output
       --dest string           Destination under festivals/: planning or ritual (use 'fest promote' to advance to active) (default "planning")
-      --dry-run               Preview the festival file tree without writing anything
+      --dry-run               Preview the festival file tree and its template markers without writing anything
       --goal string           Festival goal
   -h, --help                  help for festival
       --json                  Emit JSON output


### PR DESCRIPTION
Pins fest to `v0.6.1`, the patch that restores `fest create festival --dry-run` marker discovery (fest #336) after v0.6.0 dropped it; the festival beginner-path smoke, which `just release preflight` and the release workflow run, depends on those hints and fails against v0.6.0. camp stays at `v0.4.0`. Only `docs/cli-reference/fest/fest_create_festival.md` changed in the regen (the `--dry-run` help text).

After merge, `just release preflight mode=stable` should pass and the bundle can be cut.
