### PR TITLE
Declare Apache-2.0 in the plugin manifests and generated skills

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://github.com/Obedience-Corp/festival",
   "repository": "https://github.com/Obedience-Corp/festival",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": [
     "festival",
     "project-management",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Plugin manifests (Claude, Codex, Cursor) and every generated Hermes tap skill declared `MIT`; the repo and everything in it is Apache 2.0 (ADR-0002). All now say `Apache-2.0`.
+
 ### Added
 
 - Hermes Agent: generated skills tap (`skills/`), survey and matrix row. `packaging/targets/hermes.target.mjs` emits the 12 skills in Hermes tap layout (`skills/<name>/SKILL.md`) with `version`, `author`, `license` and `metadata.hermes.{tags,category}` merged into each skill's frontmatter and the body left byte-identical, plus a generated `skills/README.md` and a root `skills.sh.json`. Users run `hermes skills tap add Obedience-Corp/festival`; the same tree also serves `npx skills add Obedience-Corp/festival`. Documented in `packaging/survey/hermes.md` with a Hermes column in `packaging/survey/MATRIX.md`.

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://github.com/Obedience-Corp/festival",
   "repository": "https://github.com/Obedience-Corp/festival",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": [
     "festival",
     "project-management",

--- a/plugins/festival/.codex-plugin/plugin.json
+++ b/plugins/festival/.codex-plugin/plugin.json
@@ -9,7 +9,7 @@
   },
   "homepage": "https://github.com/Obedience-Corp/festival",
   "repository": "https://github.com/Obedience-Corp/festival",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": [
     "festival",
     "project-management",

--- a/skills/camp-navigation/SKILL.md
+++ b/skills/camp-navigation/SKILL.md
@@ -3,7 +3,7 @@ name: camp-navigation
 description: Navigate campaign workspaces with `cgo` and `camp go`. Use when you need to move between projects/festivals/workflow directories, switch context quickly, or resolve script-safe paths with `camp go --print`.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:

--- a/skills/camp-projects/SKILL.md
+++ b/skills/camp-projects/SKILL.md
@@ -3,7 +3,7 @@ name: camp-projects
 description: Manage campaign submodule projects. Use when committing inside `projects/*`, deciding status/pull/push scope (root vs submodule vs all), or creating/removing project worktrees.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:

--- a/skills/camp-workitems/SKILL.md
+++ b/skills/camp-workitems/SKILL.md
@@ -3,7 +3,7 @@ name: camp-workitems
 description: Find, filter, choose, create, or adopt campaign work items with `camp workitem`, `camp wi`, or `camp workitems`. Use when a user wants current active work across intents, designs, explore notes, festivals, or tracked workflow directories; when agents need safe `camp workitem --json` output; or when creating/adopting tracked workflow folders.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:

--- a/skills/campaign-commit/SKILL.md
+++ b/skills/campaign-commit/SKILL.md
@@ -3,7 +3,7 @@ name: campaign-commit
 description: Choose the correct commit command in a campaign workspace. Use when you are about to commit and need to select `camp commit`, `camp p commit`, `fest commit`, or intentional root pointer sync via `camp refs-sync`.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:

--- a/skills/campaign-structure/SKILL.md
+++ b/skills/campaign-structure/SKILL.md
@@ -3,7 +3,7 @@ name: campaign-structure
 description: Orient within campaign directory structure. Use when deciding where work belongs (intents vs festivals vs design vs docs vs dungeon), especially when a task is not yet planned or folder ownership is unclear.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:

--- a/skills/campaign-workflows/SKILL.md
+++ b/skills/campaign-workflows/SKILL.md
@@ -3,7 +3,7 @@ name: campaign-workflows
 description: Manage campaign intents, dungeons, and workflow collections with `camp`. Use when capturing ideas, promoting intents to festivals, archiving work, or moving workflow items between statuses.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:

--- a/skills/cross-campaign/SKILL.md
+++ b/skills/cross-campaign/SKILL.md
@@ -3,7 +3,7 @@ name: cross-campaign
 description: Discover and reference other campaigns, projects, and files across campaign boundaries. Use when the user mentions another campaign by name, references work done "in another project/campaign", or needs to find/copy/compare code across campaigns.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:

--- a/skills/fest-execution/SKILL.md
+++ b/skills/fest-execution/SKILL.md
@@ -3,7 +3,7 @@ name: fest-execution
 description: Execute active festival tasks. Use when finding the next task, marking tasks completed/blocked/reset, committing with festival traceability, advancing workflow steps, and validating sequence progress.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:

--- a/skills/fest-methodology/SKILL.md
+++ b/skills/fest-methodology/SKILL.md
@@ -3,7 +3,7 @@ name: fest-methodology
 description: Use when the user mentions festivals, the fest CLI, phases, sequences, or tasks, or when working inside a `festivals/` directory. Provides the core Festival methodology model so Claude understands the planning system.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:

--- a/skills/fest-planning/SKILL.md
+++ b/skills/fest-planning/SKILL.md
@@ -3,7 +3,7 @@ name: fest-planning
 description: Plan and scaffold festivals. Use when creating festival/phase/sequence/task structure, enforcing naming rules, linking festivals to projects, and promoting lifecycle states.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:

--- a/skills/fest-standalone-workflows/SKILL.md
+++ b/skills/fest-standalone-workflows/SKILL.md
@@ -3,7 +3,7 @@ name: fest-standalone-workflows
 description: Create and run lightweight standalone `WORKFLOW.md` loops with `fest create workflow`, `fest next`, and `fest workflow advance`. Use when a user wants step-by-step workflow guidance inside any ordinary directory, explore/design work item, project folder, or thin-start workflow.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:

--- a/skills/festival-intake/SKILL.md
+++ b/skills/festival-intake/SKILL.md
@@ -3,7 +3,7 @@ name: festival-intake
 description: Route work that is too large for a single chat into a structured plan. Use when the user describes a multi-step build, a migration, a rewrite, an audit, a refactor across many files, or a research question with several threads. Use when a goal would otherwise need step-by-step supervision across more than one session. Also use when the user says "plan this", "where do I start", "help me build X", "this is a big one", or hands over a spec, a ticket, or a document and asks what to do with it.
 version: "1.3.0"
 author: Obedience Corp
-license: MIT
+license: Apache-2.0
 metadata:
   hermes:
     tags:


### PR DESCRIPTION
The plugin manifests (`claude-plugin/.claude-plugin/plugin.json`, `plugins/festival/.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`) said `MIT` since before #130, and #130 propagated that into the frontmatter of all 12 generated Hermes tap skills (`skills/*/SKILL.md`). The repository is Apache 2.0 (ADR-0002, executed; `LICENSE` at the root), and so is the plugin content.

Change: the source manifest now declares `Apache-2.0`; `just plugin generate` propagated it to the Codex and Cursor manifests and to every generated skill (12/12 now `license: Apache-2.0`). CHANGELOG notes it under Unreleased.

Gate: `just test plugin` passes (commit-guard tests, command sync check against the installed CLIs, Claude plugin smoke, Hermes target check); `git diff --check` clean.
