### PR TITLE
Publish marketplace entries through a pull request instead of pushing to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,11 +86,14 @@ jobs:
           esac
 
       - name: Validate stable publish credentials
+        # Only the stable channel publishes to the marketplace, so dev and rc
+        # releases skip this check entirely; that gate stays as it is.
         if: steps.release_channel.outputs.mode == 'stable'
         env:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
           MARKETPLACE_PUBLISH_TOKEN: ${{ secrets.MARKETPLACE_PUBLISH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           missing=0
           for name in HOMEBREW_TAP_GITHUB_TOKEN AUR_SSH_KEY MARKETPLACE_PUBLISH_TOKEN; do
@@ -99,7 +102,14 @@ jobs:
               missing=1
             fi
           done
-          exit "${missing}"
+          if [ "${missing}" -ne 0 ]; then
+            exit "${missing}"
+          fi
+          push_ok="$(GH_TOKEN="${MARKETPLACE_PUBLISH_TOKEN}" gh api repos/Obedience-Corp/marketplace --jq '.permissions.push')"
+          if [ "${push_ok}" != "true" ]; then
+            echo "::error::MARKETPLACE_PUBLISH_TOKEN cannot push to Obedience-Corp/marketplace (needed to open the marketplace entry pull request)"
+            exit 1
+          fi
 
       - name: Trust AUR host key
         if: steps.release_channel.outputs.mode == 'stable'
@@ -210,17 +220,25 @@ jobs:
           test -f dist/checksums.txt
 
       - name: Generate marketplace entry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          published_at="$(gh release view "${GITHUB_REF_NAME}" \
+            --repo Obedience-Corp/festival --json publishedAt --jq .publishedAt)"
           go -C tools/release-operator run . emit-marketplace-entry \
             --repo-root ../.. \
             --tag "${GITHUB_REF_NAME}" \
             --channel "${{ steps.release_channel.outputs.mode }}" \
             --checksums dist/checksums.txt \
-            --output dist/marketplace/obey-package.json
+            --output dist/marketplace/obey-package.json \
+            --published-at "${published_at}"
 
+      # Keep this step and its counterpart in the workflow_dispatch job below
+      # in sync; a diff between them is invisible until a release runs.
       - name: Publish marketplace entry
         env:
           MARKETPLACE_PUBLISH_TOKEN: ${{ secrets.MARKETPLACE_PUBLISH_TOKEN }}
+          GH_TOKEN: ${{ secrets.MARKETPLACE_PUBLISH_TOKEN }}
           FESTIVAL_TAG: ${{ github.ref_name }}
           RELEASE_CHANNEL: ${{ steps.release_channel.outputs.mode }}
         run: scripts/publish_marketplace_entry.sh
@@ -323,17 +341,25 @@ jobs:
           test -f dist/checksums.txt
 
       - name: Generate marketplace entry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          published_at="$(gh release view "v${{ inputs.version }}" \
+            --repo Obedience-Corp/festival --json publishedAt --jq .publishedAt)"
           go -C tools/release-operator run . emit-marketplace-entry \
             --repo-root ../.. \
             --tag "v${{ inputs.version }}" \
             --channel "${{ inputs.release_mode }}" \
             --checksums dist/checksums.txt \
-            --output dist/marketplace/obey-package.json
+            --output dist/marketplace/obey-package.json \
+            --published-at "${published_at}"
 
+      # Keep this step and its counterpart in the tag-triggered job above in
+      # sync; a diff between them is invisible until a release runs.
       - name: Publish marketplace entry
         env:
           MARKETPLACE_PUBLISH_TOKEN: ${{ secrets.MARKETPLACE_PUBLISH_TOKEN }}
+          GH_TOKEN: ${{ secrets.MARKETPLACE_PUBLISH_TOKEN }}
           FESTIVAL_TAG: v${{ inputs.version }}
           RELEASE_CHANNEL: ${{ inputs.release_mode }}
         run: scripts/publish_marketplace_entry.sh

--- a/.justfiles/test.just
+++ b/.justfiles/test.just
@@ -7,7 +7,7 @@ default:
 
 # Test all projects
 [no-cd]
-all: fest camp festival-installer release-operator release-notes plugin no-em-dash
+all: fest camp festival-installer release-operator release-notes plugin marketplace-publish no-em-dash
     @echo "All tests passed"
 
 # Fail if an em dash (U+2014) appears in tracked or untracked files this repo
@@ -59,6 +59,11 @@ release-pins mode="stable":
 [no-cd]
 beginner-path-smoke:
     bash scripts/smoke_beginner_path.sh
+
+# Verify the marketplace publish path opens a pull request and never writes to main
+[no-cd]
+marketplace-publish:
+    bash scripts/test_marketplace_publish.sh
 
 # Test fest
 [no-cd]

--- a/scripts/publish_marketplace_entry.sh
+++ b/scripts/publish_marketplace_entry.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 : "${FESTIVAL_TAG:?missing FESTIVAL_TAG}"
 : "${RELEASE_CHANNEL:?missing RELEASE_CHANNEL}"
 
+# gh authenticates from GH_TOKEN. Reuse the marketplace publish token so the
+# git push and the gh pr create below share one credential.
+export GH_TOKEN="${MARKETPLACE_PUBLISH_TOKEN:-${GH_TOKEN:-}}"
+
 repo_url="${MARKETPLACE_REPO_URL:-}"
 if [ -z "${repo_url}" ]; then
   : "${MARKETPLACE_PUBLISH_TOKEN:?missing MARKETPLACE_PUBLISH_TOKEN}"
@@ -14,6 +18,18 @@ work="$(mktemp -d)"
 trap 'rm -rf "${work}"' EXIT
 
 git clone --depth 1 "${repo_url}" "${work}/marketplace"
+
+# Verify the marketplace trust root before editing anything. After the edit
+# below, the manifest this script just wrote is unsigned by construction, so
+# verify would always fail there and the check would be useless. Before the
+# edit, verify answers the question that actually matters to a release: was
+# the trust root intact when we started. A release must not quietly publish
+# on top of a broken trust root.
+if ! (cd "${work}/marketplace" && go run ./tools/metadata verify); then
+  echo "refusing to publish: ${repo_url##*/} does not verify before this change" >&2
+  echo "fix the marketplace signatures first (run the Sign metadata workflow)" >&2
+  exit 1
+fi
 
 dest_dir="${work}/marketplace/packages/obedience-corp/festival"
 mkdir -p "${dest_dir}"
@@ -35,4 +51,31 @@ if git diff --cached --quiet; then
 fi
 
 git commit -m "Publish obedience-corp/festival ${FESTIVAL_TAG} (${RELEASE_CHANNEL})"
-git push origin HEAD:main
+
+branch="release/festival-${FESTIVAL_TAG}-${RELEASE_CHANNEL}"
+git switch -c "${branch}"
+git push --set-upstream origin "${branch}"
+
+# MARKETPLACE_REPO_URL is the local-fixture injection point. When it is set,
+# stop after the branch push so a fixture test can drive the git half with no
+# real GitHub involved.
+if [ -n "${MARKETPLACE_REPO_URL:-}" ]; then
+  echo "MARKETPLACE_REPO_URL set; pushed ${branch} without opening a pull request"
+  exit 0
+fi
+
+pr_url="$(gh pr create \
+  --repo Obedience-Corp/marketplace \
+  --base main \
+  --head "${branch}" \
+  --title "Publish obedience-corp/festival ${FESTIVAL_TAG} (${RELEASE_CHANNEL})" \
+  --body "Automated marketplace entry for ${FESTIVAL_TAG} on the ${RELEASE_CHANNEL} channel.
+
+The metadata in this branch is not signed yet. Run the **Sign metadata**
+workflow against this branch, or let its pull_request trigger sign it, then
+merge. Merging unsigned metadata to main will break strict installs.")"
+
+echo "opened ${pr_url}"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  echo "Marketplace entry PR: ${pr_url}" >> "${GITHUB_STEP_SUMMARY}"
+fi

--- a/scripts/test_marketplace_publish.sh
+++ b/scripts/test_marketplace_publish.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fixture-driven coverage for scripts/publish_marketplace_entry.sh, the
+# release step that broke production three releases running. This test
+# drives the real script through its existing MARKETPLACE_REPO_URL
+# injection point (publish_marketplace_entry.sh:7-11) against a local,
+# disposable marketplace repository. No network and no GitHub credentials
+# are used.
+#
+# What this test does NOT cover:
+#   - The real `gh pr create` call. The fixture path exits before it
+#     (MARKETPLACE_REPO_URL is set, so the script prints "pushed ... without
+#     opening a pull request" and stops).
+#   - The real marketplace verifier. testdata/marketplace-fixture/tools/metadata
+#     is a stand-in that exits 0 or 1 based on FIXTURE_VERIFY_EXIT; it does not
+#     check signatures or schema. The real verifier is exercised in sequence 03.
+#   - The GitHub Actions wiring in .github/workflows/release.yaml. Only a real
+#     release exercises that; both call sites are diffed side by side instead
+#     (see results/ for sequence 02, task 01).
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "ok: $*"; }
+
+# staged_repo is the cwd the script runs from. publish_marketplace_entry.sh
+# reads dist/marketplace/obey-package.json and scripts/upsert_marketplace_index.py
+# relative to its cwd (publish_marketplace_entry.sh:20-25), so this staged
+# copy stands in for a release checkout instead of writing into this repo's
+# real dist/ directory, which would make the suite untrustworthy.
+staged_repo="${work}/staged-repo"
+mkdir -p "${staged_repo}/scripts" "${staged_repo}/dist/marketplace"
+cp "${repo_root}/scripts/publish_marketplace_entry.sh" "${staged_repo}/scripts/publish_marketplace_entry.sh"
+cp "${repo_root}/scripts/upsert_marketplace_index.py" "${staged_repo}/scripts/upsert_marketplace_index.py"
+chmod +x "${staged_repo}/scripts/publish_marketplace_entry.sh"
+
+new_release_manifest() {
+  # The v9.9.9 entry this test publishes. Distinct from the fixture's seeded
+  # v0.2.16 entry (testdata/marketplace-fixture/packages/.../obey-package.json)
+  # so a real publish produces a real diff.
+  cat <<'JSON'
+{
+  "aliases": ["festival", "camp", "fest"],
+  "class": "product",
+  "description": "Fixture entry for the festival suite, published by the test.",
+  "display_name": "Festival Suite",
+  "homepage": "https://fest.build",
+  "host_runtimes": [
+    {"display_name": "Camp CLI plugins", "features": [], "runtime": "camp-cli"},
+    {"display_name": "Fest CLI plugins", "features": [], "runtime": "fest-cli"}
+  ],
+  "id": "obedience-corp/festival",
+  "licenses": ["Apache-2.0"],
+  "provides_binaries": ["camp", "fest"],
+  "releases": [
+    {
+      "artifacts": [
+        {"arch": "all", "binaries": ["camp", "fest"], "filename": "festival-9.9.9-macOS-all.tar.gz", "kind": "suite-archive", "os": "darwin", "sha256": "1111111111111111111111111111111111111111111111111111111111111111", "url": "https://example.invalid/festival-9.9.9-macOS-all.tar.gz"}
+      ],
+      "channel": "stable",
+      "compatibility": {"arch": ["amd64", "arm64"], "os": ["darwin", "linux"]},
+      "components": {"camp": "0.5.0", "fest": "0.6.2"},
+      "dependencies": [],
+      "install": {
+        "entries": [
+          {"executable_name": "camp", "kind": "binary", "source": "camp"},
+          {"executable_name": "fest", "kind": "binary", "source": "fest"}
+        ]
+      },
+      "published_at": "2026-08-21T00:00:00Z",
+      "version": "9.9.9"
+    }
+  ],
+  "schema_version": 1,
+  "summary": "Fixture entry, not the real marketplace.",
+  "supported_scopes": ["user"],
+  "tags": ["festival", "planning", "cli"]
+}
+JSON
+}
+new_release_manifest > "${staged_repo}/dist/marketplace/obey-package.json"
+
+# make_fixture builds a bare "remote" marketplace repository at $1. In
+# "stale" mode (the default) it seeds an older entry, so publishing the new
+# v9.9.9 entry produces a real diff. In "matching" mode it seeds the exact
+# v9.9.9 entry already applied, so a re-publish has nothing to do.
+#
+# The seeded entry is signed with an ed25519 key generated for this run only
+# (openssl, no real key involved), matching the shape of a real signed
+# marketplace tree. The stand-in tools/metadata verifier does not check this
+# signature; it only reports FIXTURE_VERIFY_EXIT. The signature is here for
+# structural realism, not enforcement.
+make_fixture() {
+  local dest="$1" mode="${2:-stale}"
+  local src
+  src="$(mktemp -d)"
+  mkdir -p "${src}/packages/obedience-corp/festival" "${src}/tools/metadata" "${src}/keys"
+
+  cp "${repo_root}/testdata/marketplace-fixture/go.mod" "${src}/go.mod"
+  cp "${repo_root}/testdata/marketplace-fixture/tools/metadata/main.go" "${src}/tools/metadata/main.go"
+  cp "${repo_root}/testdata/marketplace-fixture/obey-marketplace.json" "${src}/obey-marketplace.json"
+
+  if [ "${mode}" = "matching" ]; then
+    new_release_manifest > "${src}/packages/obedience-corp/festival/obey-package.json"
+    cat > "${src}/index.json" <<'JSON'
+{
+  "source": "official-obey",
+  "updatedAt": "2026-08-01T00:00:00Z",
+  "packages": [
+    {"id": "obedience-corp/festival", "channels": ["stable"]}
+  ]
+}
+JSON
+  else
+    cp "${repo_root}/testdata/marketplace-fixture/packages/obedience-corp/festival/obey-package.json" \
+      "${src}/packages/obedience-corp/festival/obey-package.json"
+    cp "${repo_root}/testdata/marketplace-fixture/index.json" "${src}/index.json"
+  fi
+
+  if command -v openssl >/dev/null 2>&1; then
+    openssl genpkey -algorithm ed25519 -out "${src}/fixture-key.pem" >/dev/null 2>&1
+    openssl pkeyutl -sign -inkey "${src}/fixture-key.pem" -rawin \
+      -in "${src}/packages/obedience-corp/festival/obey-package.json" \
+      -out "${src}/packages/obedience-corp/festival/obey-package.json.sig.bin" >/dev/null 2>&1
+    base64 <"${src}/packages/obedience-corp/festival/obey-package.json.sig.bin" \
+      >"${src}/packages/obedience-corp/festival/obey-package.json.sig"
+    rm -f "${src}/fixture-key.pem" "${src}/packages/obedience-corp/festival/obey-package.json.sig.bin"
+  fi
+
+  git -C "${src}" init -q -b main
+  git -C "${src}" -c user.email=fixture@example.invalid -c user.name=fixture add -A
+  git -C "${src}" -c user.email=fixture@example.invalid -c user.name=fixture \
+    commit -q -m "seed fixture marketplace (${mode})"
+  git clone -q --bare "${src}" "${dest}"
+  rm -rf "${src}"
+}
+
+run_script() {
+  (cd "${staged_repo}" && env -u MARKETPLACE_PUBLISH_TOKEN \
+    bash "${repo_root}/scripts/publish_marketplace_entry.sh")
+}
+
+# --- Case 1: ERROR, marketplace does not verify before the change ---------
+make_fixture "${work}/bare-broken.git"
+out="$(FIXTURE_VERIFY_EXIT=1 MARKETPLACE_REPO_URL="${work}/bare-broken.git" \
+  FESTIVAL_TAG=v9.9.9 RELEASE_CHANNEL=stable run_script 2>&1 || true)"
+grep -q "does not verify before this change" <<<"${out}" \
+  || fail "missing refusal message: ${out}"
+[ -z "$(git --git-dir="${work}/bare-broken.git" branch --list 'release/*')" ] \
+  || fail "a branch was pushed despite the refusal"
+pass "refuses to publish onto an unverifiable marketplace, and pushes nothing"
+
+# --- Case 2: missing FESTIVAL_TAG ------------------------------------------
+make_fixture "${work}/bare-missing-tag.git"
+out="$(FIXTURE_VERIFY_EXIT=0 MARKETPLACE_REPO_URL="${work}/bare-missing-tag.git" \
+  RELEASE_CHANNEL=stable run_script 2>&1 || true)"
+grep -q "FESTIVAL_TAG" <<<"${out}" || fail "missing-FESTIVAL_TAG message does not name FESTIVAL_TAG: ${out}"
+pass "refuses to run without FESTIVAL_TAG"
+
+# --- Case 3: missing RELEASE_CHANNEL ---------------------------------------
+out="$(FIXTURE_VERIFY_EXIT=0 MARKETPLACE_REPO_URL="${work}/bare-missing-tag.git" \
+  FESTIVAL_TAG=v9.9.9 run_script 2>&1 || true)"
+grep -q "RELEASE_CHANNEL" <<<"${out}" || fail "missing-RELEASE_CHANNEL message does not name RELEASE_CHANNEL: ${out}"
+pass "refuses to run without RELEASE_CHANNEL"
+
+# --- Case 4: nothing to publish --------------------------------------------
+# The fixture's main already carries exactly the v9.9.9 entry this run would
+# publish (simulating a retried or duplicate release). The script must
+# detect the empty diff and exit 0 without creating a branch.
+make_fixture "${work}/bare-matching.git" matching
+out="$(FIXTURE_VERIFY_EXIT=0 MARKETPLACE_REPO_URL="${work}/bare-matching.git" \
+  FESTIVAL_TAG=v9.9.9 RELEASE_CHANNEL=stable run_script 2>&1)"
+grep -q "already up to date" <<<"${out}" || fail "missing idempotent message: ${out}"
+[ -z "$(git --git-dir="${work}/bare-matching.git" branch --list 'release/*')" ] \
+  || fail "a branch was pushed for a no-op publish"
+pass "re-publishing identical content is a no-op, and pushes no branch"
+
+# --- Case 5: happy path -----------------------------------------------------
+make_fixture "${work}/bare-happy.git"
+seed_main_before="$(git --git-dir="${work}/bare-happy.git" rev-parse main)"
+FIXTURE_VERIFY_EXIT=0 MARKETPLACE_REPO_URL="${work}/bare-happy.git" \
+  FESTIVAL_TAG=v9.9.9 RELEASE_CHANNEL=stable run_script >/dev/null
+branch_ref="$(git --git-dir="${work}/bare-happy.git" branch --list 'release/festival-v9.9.9-stable')"
+[ -n "${branch_ref}" ] || fail "release/festival-v9.9.9-stable was not pushed"
+pass "opens (pushes) a release branch for a real change"
+
+# --- Case 6: main untouched --------------------------------------------------
+seed_main_after="$(git --git-dir="${work}/bare-happy.git" rev-parse main)"
+[ "${seed_main_before}" = "${seed_main_after}" ] \
+  || fail "main moved: was ${seed_main_before}, now ${seed_main_after}"
+pass "main is untouched by a successful publish; this is what sequence 02 exists for"
+
+echo "all cases passed"

--- a/testdata/marketplace-fixture/go.mod
+++ b/testdata/marketplace-fixture/go.mod
@@ -1,0 +1,3 @@
+module github.com/Obedience-Corp/marketplace-fixture
+
+go 1.25.6

--- a/testdata/marketplace-fixture/index.json
+++ b/testdata/marketplace-fixture/index.json
@@ -1,0 +1,12 @@
+{
+  "source": "official-obey",
+  "updatedAt": "2026-08-01T00:00:00Z",
+  "packages": [
+    {
+      "id": "obedience-corp/festival",
+      "channels": [
+        "stable"
+      ]
+    }
+  ]
+}

--- a/testdata/marketplace-fixture/obey-marketplace.json
+++ b/testdata/marketplace-fixture/obey-marketplace.json
@@ -1,0 +1,25 @@
+{
+  "id": "obedience-corp/official-fixture",
+  "name": "Fixture Marketplace",
+  "description": "Local fixture marketplace for scripts/test_marketplace_publish.sh. Not a real marketplace; never point a real client at it.",
+  "homepage": "https://example.invalid/fixture-marketplace",
+  "schema_version": "1",
+  "namespace": "obedience-corp",
+  "packages": [
+    {
+      "id": "obedience-corp/festival",
+      "display_name": "Festival Suite",
+      "class": "product",
+      "summary": "Fixture entry for the festival suite.",
+      "host_runtimes": [
+        "camp-cli",
+        "fest-cli",
+        "fest-extension"
+      ],
+      "channels": [
+        "stable"
+      ],
+      "manifest_path": "packages/obedience-corp/festival/obey-package.json"
+    }
+  ]
+}

--- a/testdata/marketplace-fixture/packages/obedience-corp/festival/obey-package.json
+++ b/testdata/marketplace-fixture/packages/obedience-corp/festival/obey-package.json
@@ -1,0 +1,37 @@
+{
+  "aliases": ["festival", "camp", "fest"],
+  "class": "product",
+  "description": "Fixture entry for the festival suite, seeded at an older release than the test publishes.",
+  "display_name": "Festival Suite",
+  "homepage": "https://fest.build",
+  "host_runtimes": [
+    {"display_name": "Camp CLI plugins", "features": [], "runtime": "camp-cli"},
+    {"display_name": "Fest CLI plugins", "features": [], "runtime": "fest-cli"}
+  ],
+  "id": "obedience-corp/festival",
+  "licenses": ["Apache-2.0"],
+  "provides_binaries": ["camp", "fest"],
+  "releases": [
+    {
+      "artifacts": [
+        {"arch": "all", "binaries": ["camp", "fest"], "filename": "festival-0.2.16-macOS-all.tar.gz", "kind": "suite-archive", "os": "darwin", "sha256": "0000000000000000000000000000000000000000000000000000000000000000", "url": "https://example.invalid/festival-0.2.16-macOS-all.tar.gz"}
+      ],
+      "channel": "stable",
+      "compatibility": {"arch": ["amd64", "arm64"], "os": ["darwin", "linux"]},
+      "components": {"camp": "0.4.9", "fest": "0.6.1"},
+      "dependencies": [],
+      "install": {
+        "entries": [
+          {"executable_name": "camp", "kind": "binary", "source": "camp"},
+          {"executable_name": "fest", "kind": "binary", "source": "fest"}
+        ]
+      },
+      "published_at": "2026-07-01T00:00:00Z",
+      "version": "0.2.16"
+    }
+  ],
+  "schema_version": 1,
+  "summary": "Fixture entry, not the real marketplace.",
+  "supported_scopes": ["user"],
+  "tags": ["festival", "planning", "cli"]
+}

--- a/testdata/marketplace-fixture/tools/metadata/main.go
+++ b/testdata/marketplace-fixture/tools/metadata/main.go
@@ -1,0 +1,33 @@
+// This is NOT the real marketplace verifier. It is a stand-in used only by
+// scripts/test_marketplace_publish.sh so the fixture harness can drive both
+// branches of publish_marketplace_entry.sh's pre-edit check deterministically,
+// with no network and no real signing key. It does not check signatures or
+// schema; it only reports the exit code the test asked for. The real
+// verifier lives in Obedience-Corp/marketplace's own tools/metadata and is
+// exercised in sequence 03, not here. A reader who mistakes this for the
+// real verifier will draw the wrong conclusion from a green test.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func main() {
+	exit := 0
+	if v := os.Getenv("FIXTURE_VERIFY_EXIT"); v != "" {
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FIXTURE_VERIFY_EXIT must be an integer, got %q\n", v)
+			os.Exit(2)
+		}
+		exit = parsed
+	}
+	if exit == 0 {
+		fmt.Println("fixture verify: ok (FIXTURE_VERIFY_EXIT=0)")
+	} else {
+		fmt.Fprintln(os.Stderr, "fixture verify: broken (FIXTURE_VERIFY_EXIT set non-zero)")
+	}
+	os.Exit(exit)
+}

--- a/tools/release-operator/internal/operator/marketplace.go
+++ b/tools/release-operator/internal/operator/marketplace.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"time"
 )
 
 type MarketplaceEntryInput struct {
@@ -103,6 +104,18 @@ func BuildMarketplaceEntry(in MarketplaceEntryInput) ([]byte, error) {
 	}
 	if len(in.Artifacts) == 0 {
 		return nil, fmt.Errorf("no artifacts for %s", in.FestivalVersion)
+	}
+	// The hub's manifest schema requires published_at to be "format":
+	// "date-time". v0.2.17 shipped with published_at="" because the workflow
+	// omitted --published-at and this function accepted the empty string
+	// anyway; the failure only surfaced on a user's machine as "schema
+	// invalid at /releases/0/published_at". Refuse it here instead, so a
+	// missing or malformed value fails the release, not the install.
+	if in.PublishedAt == "" {
+		return nil, fmt.Errorf("missing published_at for %s", in.FestivalVersion)
+	}
+	if _, err := time.Parse(time.RFC3339, in.PublishedAt); err != nil {
+		return nil, fmt.Errorf("published_at %q is not RFC 3339: %w", in.PublishedAt, err)
 	}
 
 	binaries := make([]string, len(in.Components))

--- a/tools/release-operator/internal/operator/marketplace_test.go
+++ b/tools/release-operator/internal/operator/marketplace_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -72,6 +73,67 @@ func TestBuildMarketplaceEntry_DeterministicAcrossRuns(t *testing.T) {
 	}
 	if string(a) != string(b) {
 		t.Fatal("non-deterministic output")
+	}
+}
+
+// TestBuildMarketplaceEntry_RejectsBadPublishedAt covers the known defect
+// found 2026-08-21: the official v0.2.17 manifest published with
+// published_at="", which failed the hub's schema (format: date-time) only on
+// a user's machine. These cases assert the release fails instead, in CI.
+func TestBuildMarketplaceEntry_RejectsBadPublishedAt(t *testing.T) {
+	base := MarketplaceEntryInput{
+		FestivalVersion: "0.2.10",
+		Channel:         "stable",
+		Components: []ComponentVersion{
+			{Name: "camp", Version: "0.2.11"},
+			{Name: "fest", Version: "0.4.5"},
+			{Name: "festival", Version: "0.1.0"},
+		},
+		Artifacts: []ArtifactInput{{OS: "darwin", Arch: "all", Filename: "x", URL: "u", SHA256: "s"}},
+	}
+
+	cases := []struct {
+		name        string
+		publishedAt string
+		wantErrHas  string
+	}{
+		{name: "empty string, the exact v0.2.17 defect", publishedAt: "", wantErrHas: "published_at"},
+		{name: "date only, no time component", publishedAt: "2026-08-20", wantErrHas: "RFC 3339"},
+		{name: "not a date at all", publishedAt: "not-a-timestamp", wantErrHas: "RFC 3339"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			in := base
+			in.PublishedAt = tt.publishedAt
+			_, err := BuildMarketplaceEntry(in)
+			if err == nil {
+				t.Fatalf("BuildMarketplaceEntry(published_at=%q): expected error, got nil", tt.publishedAt)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrHas) {
+				t.Fatalf("BuildMarketplaceEntry(published_at=%q) error = %q, want it to mention %q", tt.publishedAt, err.Error(), tt.wantErrHas)
+			}
+		})
+	}
+}
+
+func TestBuildMarketplaceEntry_AcceptsValidPublishedAt(t *testing.T) {
+	in := MarketplaceEntryInput{
+		FestivalVersion: "0.2.10",
+		Channel:         "stable",
+		PublishedAt:     "2026-08-20T01:51:38Z",
+		Components: []ComponentVersion{
+			{Name: "camp", Version: "0.2.11"},
+			{Name: "fest", Version: "0.4.5"},
+			{Name: "festival", Version: "0.1.0"},
+		},
+		Artifacts: []ArtifactInput{{OS: "darwin", Arch: "all", Filename: "x", URL: "u", SHA256: "s"}},
+	}
+	out, err := BuildMarketplaceEntry(in)
+	if err != nil {
+		t.Fatalf("BuildMarketplaceEntry: %v", err)
+	}
+	if !strings.Contains(string(out), `"published_at": "2026-08-20T01:51:38Z"`) {
+		t.Fatalf("emitted manifest does not contain the published_at value:\n%s", out)
 	}
 }
 

--- a/tools/release-operator/main_test.go
+++ b/tools/release-operator/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseBundleArgsAcceptsRepoRootBeforeChannel(t *testing.T) {
@@ -279,6 +282,80 @@ func TestExactTagAt(t *testing.T) {
 					t.Fatalf("exactTagAtForMode(%q) = %q, want %q", tt.mode, got, tt.want)
 				}
 			})
+		}
+	})
+}
+
+// TestRunEmitMarketplaceEntry_PublishedAt exercises runEmitMarketplaceEntry,
+// the exact function the emit-marketplace-entry command's --published-at
+// flag drives, the way release.yaml calls it (real repo-root tag resolution,
+// real checksums file, a real timestamp), rather than a hand-built manifest.
+// This is the known defect found 2026-08-21: v0.2.17 published with
+// published_at="" because the workflow never passed --published-at.
+func TestRunEmitMarketplaceEntry_PublishedAt(t *testing.T) {
+	repoRoot := t.TempDir()
+	tags := map[string]string{"fest": "v0.6.2", "camp": "v0.5.0", "festival-installer": "v0.1.0"}
+	for _, c := range components {
+		dir := filepath.Join(repoRoot, c.Dir)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		runGit(t, dir, "init", "-b", "main")
+		runGit(t, dir, "config", "user.name", "Test User")
+		runGit(t, dir, "config", "user.email", "test@example.com")
+		writeFile(t, filepath.Join(dir, "README.md"), c.Dir+"\n")
+		runGit(t, dir, "add", "README.md")
+		runGit(t, dir, "commit", "-m", "initial commit")
+		runGit(t, dir, "tag", tags[c.Dir])
+	}
+
+	checksumsPath := filepath.Join(repoRoot, "checksums.txt")
+	writeFile(t, checksumsPath, strings.Join([]string{
+		"1111111111111111111111111111111111111111111111111111111111111111  festival-9.9.9-macOS-all.tar.gz",
+		"2222222222222222222222222222222222222222222222222222222222222222  festival-9.9.9-linux-x86_64.tar.gz",
+		"3333333333333333333333333333333333333333333333333333333333333333  festival-9.9.9-linux-arm64.tar.gz",
+		"",
+	}, "\n"))
+
+	t.Run("a real published-at value reaches the emitted manifest and satisfies the hub schema's date-time format", func(t *testing.T) {
+		outputPath := filepath.Join(t.TempDir(), "obey-package.json")
+		if err := runEmitMarketplaceEntry(repoRoot, "v9.9.9", "stable", checksumsPath, outputPath, "2026-08-20T01:51:38Z"); err != nil {
+			t.Fatalf("runEmitMarketplaceEntry: %v", err)
+		}
+		raw, err := os.ReadFile(outputPath)
+		if err != nil {
+			t.Fatalf("read emitted manifest: %v", err)
+		}
+		var doc struct {
+			Releases []struct {
+				PublishedAt string `json:"published_at"`
+			} `json:"releases"`
+		}
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("decode emitted manifest: %v", err)
+		}
+		if len(doc.Releases) != 1 {
+			t.Fatalf("got %d releases, want 1", len(doc.Releases))
+		}
+		// This is the exact constraint the hub's manifest.schema.json places
+		// on published_at ("format": "date-time"), and the exact field that
+		// shipped empty in v0.2.17. time.RFC3339 is Go's date-time format.
+		if _, err := time.Parse(time.RFC3339, doc.Releases[0].PublishedAt); err != nil {
+			t.Fatalf("emitted published_at %q does not satisfy the hub schema's date-time format: %v", doc.Releases[0].PublishedAt, err)
+		}
+	})
+
+	t.Run("an empty published-at is refused before a manifest is ever written", func(t *testing.T) {
+		outputPath := filepath.Join(t.TempDir(), "obey-package.json")
+		err := runEmitMarketplaceEntry(repoRoot, "v9.9.9", "stable", checksumsPath, outputPath, "")
+		if err == nil {
+			t.Fatal("expected an error for empty --published-at, got nil")
+		}
+		if !strings.Contains(err.Error(), "published_at") {
+			t.Fatalf("error %q does not name published_at", err.Error())
+		}
+		if _, statErr := os.Stat(outputPath); statErr == nil {
+			t.Fatal("a manifest was written despite the refusal")
 		}
 	})
 }


### PR DESCRIPTION
## What this does

Stops `projects/festival` releases from pushing unsigned, non-canonical
marketplace metadata straight to `Obedience-Corp/marketplace` `main`. The
release now pushes a topic branch and opens a pull request instead, so the
marketplace's own `Sign metadata` workflow, which is the only thing holding
the private key, is what writes signed content to the default branch
(ruling G1, marketplace-trust-chain-MT0001 sequence 01: ".../results/decisions.md").

- `scripts/publish_marketplace_entry.sh` verifies the marketplace clone with
  `go run ./tools/metadata verify` before editing anything, and refuses to
  publish onto an already-broken tree. It no longer runs
  `git push origin HEAD:main`; it pushes `release/festival-<tag>-<channel>`
  and opens a PR with `gh pr create`, printing the PR URL and writing it to
  `GITHUB_STEP_SUMMARY`. `MARKETPLACE_REPO_URL` still short-circuits after
  the branch push, which is what the new fixture test drives.
- Both `.github/workflows/release.yaml` `Publish marketplace entry` call
  sites (tag-triggered and `workflow_dispatch` jobs) get a `GH_TOKEN` env
  and a comment cross-referencing the other site. The stable-channel
  credential preflight now also asserts `MARKETPLACE_PUBLISH_TOKEN` can
  push to `Obedience-Corp/marketplace`.
- `scripts/test_marketplace_publish.sh` (new) plus a `just test
  marketplace-publish` recipe drive the real script against a local fixture
  marketplace (`testdata/marketplace-fixture/`) through the existing
  `MARKETPLACE_REPO_URL` injection point. No network, no GitHub
  credentials. Error cases (broken tree, missing env, no-op re-publish) are
  asserted before the happy path; case 6 explicitly asserts the fixture's
  `main` is untouched after a successful publish, which is what this whole
  sequence exists to guarantee.
- Known defect fixed (found 2026-08-21): the official v0.2.17 manifest
  shipped with `"published_at": ""` because `release.yaml` called
  `emit-marketplace-entry` without `--published-at`, and the hub's schema
  requires `format: date-time`. Both `Generate marketplace entry` steps now
  pass `--published-at "$(gh release view ... --json publishedAt --jq
  .publishedAt)"`, and `BuildMarketplaceEntry` in
  `tools/release-operator` now refuses an empty or non-RFC-3339
  `published_at` instead of emitting it, covered by Go tests in
  `tools/release-operator/internal/operator/marketplace_test.go` and an
  end-to-end `--published-at` test in `tools/release-operator/main_test.go`
  that resolves real submodule tags the way `release.yaml` does.
- `results/canonical-json-decision.md` (festival campaign) records the
  decision not to add a JSON-canonicalization dependency to
  `tools/release-operator` (currently zero dependencies), since the
  marketplace's own `Sign metadata` workflow canonicalizes on signing
  regardless of what this operator emits.

## FH0002 PR #135

This branch is based on `main` **after** #135 merged (`3278a9c`), so there is
no rebase pending; the three-suite-component `release.yaml` changes from
#135 are already the base this PR diffs against.

## Operational follow-up for Lance

`MARKETPLACE_PUBLISH_TOKEN` needs pull-request scope (push access to
`Obedience-Corp/marketplace`) for the next release to succeed; the new
credential preflight in `release.yaml` will fail loudly if it does not. This
is a secret change outside what this PR can do.

The release now requires a human merge on the marketplace side (the opened
pull request) before the entry is live. That is the intended tradeoff under
ruling G1: one copy of the signing key, held only by the marketplace's own
workflow.

## Testing

- `just build all`
- `just test release-operator`
- `just test marketplace-publish` (new)
- `just test all`
- `bash -n` and `shellcheck` clean on both shell scripts
- `go vet ./...` clean in `tools/release-operator`
