### PR TITLE
Correct the plugin README bundle counts

### DIFF
--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -16,8 +16,8 @@ docs linked at the end.
 ```
 claude-plugin/
   .claude-plugin/plugin.json    plugin manifest (name, version, description)
-  skills/                       9 skills, one SKILL.md each
-  commands/                     10 fest-* and camp-* slash commands
+  skills/                       12 skills, one SKILL.md each
+  commands/                     11 fest-* and camp-* slash commands
   agents/                       fest-executor, fest-planner
   hooks/
     hooks.json                  SessionStart + PreToolUse hook wiring
@@ -115,7 +115,7 @@ every local default test run, not only in the release workflow.
 - Supporting-file pattern. Keep `SKILL.md` short (when to use, core loop, key
   commands) and move heavy reference into sibling files loaded just in time.
   Split a skill when its `SKILL.md` crosses roughly 100 lines or carries a large
-  reference table. The current 9 skills are short and stay single-file.
+  reference table. The current 12 skills are short and stay single-file.
 
 ## Methodology docs
 


### PR DESCRIPTION
## What this is

`claude-plugin/README.md` still described the bundle as 9 skills and 10 commands. The tree has had 12 skills since the festival-intake, fest-methodology, and cross-campaign additions, and 11 commands. Three lines corrected, nothing else touched.

From the intent `claude-pluginreadmemd-says-9-skills` filed during the agent setup guides work.

## Verification

- `ls claude-plugin/skills | wc -l` returns 12; `ls claude-plugin/commands | wc -l` returns 11.
- `just plugin generate` produces no drift (the per-target READMEs count from the manifest, not this file).
- `just plugin check` passes.

Commit authored by Obey Veronica (Obedience Corp agent), at Lance's request.
