### PR TITLE
Pin the festival hub at v0.1.0 and fix the release confirm prompts

### DIFF
--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -55,19 +55,19 @@ plan mode="stable" fest="latest" camp="latest" festival_installer="latest":
 # - keep: keep the currently pinned exact tag for that submodule
 # - vX.Y.Z: pin a specific release tag
 [no-cd]
-[confirm("This will create a dev festival release using the selected fest/camp/festival-installer tags. Run 'just release plan mode=dev fest=... camp=... festival_installer=...' first if you want to see the exact tags. Continue?")]
+[confirm("This will create a dev festival release using the selected fest/camp/festival-installer tags. Run 'just release plan dev <fest> <camp> <festival_installer>' first if you want to see the exact tags (positional selectors: latest, keep, or vX.Y.Z). Continue?")]
 dev fest="latest" camp="latest" festival_installer="latest":
     just test release-operator
     go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" --festival-installer-tag "{{festival_installer}}" dev
 
 [no-cd]
-[confirm("This will create an RC festival release using the selected fest/camp/festival-installer tags. Run 'just release plan mode=rc fest=... camp=... festival_installer=...' first if you want to see the exact tags. Continue?")]
+[confirm("This will create an RC festival release using the selected fest/camp/festival-installer tags. Run 'just release plan rc <fest> <camp> <festival_installer>' first if you want to see the exact tags (positional selectors: latest, keep, or vX.Y.Z). Continue?")]
 rc fest="latest" camp="latest" festival_installer="latest":
     just test release-operator
     go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" --festival-installer-tag "{{festival_installer}}" rc
 
 [no-cd]
-[confirm("This will create a stable festival release on main using the selected fest/camp/festival-installer tags (the pin commit ships through an auto-merged PR because main is PR-only). Run 'just release plan mode=stable fest=... camp=... festival_installer=...' first if you want to see the exact tags. Continue?")]
+[confirm("This will create a stable festival release on main using the selected fest/camp/festival-installer tags (the pin commit ships through an auto-merged PR because main is PR-only). Run 'just release plan stable <fest> <camp> <festival_installer>' first if you want to see the exact tags (positional selectors: latest, keep, or vX.Y.Z). Continue?")]
 stable fest="latest" camp="latest" festival_installer="latest":
     just test release-operator
     go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" --festival-installer-tag "{{festival_installer}}" stable


### PR DESCRIPTION
FH0002 sequence 05 task 04.

## What

- `festival-installer` submodule pinned at the first hub release, `v0.1.0` (`1df39fd`), via `just release refresh-stable`. fest stays at `v0.6.2`, camp at `v0.5.0`.
- The three `[confirm(...)]` prompts in `.justfiles/release.just` (dev, rc, stable) printed `just release plan mode=... fest=... camp=... festival_installer=...`, which passes the literal string `mode=stable` as the mode because just parameters are positional. They now print the positional form: `just release plan <mode> <fest> <camp> <festival_installer>`.

## Verification

- `just test release-pins stable`: fest v0.6.2, camp v0.5.0, festival-installer v0.1.0, pass.
- `just release preflight stable`: exit 0 (publisher secrets present, pins, bundled module resolution, docs profile, release-operator tests, build, beginner-path smoke).
- `just release dry-run`: exit 0. `festival-0.2.18-next-macOS-all.tar.gz` unpacks to `camp`, `fest`, `festival`; `lipo -archs` reports `arm64 x86_64` for all three; the linux x86_64 archive lists all three binaries plus nine completion files and three shell files.

## Not in this PR

The suite release itself. Note for whoever cuts it: `just release stable ...` derives the next version with `BumpPatch()` (v0.2.18); the intended v0.3.0 (a new binary is a feature) goes through `just release draft-stable-from-latest 0.3.0` from `main`.