### PR TITLE
Release: refresh bundled docs for fest v0.6.2, camp v0.5.0, and festival-installer v0.1.0

### DIFF
--- a/docs/cli-reference/festival/festival_browse.md
+++ b/docs/cli-reference/festival/festival_browse.md
@@ -15,10 +15,11 @@ festival browse [flags]
 ### Options
 
 ```
-  -h, --help             help for browse
-      --json             emit JSON output
-      --kind string      filter by package class (plugin|tool|product|bundle)
-      --product string   filter by host product (fest|camp|obey)
+      --allow-unverified   allow browsing a marketplace with unsigned metadata without prompting
+  -h, --help               help for browse
+      --json               emit JSON output
+      --kind string        filter by package class (plugin|tool|product|bundle)
+      --product string     filter by host product (fest|camp|obey)
 ```
 
 ### SEE ALSO

--- a/docs/cli-reference/festival/festival_marketplace_add.md
+++ b/docs/cli-reference/festival/festival_marketplace_add.md
@@ -15,8 +15,9 @@ festival marketplace add <git-url> [flags]
 ### Options
 
 ```
-  -h, --help          help for add
-      --name string   override the derived source name
+      --allow-unverified   allow adding a marketplace with unsigned metadata without prompting
+  -h, --help               help for add
+      --name string        override the derived source name
 ```
 
 ### SEE ALSO

--- a/docs/cli-reference/festival/festival_marketplace_refresh.md
+++ b/docs/cli-reference/festival/festival_marketplace_refresh.md
@@ -15,8 +15,9 @@ festival marketplace refresh [name] [flags]
 ### Options
 
 ```
-  -h, --help   help for refresh
-      --json   emit JSON output
+      --allow-unverified   allow refreshing a marketplace with unsigned metadata without prompting
+  -h, --help               help for refresh
+      --json               emit JSON output
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Release: refresh bundled docs for fest v0.6.2, camp v0.5.0, and festival-installer v0.1.0.

Created by the release operator: main only accepts changes through pull requests, so the pin commit ships through this PR. After the squash merge, the operator tags v0.3.0 on main to trigger release CI.