### PR TITLE
fix(plugin): skip ensure-festival update nag on non-release versions

### DIFF
--- a/.cursor-plugin/hooks/scripts/ensure-festival.sh
+++ b/.cursor-plugin/hooks/scripts/ensure-festival.sh
@@ -184,67 +184,111 @@ download_and_install() {
     done
 }
 
-# --- Main ---
-
-require_command curl
-require_command tar
-require_command grep
-require_command sed
-require_command awk
-require_command find
-require_command install
-require_checksum_command
-detect_platform
-
-if ! check_installed; then
-    # Fresh install
-    info "Festival CLI not found. Installing fest and camp..."
-
-    RELEASE_JSON=$(fetch_release) || {
-        info "Could not fetch release info. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
-        exit 1
-    }
-
-    ARCHIVE_URL=$(find_archive_url "$RELEASE_JSON")
-    if [ -z "$ARCHIVE_URL" ]; then
-        info "No compatible archive found for ${OS}/${ARCH}. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
-        exit 1
+# parse_local_fest_version SHORT_OUTPUT FULL_OUTPUT
+#
+# Prefer `fest version --short` (a single token: "dev", "v0.2.16", ...). If that
+# is empty (old binary, flag unknown), take field 2 of the first `fest version`
+# line ("fest v0.2.16" / "fest dev"). Do not scan the whole block for X.Y.Z:
+# the Go runtime line is `go: go1.26.4` and a greedy grep treats 1.26.4 as the
+# installed festival version.
+parse_local_fest_version() {
+    local short="${1-}"
+    local full="${2-}"
+    local token
+    token="$(printf '%s\n' "$short" | awk 'NR==1 {print $1; exit}')"
+    if [ -n "$token" ]; then
+        printf '%s' "$token"
+        return 0
     fi
-
-    download_and_install "$ARCHIVE_URL"
-    record_check
-
-    if command -v fest >/dev/null 2>&1; then
-        info "Festival installed successfully: $(fest version 2>/dev/null || echo 'fest ready')"
-    else
-        info "Installed to ${INSTALL_DIR}. You may need to add it to your PATH: export PATH=\"${INSTALL_DIR}:\$PATH\""
-    fi
-    exit 0
-fi
-
-# Already installed, check for updates (rate-limited to once/day)
-if ! should_check_update; then
-    exit 0
-fi
-
-CURRENT_VERSION=$(fest version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
-if [ -z "$CURRENT_VERSION" ]; then
-    record_check
-    exit 0
-fi
-
-RELEASE_JSON=$(fetch_release 2>/dev/null) || {
-    record_check
-    exit 0
+    printf '%s\n' "$full" | awk 'NR==1 {print $2; exit}'
 }
 
-LATEST_TAG=$(extract_tag "$RELEASE_JSON")
-# Normalize: strip leading v for comparison
-CURRENT_CLEAN="${CURRENT_VERSION#v}"
-LATEST_CLEAN="${LATEST_TAG#v}"
+# is_release_version TOKEN: 0 when TOKEN is a festival release semver
+# (optional leading v, X.Y.Z, optional -rc.N / dotted suffix). Rejects "dev",
+# empty, and *-dev.* snapshot builds.
+is_release_version() {
+    local v="${1-}"
+    case "$v" in
+        ""|dev|unknown) return 1 ;;
+        *-dev|*-dev.*) return 1 ;;
+    esac
+    printf '%s' "$v" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.]+)?$'
+}
 
-record_check
+read_local_fest_version() {
+    local short full
+    short="$(fest version --short 2>/dev/null || true)"
+    full="$(fest version 2>/dev/null || true)"
+    parse_local_fest_version "$short" "$full"
+}
 
-if [ "$CURRENT_CLEAN" != "$LATEST_CLEAN" ]; then
-    info "Festival update available: ${CURRENT_VERSION} -> ${LATEST_TAG}. Run: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+main() {
+    require_command curl
+    require_command tar
+    require_command grep
+    require_command sed
+    require_command awk
+    require_command find
+    require_command install
+    require_checksum_command
+    detect_platform
+
+    if ! check_installed; then
+        info "Festival CLI not found. Installing fest and camp..."
+
+        RELEASE_JSON=$(fetch_release) || {
+            info "Could not fetch release info. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+            exit 1
+        }
+
+        ARCHIVE_URL=$(find_archive_url "$RELEASE_JSON")
+        if [ -z "$ARCHIVE_URL" ]; then
+            info "No compatible archive found for ${OS}/${ARCH}. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+            exit 1
+        fi
+
+        download_and_install "$ARCHIVE_URL"
+        record_check
+
+        if command -v fest >/dev/null 2>&1; then
+            info "Festival installed successfully: $(fest version 2>/dev/null || echo 'fest ready')"
+        else
+            info "Installed to ${INSTALL_DIR}. You may need to add it to your PATH: export PATH=\"${INSTALL_DIR}:\$PATH\""
+        fi
+        exit 0
+    fi
+
+    # Already installed: check for updates (rate-limited to once/day)
+    if ! should_check_update; then
+        exit 0
+    fi
+
+    CURRENT_VERSION="$(read_local_fest_version)"
+    if ! is_release_version "$CURRENT_VERSION"; then
+        if [ -n "$CURRENT_VERSION" ]; then
+            info "Festival update check skipped: local fest version '${CURRENT_VERSION}' is not a release"
+        fi
+        record_check
+        exit 0
+    fi
+
+    RELEASE_JSON=$(fetch_release 2>/dev/null) || {
+        record_check
+        exit 0
+    }
+
+    LATEST_TAG=$(extract_tag "$RELEASE_JSON")
+    CURRENT_CLEAN="${CURRENT_VERSION#v}"
+    LATEST_CLEAN="${LATEST_TAG#v}"
+
+    record_check
+
+    if [ "$CURRENT_CLEAN" != "$LATEST_CLEAN" ]; then
+        info "Festival update available: ${CURRENT_VERSION} -> ${LATEST_TAG}. Run: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+    fi
+}
+
+# Run main only when executed, not when sourced by the test harness.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+    main "$@"
 fi

--- a/.opencode/scripts/ensure-festival.sh
+++ b/.opencode/scripts/ensure-festival.sh
@@ -184,67 +184,111 @@ download_and_install() {
     done
 }
 
-# --- Main ---
-
-require_command curl
-require_command tar
-require_command grep
-require_command sed
-require_command awk
-require_command find
-require_command install
-require_checksum_command
-detect_platform
-
-if ! check_installed; then
-    # Fresh install
-    info "Festival CLI not found. Installing fest and camp..."
-
-    RELEASE_JSON=$(fetch_release) || {
-        info "Could not fetch release info. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
-        exit 1
-    }
-
-    ARCHIVE_URL=$(find_archive_url "$RELEASE_JSON")
-    if [ -z "$ARCHIVE_URL" ]; then
-        info "No compatible archive found for ${OS}/${ARCH}. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
-        exit 1
+# parse_local_fest_version SHORT_OUTPUT FULL_OUTPUT
+#
+# Prefer `fest version --short` (a single token: "dev", "v0.2.16", ...). If that
+# is empty (old binary, flag unknown), take field 2 of the first `fest version`
+# line ("fest v0.2.16" / "fest dev"). Do not scan the whole block for X.Y.Z:
+# the Go runtime line is `go: go1.26.4` and a greedy grep treats 1.26.4 as the
+# installed festival version.
+parse_local_fest_version() {
+    local short="${1-}"
+    local full="${2-}"
+    local token
+    token="$(printf '%s\n' "$short" | awk 'NR==1 {print $1; exit}')"
+    if [ -n "$token" ]; then
+        printf '%s' "$token"
+        return 0
     fi
-
-    download_and_install "$ARCHIVE_URL"
-    record_check
-
-    if command -v fest >/dev/null 2>&1; then
-        info "Festival installed successfully: $(fest version 2>/dev/null || echo 'fest ready')"
-    else
-        info "Installed to ${INSTALL_DIR}. You may need to add it to your PATH: export PATH=\"${INSTALL_DIR}:\$PATH\""
-    fi
-    exit 0
-fi
-
-# Already installed, check for updates (rate-limited to once/day)
-if ! should_check_update; then
-    exit 0
-fi
-
-CURRENT_VERSION=$(fest version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
-if [ -z "$CURRENT_VERSION" ]; then
-    record_check
-    exit 0
-fi
-
-RELEASE_JSON=$(fetch_release 2>/dev/null) || {
-    record_check
-    exit 0
+    printf '%s\n' "$full" | awk 'NR==1 {print $2; exit}'
 }
 
-LATEST_TAG=$(extract_tag "$RELEASE_JSON")
-# Normalize: strip leading v for comparison
-CURRENT_CLEAN="${CURRENT_VERSION#v}"
-LATEST_CLEAN="${LATEST_TAG#v}"
+# is_release_version TOKEN: 0 when TOKEN is a festival release semver
+# (optional leading v, X.Y.Z, optional -rc.N / dotted suffix). Rejects "dev",
+# empty, and *-dev.* snapshot builds.
+is_release_version() {
+    local v="${1-}"
+    case "$v" in
+        ""|dev|unknown) return 1 ;;
+        *-dev|*-dev.*) return 1 ;;
+    esac
+    printf '%s' "$v" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.]+)?$'
+}
 
-record_check
+read_local_fest_version() {
+    local short full
+    short="$(fest version --short 2>/dev/null || true)"
+    full="$(fest version 2>/dev/null || true)"
+    parse_local_fest_version "$short" "$full"
+}
 
-if [ "$CURRENT_CLEAN" != "$LATEST_CLEAN" ]; then
-    info "Festival update available: ${CURRENT_VERSION} -> ${LATEST_TAG}. Run: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+main() {
+    require_command curl
+    require_command tar
+    require_command grep
+    require_command sed
+    require_command awk
+    require_command find
+    require_command install
+    require_checksum_command
+    detect_platform
+
+    if ! check_installed; then
+        info "Festival CLI not found. Installing fest and camp..."
+
+        RELEASE_JSON=$(fetch_release) || {
+            info "Could not fetch release info. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+            exit 1
+        }
+
+        ARCHIVE_URL=$(find_archive_url "$RELEASE_JSON")
+        if [ -z "$ARCHIVE_URL" ]; then
+            info "No compatible archive found for ${OS}/${ARCH}. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+            exit 1
+        fi
+
+        download_and_install "$ARCHIVE_URL"
+        record_check
+
+        if command -v fest >/dev/null 2>&1; then
+            info "Festival installed successfully: $(fest version 2>/dev/null || echo 'fest ready')"
+        else
+            info "Installed to ${INSTALL_DIR}. You may need to add it to your PATH: export PATH=\"${INSTALL_DIR}:\$PATH\""
+        fi
+        exit 0
+    fi
+
+    # Already installed: check for updates (rate-limited to once/day)
+    if ! should_check_update; then
+        exit 0
+    fi
+
+    CURRENT_VERSION="$(read_local_fest_version)"
+    if ! is_release_version "$CURRENT_VERSION"; then
+        if [ -n "$CURRENT_VERSION" ]; then
+            info "Festival update check skipped: local fest version '${CURRENT_VERSION}' is not a release"
+        fi
+        record_check
+        exit 0
+    fi
+
+    RELEASE_JSON=$(fetch_release 2>/dev/null) || {
+        record_check
+        exit 0
+    }
+
+    LATEST_TAG=$(extract_tag "$RELEASE_JSON")
+    CURRENT_CLEAN="${CURRENT_VERSION#v}"
+    LATEST_CLEAN="${LATEST_TAG#v}"
+
+    record_check
+
+    if [ "$CURRENT_CLEAN" != "$LATEST_CLEAN" ]; then
+        info "Festival update available: ${CURRENT_VERSION} -> ${LATEST_TAG}. Run: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+    fi
+}
+
+# Run main only when executed, not when sourced by the test harness.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+    main "$@"
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- SessionStart `ensure-festival.sh` no longer treats the Go toolchain line (`go: go1.26.4`) as the installed festival version. Dev builds (`fest version --short` → `dev`) skip the update compare instead of nagging `Festival update available: 1.26.4 -> vX.Y.Z`.
 - The plugin's hooks did not load on Claude Code. `claude-plugin/hooks/hooks.json` listed `SessionStart` and `PreToolUse` at the top level, and Claude Code (2.1.235) wants the event map nested under a top-level `hooks` object, so the plugin installed and then reported `Status: failed to load` with `Hook load failed: hooks: Invalid input: expected record, received undefined`. Skills, commands, and agents loaded; both hooks were lost, which meant no session-start CLI install and no commit guard. The file now carries the `description` plus `hooks` wrapper, the Codex projection in `packaging/targets/codex.target.mjs` was corrected the same way (Codex documents the same shape), and `just plugin check` gained a shape check so a bare event map fails the gate instead of shipping. The plugin manifests are bumped to 1.3.1 so marketplace users pick the working bundle up.
 - Plugin manifests (Claude, Codex, Cursor) and every generated Hermes tap skill declared `MIT`; the repo and everything in it is Apache 2.0 (ADR-0002). All now say `Apache-2.0`.
 

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -22,6 +22,7 @@ claude-plugin/
   hooks/
     hooks.json                  SessionStart + PreToolUse hook wiring
     scripts/ensure-festival.sh  installs and updates fest and camp
+    scripts/ensure-festival.test.sh  unit tests for local-version parsing (run by the gate)
     scripts/commit-guard.sh     blocks raw `git commit` inside a campaign
     scripts/commit-guard.test.sh  unit tests for the guard (run by the gate)
     scripts/sync-check.sh       checks plugin command refs against the CLIs

--- a/claude-plugin/hooks/scripts/ensure-festival.sh
+++ b/claude-plugin/hooks/scripts/ensure-festival.sh
@@ -183,67 +183,111 @@ download_and_install() {
     done
 }
 
-# --- Main ---
-
-require_command curl
-require_command tar
-require_command grep
-require_command sed
-require_command awk
-require_command find
-require_command install
-require_checksum_command
-detect_platform
-
-if ! check_installed; then
-    # Fresh install
-    info "Festival CLI not found. Installing fest and camp..."
-
-    RELEASE_JSON=$(fetch_release) || {
-        info "Could not fetch release info. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
-        exit 1
-    }
-
-    ARCHIVE_URL=$(find_archive_url "$RELEASE_JSON")
-    if [ -z "$ARCHIVE_URL" ]; then
-        info "No compatible archive found for ${OS}/${ARCH}. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
-        exit 1
+# parse_local_fest_version SHORT_OUTPUT FULL_OUTPUT
+#
+# Prefer `fest version --short` (a single token: "dev", "v0.2.16", ...). If that
+# is empty (old binary, flag unknown), take field 2 of the first `fest version`
+# line ("fest v0.2.16" / "fest dev"). Do not scan the whole block for X.Y.Z:
+# the Go runtime line is `go: go1.26.4` and a greedy grep treats 1.26.4 as the
+# installed festival version.
+parse_local_fest_version() {
+    local short="${1-}"
+    local full="${2-}"
+    local token
+    token="$(printf '%s\n' "$short" | awk 'NR==1 {print $1; exit}')"
+    if [ -n "$token" ]; then
+        printf '%s' "$token"
+        return 0
     fi
-
-    download_and_install "$ARCHIVE_URL"
-    record_check
-
-    if command -v fest >/dev/null 2>&1; then
-        info "Festival installed successfully: $(fest version 2>/dev/null || echo 'fest ready')"
-    else
-        info "Installed to ${INSTALL_DIR}. You may need to add it to your PATH: export PATH=\"${INSTALL_DIR}:\$PATH\""
-    fi
-    exit 0
-fi
-
-# Already installed, check for updates (rate-limited to once/day)
-if ! should_check_update; then
-    exit 0
-fi
-
-CURRENT_VERSION=$(fest version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
-if [ -z "$CURRENT_VERSION" ]; then
-    record_check
-    exit 0
-fi
-
-RELEASE_JSON=$(fetch_release 2>/dev/null) || {
-    record_check
-    exit 0
+    printf '%s\n' "$full" | awk 'NR==1 {print $2; exit}'
 }
 
-LATEST_TAG=$(extract_tag "$RELEASE_JSON")
-# Normalize: strip leading v for comparison
-CURRENT_CLEAN="${CURRENT_VERSION#v}"
-LATEST_CLEAN="${LATEST_TAG#v}"
+# is_release_version TOKEN: 0 when TOKEN is a festival release semver
+# (optional leading v, X.Y.Z, optional -rc.N / dotted suffix). Rejects "dev",
+# empty, and *-dev.* snapshot builds.
+is_release_version() {
+    local v="${1-}"
+    case "$v" in
+        ""|dev|unknown) return 1 ;;
+        *-dev|*-dev.*) return 1 ;;
+    esac
+    printf '%s' "$v" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.]+)?$'
+}
 
-record_check
+read_local_fest_version() {
+    local short full
+    short="$(fest version --short 2>/dev/null || true)"
+    full="$(fest version 2>/dev/null || true)"
+    parse_local_fest_version "$short" "$full"
+}
 
-if [ "$CURRENT_CLEAN" != "$LATEST_CLEAN" ]; then
-    info "Festival update available: ${CURRENT_VERSION} -> ${LATEST_TAG}. Run: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+main() {
+    require_command curl
+    require_command tar
+    require_command grep
+    require_command sed
+    require_command awk
+    require_command find
+    require_command install
+    require_checksum_command
+    detect_platform
+
+    if ! check_installed; then
+        info "Festival CLI not found. Installing fest and camp..."
+
+        RELEASE_JSON=$(fetch_release) || {
+            info "Could not fetch release info. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+            exit 1
+        }
+
+        ARCHIVE_URL=$(find_archive_url "$RELEASE_JSON")
+        if [ -z "$ARCHIVE_URL" ]; then
+            info "No compatible archive found for ${OS}/${ARCH}. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+            exit 1
+        fi
+
+        download_and_install "$ARCHIVE_URL"
+        record_check
+
+        if command -v fest >/dev/null 2>&1; then
+            info "Festival installed successfully: $(fest version 2>/dev/null || echo 'fest ready')"
+        else
+            info "Installed to ${INSTALL_DIR}. You may need to add it to your PATH: export PATH=\"${INSTALL_DIR}:\$PATH\""
+        fi
+        exit 0
+    fi
+
+    # Already installed: check for updates (rate-limited to once/day)
+    if ! should_check_update; then
+        exit 0
+    fi
+
+    CURRENT_VERSION="$(read_local_fest_version)"
+    if ! is_release_version "$CURRENT_VERSION"; then
+        if [ -n "$CURRENT_VERSION" ]; then
+            info "Festival update check skipped: local fest version '${CURRENT_VERSION}' is not a release"
+        fi
+        record_check
+        exit 0
+    fi
+
+    RELEASE_JSON=$(fetch_release 2>/dev/null) || {
+        record_check
+        exit 0
+    }
+
+    LATEST_TAG=$(extract_tag "$RELEASE_JSON")
+    CURRENT_CLEAN="${CURRENT_VERSION#v}"
+    LATEST_CLEAN="${LATEST_TAG#v}"
+
+    record_check
+
+    if [ "$CURRENT_CLEAN" != "$LATEST_CLEAN" ]; then
+        info "Festival update available: ${CURRENT_VERSION} -> ${LATEST_TAG}. Run: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+    fi
+}
+
+# Run main only when executed, not when sourced by the test harness.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+    main "$@"
 fi

--- a/claude-plugin/hooks/scripts/ensure-festival.test.sh
+++ b/claude-plugin/hooks/scripts/ensure-festival.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Unit tests for ensure-festival.sh local-version parsing.
+#
+# Sources the installer (its main() is guarded so sourcing only defines
+# functions) and exercises parse_local_fest_version / is_release_version
+# against the SessionStart nag that treated `go: go1.26.4` as the installed
+# festival version. Pure string logic: no network, no temp dirs. Invoked by
+# `just plugin check`.
+set -u
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./ensure-festival.sh
+source "$DIR/ensure-festival.sh"
+
+fail=0
+check_parse() { # $1 want  $2 short  $3 full
+  local want="$1" short="$2" full="$3" got
+  got="$(parse_local_fest_version "$short" "$full")"
+  if [ "$got" = "$want" ]; then
+    if [ -n "${ENSURE_FESTIVAL_TEST_VERBOSE:-}" ]; then
+      printf 'ok   parse %-12s\n' "$want"
+    fi
+  else
+    printf 'FAIL parse want=%s got=%s\n' "$want" "$got"
+    fail=1
+  fi
+}
+
+check_release() { # $1 want(yes|no)  $2 token
+  local want="$1" token="$2" got
+  if is_release_version "$token"; then got=yes; else got=no; fi
+  if [ "$got" = "$want" ]; then
+    if [ -n "${ENSURE_FESTIVAL_TEST_VERBOSE:-}" ]; then
+      printf 'ok   release %-4s %s\n' "$want" "$token"
+    fi
+  else
+    printf 'FAIL release want=%s got=%s  %s\n' "$want" "$got" "$token"
+    fail=1
+  fi
+}
+
+classic_full=$'fest dev\ncommit: 00bc23e\nbuilt: 2026-08-17T23:38:19Z\ngo: go1.26.4\nplatform: darwin/arm64'
+buggy="$(printf '%s\n' "$classic_full" | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+if [ "$buggy" = "1.26.4" ]; then
+  if [ -n "${ENSURE_FESTIVAL_TEST_VERBOSE:-}" ]; then
+    printf 'ok   fixture still reproduces the greedy grep\n'
+  fi
+else
+  printf 'FAIL fixture no longer reproduces the grep bug (got %s)\n' "$buggy"
+  fail=1
+fi
+
+# --short is the version token; full output's Go line must not win.
+check_parse "dev" "dev" "$classic_full"
+check_parse "v0.2.16" "v0.2.16" $'fest v0.2.16\ngo: go1.26.4'
+check_parse "v9.8.7" "v9.8.7" $'fest v9.8.7\ngo: go1.26.4'
+
+# Fallback when --short is empty: field 2 of the first line, not a blob grep.
+check_parse "dev" "" "$classic_full"
+check_parse "v0.2.16" "" $'fest v0.2.16\ncommit: abc\ngo: go1.26.4'
+check_parse "" "" ""
+
+# Accidental full-block in the short slot: first field is "fest", never 1.26.4.
+check_parse "fest" "$classic_full" "$classic_full"
+
+check_release yes "v0.2.16"
+check_release yes "0.2.16"
+check_release yes "v9.8.7"
+check_release yes "v0.2.16-rc.1"
+check_release no "dev"
+check_release no ""
+check_release no "unknown"
+check_release no "fest"
+check_release no "go1.26.4"
+check_release no "v0.2.16-dev.3"
+check_release no "0.2.16-dev"
+
+if [ "$fail" -ne 0 ]; then
+  echo "ensure-festival version parse tests failed" >&2
+  exit 1
+fi
+
+echo "ensure-festival version parse tests passed"

--- a/plugins/festival/hooks/scripts/ensure-festival.sh
+++ b/plugins/festival/hooks/scripts/ensure-festival.sh
@@ -184,67 +184,111 @@ download_and_install() {
     done
 }
 
-# --- Main ---
-
-require_command curl
-require_command tar
-require_command grep
-require_command sed
-require_command awk
-require_command find
-require_command install
-require_checksum_command
-detect_platform
-
-if ! check_installed; then
-    # Fresh install
-    info "Festival CLI not found. Installing fest and camp..."
-
-    RELEASE_JSON=$(fetch_release) || {
-        info "Could not fetch release info. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
-        exit 1
-    }
-
-    ARCHIVE_URL=$(find_archive_url "$RELEASE_JSON")
-    if [ -z "$ARCHIVE_URL" ]; then
-        info "No compatible archive found for ${OS}/${ARCH}. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
-        exit 1
+# parse_local_fest_version SHORT_OUTPUT FULL_OUTPUT
+#
+# Prefer `fest version --short` (a single token: "dev", "v0.2.16", ...). If that
+# is empty (old binary, flag unknown), take field 2 of the first `fest version`
+# line ("fest v0.2.16" / "fest dev"). Do not scan the whole block for X.Y.Z:
+# the Go runtime line is `go: go1.26.4` and a greedy grep treats 1.26.4 as the
+# installed festival version.
+parse_local_fest_version() {
+    local short="${1-}"
+    local full="${2-}"
+    local token
+    token="$(printf '%s\n' "$short" | awk 'NR==1 {print $1; exit}')"
+    if [ -n "$token" ]; then
+        printf '%s' "$token"
+        return 0
     fi
-
-    download_and_install "$ARCHIVE_URL"
-    record_check
-
-    if command -v fest >/dev/null 2>&1; then
-        info "Festival installed successfully: $(fest version 2>/dev/null || echo 'fest ready')"
-    else
-        info "Installed to ${INSTALL_DIR}. You may need to add it to your PATH: export PATH=\"${INSTALL_DIR}:\$PATH\""
-    fi
-    exit 0
-fi
-
-# Already installed, check for updates (rate-limited to once/day)
-if ! should_check_update; then
-    exit 0
-fi
-
-CURRENT_VERSION=$(fest version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
-if [ -z "$CURRENT_VERSION" ]; then
-    record_check
-    exit 0
-fi
-
-RELEASE_JSON=$(fetch_release 2>/dev/null) || {
-    record_check
-    exit 0
+    printf '%s\n' "$full" | awk 'NR==1 {print $2; exit}'
 }
 
-LATEST_TAG=$(extract_tag "$RELEASE_JSON")
-# Normalize: strip leading v for comparison
-CURRENT_CLEAN="${CURRENT_VERSION#v}"
-LATEST_CLEAN="${LATEST_TAG#v}"
+# is_release_version TOKEN: 0 when TOKEN is a festival release semver
+# (optional leading v, X.Y.Z, optional -rc.N / dotted suffix). Rejects "dev",
+# empty, and *-dev.* snapshot builds.
+is_release_version() {
+    local v="${1-}"
+    case "$v" in
+        ""|dev|unknown) return 1 ;;
+        *-dev|*-dev.*) return 1 ;;
+    esac
+    printf '%s' "$v" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.]+)?$'
+}
 
-record_check
+read_local_fest_version() {
+    local short full
+    short="$(fest version --short 2>/dev/null || true)"
+    full="$(fest version 2>/dev/null || true)"
+    parse_local_fest_version "$short" "$full"
+}
 
-if [ "$CURRENT_CLEAN" != "$LATEST_CLEAN" ]; then
-    info "Festival update available: ${CURRENT_VERSION} -> ${LATEST_TAG}. Run: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+main() {
+    require_command curl
+    require_command tar
+    require_command grep
+    require_command sed
+    require_command awk
+    require_command find
+    require_command install
+    require_checksum_command
+    detect_platform
+
+    if ! check_installed; then
+        info "Festival CLI not found. Installing fest and camp..."
+
+        RELEASE_JSON=$(fetch_release) || {
+            info "Could not fetch release info. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+            exit 1
+        }
+
+        ARCHIVE_URL=$(find_archive_url "$RELEASE_JSON")
+        if [ -z "$ARCHIVE_URL" ]; then
+            info "No compatible archive found for ${OS}/${ARCH}. Install manually: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+            exit 1
+        fi
+
+        download_and_install "$ARCHIVE_URL"
+        record_check
+
+        if command -v fest >/dev/null 2>&1; then
+            info "Festival installed successfully: $(fest version 2>/dev/null || echo 'fest ready')"
+        else
+            info "Installed to ${INSTALL_DIR}. You may need to add it to your PATH: export PATH=\"${INSTALL_DIR}:\$PATH\""
+        fi
+        exit 0
+    fi
+
+    # Already installed: check for updates (rate-limited to once/day)
+    if ! should_check_update; then
+        exit 0
+    fi
+
+    CURRENT_VERSION="$(read_local_fest_version)"
+    if ! is_release_version "$CURRENT_VERSION"; then
+        if [ -n "$CURRENT_VERSION" ]; then
+            info "Festival update check skipped: local fest version '${CURRENT_VERSION}' is not a release"
+        fi
+        record_check
+        exit 0
+    fi
+
+    RELEASE_JSON=$(fetch_release 2>/dev/null) || {
+        record_check
+        exit 0
+    }
+
+    LATEST_TAG=$(extract_tag "$RELEASE_JSON")
+    CURRENT_CLEAN="${CURRENT_VERSION#v}"
+    LATEST_CLEAN="${LATEST_TAG#v}"
+
+    record_check
+
+    if [ "$CURRENT_CLEAN" != "$LATEST_CLEAN" ]; then
+        info "Festival update available: ${CURRENT_VERSION} -> ${LATEST_TAG}. Run: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash"
+    fi
+}
+
+# Run main only when executed, not when sourced by the test harness.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+    main "$@"
 fi

--- a/scripts/test_claude_plugin.sh
+++ b/scripts/test_claude_plugin.sh
@@ -500,8 +500,41 @@ write_stub_binary() {
     cat > "$path" <<EOF_STUB
 #!/usr/bin/env bash
 case "\${1:-}" in
-  version|--version) echo "${name} v9.8.7" ;;
+  version)
+    case "\${2:-}" in
+      --short|-s) echo "v9.8.7" ;;
+      *) echo "${name} v9.8.7" ;;
+    esac
+    ;;
+  --version) echo "${name} v9.8.7" ;;
   *) echo "${name} stub" ;;
+esac
+EOF_STUB
+    chmod +x "$path"
+}
+
+write_fest_version_stub() {
+    local path="$1"
+    local short="$2"
+    local first_line="$3"
+
+    cat > "$path" <<EOF_STUB
+#!/usr/bin/env bash
+case "\${1:-}" in
+  version)
+    case "\${2:-}" in
+      --short|-s) echo "${short}" ;;
+      *)
+        echo "${first_line}"
+        echo "commit: testdead"
+        echo "built: 2026-08-19T00:00:00Z"
+        echo "go: go1.26.4"
+        echo "platform: testhost"
+        ;;
+    esac
+    ;;
+  --version) echo "fest version ${short}" ;;
+  *) echo "fest stub" ;;
 esac
 EOF_STUB
     chmod +x "$path"
@@ -601,9 +634,24 @@ EOF_JSON
 
     write_fake_curl "$fakebin/curl"
 
+    run_ensure() {
+        local log="$1"
+        rm -f "$tmp/last-update-check"
+        if ! FESTIVAL_PLUGIN_TEST_FIXTURE_DIR="$fixture" \
+            HOME="$home" \
+            INSTALL_DIR="$install_dir" \
+            FESTIVAL_CHECK_FILE="$tmp/last-update-check" \
+            PATH="$install_dir:$fakebin:/usr/bin:/bin:/usr/sbin:/sbin" \
+            bash "$plugin_dir/hooks/scripts/ensure-festival.sh" >"$log" 2>&1; then
+            cat "$log" >&2
+            return 1
+        fi
+    }
+
     if ! FESTIVAL_PLUGIN_TEST_FIXTURE_DIR="$fixture" \
         HOME="$home" \
         INSTALL_DIR="$install_dir" \
+        FESTIVAL_CHECK_FILE="$tmp/last-update-check" \
         PATH="$fakebin:/usr/bin:/bin:/usr/sbin:/sbin" \
         bash "$plugin_dir/hooks/scripts/ensure-festival.sh" >"$tmp/install.log" 2>&1; then
         cat "$tmp/install.log" >&2
@@ -613,12 +661,45 @@ EOF_JSON
     test -x "$install_dir/fest"
     test -x "$install_dir/camp"
 
-    if ! FESTIVAL_PLUGIN_TEST_FIXTURE_DIR="$fixture" \
-        HOME="$home" \
-        INSTALL_DIR="$install_dir" \
-        PATH="$install_dir:$fakebin:/usr/bin:/bin:/usr/sbin:/sbin" \
-        bash "$plugin_dir/hooks/scripts/ensure-festival.sh" >"$tmp/update-check.log" 2>&1; then
+    # Matching release: no nag. Clear the check file so this actually runs
+    # the update-compare path (install records a check and would otherwise skip).
+    run_ensure "$tmp/update-check.log" || return 1
+    if grep -q "Festival update available" "$tmp/update-check.log"; then
+        echo "matching version must not nag an update" >&2
         cat "$tmp/update-check.log" >&2
+        return 1
+    fi
+
+    # Dev build whose full `fest version` includes go1.26.4: skip, never nag 1.26.4.
+    write_fest_version_stub "$install_dir/fest" "dev" "fest dev"
+    run_ensure "$tmp/dev-check.log" || return 1
+    if grep -q "Festival update available" "$tmp/dev-check.log"; then
+        echo "dev build must not nag an update" >&2
+        cat "$tmp/dev-check.log" >&2
+        return 1
+    fi
+    if ! grep -q "not a release" "$tmp/dev-check.log"; then
+        echo "dev build should skip with a clear message" >&2
+        cat "$tmp/dev-check.log" >&2
+        return 1
+    fi
+    if grep -q "1.26.4" "$tmp/dev-check.log"; then
+        echo "must not surface the Go toolchain version as the festival version" >&2
+        cat "$tmp/dev-check.log" >&2
+        return 1
+    fi
+
+    # Older release plus the same Go line: nag the festival version, not 1.26.4.
+    write_fest_version_stub "$install_dir/fest" "v0.1.0" "fest v0.1.0"
+    run_ensure "$tmp/stale-check.log" || return 1
+    if ! grep -q "Festival update available: v0.1.0 -> v9.8.7" "$tmp/stale-check.log"; then
+        echo "stale release must nag the festival versions" >&2
+        cat "$tmp/stale-check.log" >&2
+        return 1
+    fi
+    if grep -q "1.26.4" "$tmp/stale-check.log"; then
+        echo "must not report the Go toolchain version as the local festival version" >&2
+        cat "$tmp/stale-check.log" >&2
         return 1
     fi
 }
@@ -640,9 +721,11 @@ cursor_target_check "$plugin_dir/.claude-plugin/plugin.json"
 opencode_target_check
 gemini_target_check "$plugin_dir/.claude-plugin/plugin.json"
 hermes_target_check "$plugin_dir/.claude-plugin/plugin.json"
-bash -n "$plugin_dir/hooks/scripts/ensure-festival.sh" "$plugin_dir/hooks/scripts/sync-check.sh" \
+bash -n "$plugin_dir/hooks/scripts/ensure-festival.sh" "$plugin_dir/hooks/scripts/ensure-festival.test.sh" \
+    "$plugin_dir/hooks/scripts/sync-check.sh" \
     "$plugin_dir/hooks/scripts/commit-guard.sh" "$plugin_dir/hooks/scripts/commit-guard.test.sh"
 bash "$plugin_dir/hooks/scripts/commit-guard.test.sh"
+bash "$plugin_dir/hooks/scripts/ensure-festival.test.sh"
 
 if [ -x "$repo_root/fest/bin/fest" ] && [ -x "$repo_root/camp/bin/camp" ]; then
     FEST_BIN="$repo_root/fest/bin/fest" CAMP_BIN="$repo_root/camp/bin/camp" \


### PR DESCRIPTION
Fixes #139

## What

SessionStart `ensure-festival.sh` compared a mis-parsed local version against the GitHub release tag. `fest version` on a dev build prints `fest dev` plus `go: go1.26.4`; the installer grepped the whole block for `X.Y.Z` and nags:

```
Festival update available: 1.26.4 -> vX.Y.Z
```

The installer now reads `fest version --short` (fallback: field 2 of the first `fest version` line) and skips the update compare when that token is not a festival release (`dev`, empty, `*-dev.*`), with a clear skip message instead of a false nag.

## Where

- Source of truth: `claude-plugin/hooks/scripts/ensure-festival.sh`
- Generated copies: `plugins/festival`, `.cursor-plugin`, `.opencode`
- Tests: `claude-plugin/hooks/scripts/ensure-festival.test.sh` and the plugin smoke hook in `scripts/test_claude_plugin.sh`

## Testing

- `just plugin check` (includes the new parse unit tests and smoke cases: matching release, `fest dev` + `go1.26.4` skip, stale `v0.1.0` nags festival versions not `1.26.4`)