### PR TITLE
packaging: rename Linux packages to obedience-festival; post-install message; never edit shell rc

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -109,7 +109,7 @@ archives:
 
 nfpms:
   - id: festival
-    package_name: festival
+    package_name: obedience-festival
     file_name_template: "{{ .ConventionalFileName }}"
     ids:
       - fest
@@ -132,6 +132,8 @@ nfpms:
     priority: optional
     conflicts:
       - festival
+    scripts:
+      postinstall: ./packaging/nfpm-postinstall.sh
     contents:
       - src: ./LICENSE
         dst: /usr/share/licenses/festival/LICENSE
@@ -298,8 +300,9 @@ homebrew_casks:
           ]
 
     caveats: |
-      Homebrew installs static fest, camp, and festival completions. To activate navigation helpers
-      (cgo, cr, csw, cint, fgo, fls) as well, add one line to your shell config:
+      Homebrew installs static fest, camp, and festival completions. This cask does not
+      edit your shell rc. To activate navigation helpers (cgo, cr, csw, cint, fgo, fls),
+      add one line to your shell config:
 
         # bash (~/.bashrc)
         source \"$(brew --prefix)/share/festival/shell/festival.bash\"
@@ -309,6 +312,10 @@ homebrew_casks:
 
         # fish (~/.config/fish/config.fish)
         source \"$(brew --prefix)/share/festival/shell/festival.fish\"
+
+      Do not run festival install (that plants a second copy under ~/.obey/installer).
+      Upgrade with: brew upgrade --cask festival
+
 
 release:
   github:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -185,6 +185,7 @@ aurs:
       - fest
       - camp
       - festival
+    install: ./packaging/festival.install
     package: |-
       install -Dm755 "./fest" "${pkgdir}/usr/bin/fest"
       install -Dm755 "./camp" "${pkgdir}/usr/bin/camp"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ brew install --cask Obedience-Corp/tap/festival
 yay -S festival-bin
 ```
 
-**Debian/Ubuntu:** Download `.deb` from [releases](https://github.com/Obedience-Corp/festival/releases/latest)
+**Debian/Ubuntu:** Download `obedience-festival_*.deb` from [releases](https://github.com/Obedience-Corp/festival/releases/latest)
 
 **Windows:** Stable Windows packages are temporarily paused while support is being hardened.
 For now, use WSL2 and the Linux install method above.
@@ -96,8 +96,14 @@ For now, use WSL2 and the Linux install method above.
 ```bash
 # Shell integration (add one setup path to ~/.zshrc)
 
+# Linux packages (AUR festival-bin, deb/rpm/apk obedience-festival)
+source /usr/share/festival/shell/festival.zsh
+
 # Preferred when installed with install.sh:
 source ~/.local/share/festival/shell/festival.zsh
+
+# Homebrew
+source "$(brew --prefix)/share/festival/shell/festival.zsh"
 
 # Or, if no helper file is installed:
 eval "$(camp shell-init zsh)"

--- a/docs/cli-reference/festival/festival_doctor.md
+++ b/docs/cli-reference/festival/festival_doctor.md
@@ -6,7 +6,10 @@ description: "Diagnose installer state (PATH, sources, receipts)"
 
 ## festival doctor
 
-Diagnose installer state (PATH, sources, receipts)
+Diagnose installer state (PATH, sources, receipts). On a coherent package
+install (AUR `festival-bin`, Homebrew, npm, or `obedience-festival`) doctor
+exits 0 when camp/fest/festival are on PATH; `no marketplaces registered` is a
+warn, not a failure. Doctor does not require `~/.obey/installer/bin` on PATH.
 
 ```
 festival doctor [flags]

--- a/docs/cli-reference/festival/festival_shell-init.md
+++ b/docs/cli-reference/festival/festival_shell-init.md
@@ -6,7 +6,9 @@ description: "Print shell code to put the installer-managed bin dir on PATH"
 
 ## festival shell-init
 
-Print shell code to put the installer-managed bin dir on PATH
+Print origin-aware shell code. Package installs print `source` of the packaged
+helper (not `export PATH=` for `~/.obey/installer/bin`). Hub-managed installs
+still prepend the managed bin dir.
 
 ```
 festival shell-init <zsh|bash|fish> [flags]

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -181,6 +181,39 @@ Source the packaged helper instead (see Shell Integration). Do not run
 `festival install` on top of a package install unless you pass `--force`; that
 plants a second copy under `~/.obey/installer`.
 
+## Migrate from leftover / source installs
+
+Leftover `camp` / `fest` copies (from `go install`, or an old `$HOME/local/bin`
+drop) can sit ahead of a package install on PATH. `festival uninstall` cannot
+remove those files: it only deletes receipt-owned files under the hub home
+(`~/.obey/installer`). Delete the leftover **files**, not the directory (other
+tools may live in `$HOME/local/bin`; keep that directory on PATH).
+
+```bash
+type -a camp
+whence -p camp    # zsh; bash: type -P camp
+# If the binary is not /usr/bin/camp or $(brew --prefix)/bin/camp:
+rm "$HOME/local/bin/camp" "$HOME/local/bin/fest"
+# Do not: rm -r ~/local/bin
+# Do not strip ~/local/bin from PATH (other tools may live there)
+```
+
+Then install with your package manager (`yay -S festival-bin` or
+`obedience-festival` for deb/rpm/apk) and run `festival doctor`.
+
+## Name clash with Edinburgh TTS
+
+Arch's official `festival` package is Edinburgh speech synthesis. It already
+owns `/usr/bin/festival`. Obedience Corp's AUR package is **`festival-bin`**.
+Deb/rpm/apk packages are named **`obedience-festival`**. Both still ship
+`/usr/bin/festival`, so they **conflict** with TTS. If you have an old GitHub
+`.deb` still named `festival`:
+
+```bash
+sudo dpkg -r festival
+sudo dpkg -i obedience-festival_*_amd64.deb
+```
+
 ## Upgrading
 
 How you upgrade depends on how you installed Festival.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -64,13 +64,13 @@ Download the `.deb` package from
 [GitHub Releases](https://github.com/Obedience-Corp/festival/releases/latest):
 
 ```bash
-sudo dpkg -i festival_*_amd64.deb
+sudo dpkg -i obedience-festival_*_amd64.deb
 ```
 
 ### Fedora / RHEL
 
 ```bash
-sudo rpm -i festival-*.x86_64.rpm
+sudo rpm -i obedience-festival-*.x86_64.rpm
 ```
 
 ### Arch Linux (AUR)
@@ -82,7 +82,7 @@ yay -S festival-bin
 ### Alpine
 
 ```bash
-sudo apk add --allow-untrusted festival_*.apk
+sudo apk add --allow-untrusted obedience-festival_*.apk
 ```
 
 ### Direct Download
@@ -169,6 +169,17 @@ line and report the suite version as the tool's version instead.
 
 Binaries built with `go install` have no `bundle:` line, since they were not
 built from a suite release.
+
+Then run `festival doctor`. On a coherent AUR (`festival-bin`), Homebrew, npm,
+or `obedience-festival` (deb/rpm/apk) install, doctor **exits 0**. Marketplace
+empty (`no marketplaces registered`) is a **warn**, not a failure. Browse if
+you want the official catalog; doctor does not require it.
+
+Package users should **not** run `eval "$(festival shell-init zsh)"`. That
+prepends an empty hub bin dir (`~/.obey/installer/bin`) ahead of the package.
+Source the packaged helper instead (see Shell Integration). Do not run
+`festival install` on top of a package install unless you pass `--force`; that
+plants a second copy under `~/.obey/installer`.
 
 ## Upgrading
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -44,8 +44,14 @@ A hosted workspace keeps your continuity in someone else's account and usually r
 ## 1. Set Up Shell Integration
 
 ```bash
+# Linux packages (AUR festival-bin, deb/rpm/apk obedience-festival)
+source /usr/share/festival/shell/festival.zsh
+
 # Add to ~/.zshrc when installed with install.sh
 source ~/.local/share/festival/shell/festival.zsh
+
+# Homebrew
+source "$(brew --prefix)/share/festival/shell/festival.zsh"
 
 # Or, if no helper file is installed:
 eval "$(camp shell-init zsh)"

--- a/docs/getting-started/shell-setup.md
+++ b/docs/getting-started/shell-setup.md
@@ -19,9 +19,12 @@ source ~/.local/share/festival/shell/festival.zsh
 # Homebrew
 source "$(brew --prefix)/share/festival/shell/festival.zsh"
 
-# Linux packages
+# Linux packages (AUR festival-bin, deb/rpm/apk obedience-festival)
 source /usr/share/festival/shell/festival.zsh
 ```
+
+Package installs do not need `eval "$(festival shell-init zsh)"`; that prepends
+an empty hub-managed bin dir. Source the helper file instead.
 
 For bash, use `festival.bash`. For fish, use `festival.fish`. There is no
 packaged helper file for POSIX sh; use the dynamic fallback below.

--- a/docs/install.md
+++ b/docs/install.md
@@ -61,10 +61,10 @@ Choose your distribution's package format:
 
 | Distribution | Command |
 |-------------|---------|
-| Debian / Ubuntu | `sudo dpkg -i festival_*_amd64.deb` |
-| Fedora / RHEL | `sudo rpm -i festival-*.x86_64.rpm` |
+| Debian / Ubuntu | `sudo dpkg -i obedience-festival_*_amd64.deb` |
+| Fedora / RHEL | `sudo rpm -i obedience-festival-*.x86_64.rpm` |
 | Arch Linux | `yay -S festival-bin` |
-| Alpine | `sudo apk add --allow-untrusted festival_*.apk` |
+| Alpine | `sudo apk add --allow-untrusted obedience-festival_*.apk` |
 
 <a href="https://github.com/Obedience-Corp/festival/releases/latest" class="btn btn--primary">Download Linux Packages</a>
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -45,13 +45,15 @@ platform, verifies it against the release `checksums.txt`, exposes `fest`,
 shell-helper assets under `share/festival/` inside the installed npm
 package.
 
-The npm installer does not edit shell startup files. Add shell integration
-manually with:
+The npm installer does not edit shell startup files. Source the packaged helper
+(not `camp shell-init` / `fest shell-init`):
 
 ```bash
-eval "$(camp shell-init zsh)"
-eval "$(fest shell-init zsh)"
+source "$(npm root -g)/@obedience-corp/festival/share/festival/shell/festival.zsh"
 ```
+
+Do not run `festival install` (that plants a second copy under `~/.obey/installer`).
+Upgrade with: `npm install -g @obedience-corp/festival@latest`
 
 ## Maintainer Notes
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -46,7 +46,9 @@ shell-helper assets under `share/festival/` inside the installed npm
 package.
 
 The npm installer does not edit shell startup files. Source the packaged helper
-(not `camp shell-init` / `fest shell-init`):
+(not `camp shell-init` / `fest shell-init`). Helpers live under
+`share/festival/shell` inside the installed package. Walk up from the binary
+or use `npm root -g`:
 
 ```bash
 source "$(npm root -g)/@obedience-corp/festival/share/festival/shell/festival.zsh"

--- a/packaging/festival.install
+++ b/packaging/festival.install
@@ -1,0 +1,15 @@
+# pacman install script for festival-bin.
+# Echo-only: this package does not edit ~/.zshrc or any other rc file.
+
+post_install() {
+	echo "festival-bin is not the Edinburgh TTS package named festival."
+	echo "This package does not edit ~/.zshrc. Add the helper yourself:"
+	echo "  source /usr/share/festival/shell/festival.zsh"
+	echo "Upgrade:"
+	echo "  yay -Syu festival-bin"
+	echo "Do not run festival install (that plants a second copy under ~/.obey/installer)."
+}
+
+post_upgrade() {
+	post_install
+}

--- a/packaging/nfpm-postinstall.sh
+++ b/packaging/nfpm-postinstall.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Post-install for obedience-festival (deb/rpm/apk). Echo-only: does not edit rc.
+echo "Package: obedience-festival (binaries stay festival, camp, and fest)."
+echo "This package is not the Edinburgh TTS package named festival; both ship /usr/bin/festival."
+echo "This package does not edit your shell rc. Add the helper yourself:"
+echo "  source /usr/share/festival/shell/festival.zsh"
+echo "Upgrade: reinstall the latest obedience-festival_*.deb (or .rpm / .apk) from GitHub Releases."
+echo "Do not run festival install (that plants a second copy under ~/.obey/installer)."
+echo "If you still have an older GitHub .deb named festival: sudo dpkg -r festival"
+echo "then install obedience-festival."


### PR DESCRIPTION
FI0001 PR 6 (distribution). Independent of the installer stack except that docs PR #161 stacks on this.

## Why
AUR `festival-bin` has no post-install message (Install Script: No). NFPM `package_name: festival` collides with Edinburgh TTS and is a self-conflict.

## Changes
- AUR **stays `festival-bin`**. `aurs.install: ./packaging/festival.install` echoes helper, `yay -Syu festival-bin`, TTS clash, do not `festival install`, does not edit rc.
- NFPM `package_name: obedience-festival`. Binaries stay `festival`/`camp`/`fest` in `/usr/bin`. Keep `conflicts: [festival]`. No `provides: festival`.
- `packaging/nfpm-postinstall.sh` is echo-only.
- Homebrew caveats: do not `festival install`.
- npm README: packaged helper, not `camp shell-init`.

## Notes
Ships on the next suite release. Old GitHub `.deb` named `festival`: `sudo dpkg -r festival` then install `obedience-festival`.

Follow-up: #161 docs.