### PR TITLE
docs: doctor is green on package installs; Linux helper on the quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ brew install --cask Obedience-Corp/tap/festival
 yay -S festival-bin
 ```
 
-**Debian/Ubuntu:** Download `.deb` from [releases](https://github.com/Obedience-Corp/festival/releases/latest)
+**Debian/Ubuntu:** Download `obedience-festival_*.deb` from [releases](https://github.com/Obedience-Corp/festival/releases/latest)
 
 **Windows:** Stable Windows packages are temporarily paused while support is being hardened.
 For now, use WSL2 and the Linux install method above.
@@ -96,8 +96,14 @@ For now, use WSL2 and the Linux install method above.
 ```bash
 # Shell integration (add one setup path to ~/.zshrc)
 
+# Linux packages (AUR festival-bin, deb/rpm/apk obedience-festival)
+source /usr/share/festival/shell/festival.zsh
+
 # Preferred when installed with install.sh:
 source ~/.local/share/festival/shell/festival.zsh
+
+# Homebrew
+source "$(brew --prefix)/share/festival/shell/festival.zsh"
 
 # Or, if no helper file is installed:
 eval "$(camp shell-init zsh)"

--- a/docs/cli-reference/festival/festival_doctor.md
+++ b/docs/cli-reference/festival/festival_doctor.md
@@ -6,7 +6,10 @@ description: "Diagnose installer state (PATH, sources, receipts)"
 
 ## festival doctor
 
-Diagnose installer state (PATH, sources, receipts)
+Diagnose installer state (PATH, sources, receipts). On a coherent package
+install (AUR `festival-bin`, Homebrew, npm, or `obedience-festival`) doctor
+exits 0 when camp/fest/festival are on PATH; `no marketplaces registered` is a
+warn, not a failure. Doctor does not require `~/.obey/installer/bin` on PATH.
 
 ```
 festival doctor [flags]

--- a/docs/cli-reference/festival/festival_shell-init.md
+++ b/docs/cli-reference/festival/festival_shell-init.md
@@ -6,7 +6,9 @@ description: "Print shell code to put the installer-managed bin dir on PATH"
 
 ## festival shell-init
 
-Print shell code to put the installer-managed bin dir on PATH
+Print origin-aware shell code. Package installs print `source` of the packaged
+helper (not `export PATH=` for `~/.obey/installer/bin`). Hub-managed installs
+still prepend the managed bin dir.
 
 ```
 festival shell-init <zsh|bash|fish> [flags]

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -181,6 +181,39 @@ Source the packaged helper instead (see Shell Integration). Do not run
 `festival install` on top of a package install unless you pass `--force`; that
 plants a second copy under `~/.obey/installer`.
 
+## Migrate from leftover / source installs
+
+Leftover `camp` / `fest` copies (from `go install`, or an old `$HOME/local/bin`
+drop) can sit ahead of a package install on PATH. `festival uninstall` cannot
+remove those files: it only deletes receipt-owned files under the hub home
+(`~/.obey/installer`). Delete the leftover **files**, not the directory (other
+tools may live in `$HOME/local/bin`; keep that directory on PATH).
+
+```bash
+type -a camp
+whence -p camp    # zsh; bash: type -P camp
+# If the binary is not /usr/bin/camp or $(brew --prefix)/bin/camp:
+rm "$HOME/local/bin/camp" "$HOME/local/bin/fest"
+# Do not: rm -r ~/local/bin
+# Do not strip ~/local/bin from PATH (other tools may live there)
+```
+
+Then install with your package manager (`yay -S festival-bin` or
+`obedience-festival` for deb/rpm/apk) and run `festival doctor`.
+
+## Name clash with Edinburgh TTS
+
+Arch's official `festival` package is Edinburgh speech synthesis. It already
+owns `/usr/bin/festival`. Obedience Corp's AUR package is **`festival-bin`**.
+Deb/rpm/apk packages are named **`obedience-festival`**. Both still ship
+`/usr/bin/festival`, so they **conflict** with TTS. If you have an old GitHub
+`.deb` still named `festival`:
+
+```bash
+sudo dpkg -r festival
+sudo dpkg -i obedience-festival_*_amd64.deb
+```
+
 ## Upgrading
 
 How you upgrade depends on how you installed Festival.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -64,13 +64,13 @@ Download the `.deb` package from
 [GitHub Releases](https://github.com/Obedience-Corp/festival/releases/latest):
 
 ```bash
-sudo dpkg -i festival_*_amd64.deb
+sudo dpkg -i obedience-festival_*_amd64.deb
 ```
 
 ### Fedora / RHEL
 
 ```bash
-sudo rpm -i festival-*.x86_64.rpm
+sudo rpm -i obedience-festival-*.x86_64.rpm
 ```
 
 ### Arch Linux (AUR)
@@ -82,7 +82,7 @@ yay -S festival-bin
 ### Alpine
 
 ```bash
-sudo apk add --allow-untrusted festival_*.apk
+sudo apk add --allow-untrusted obedience-festival_*.apk
 ```
 
 ### Direct Download
@@ -169,6 +169,17 @@ line and report the suite version as the tool's version instead.
 
 Binaries built with `go install` have no `bundle:` line, since they were not
 built from a suite release.
+
+Then run `festival doctor`. On a coherent AUR (`festival-bin`), Homebrew, npm,
+or `obedience-festival` (deb/rpm/apk) install, doctor **exits 0**. Marketplace
+empty (`no marketplaces registered`) is a **warn**, not a failure. Browse if
+you want the official catalog; doctor does not require it.
+
+Package users should **not** run `eval "$(festival shell-init zsh)"`. That
+prepends an empty hub bin dir (`~/.obey/installer/bin`) ahead of the package.
+Source the packaged helper instead (see Shell Integration). Do not run
+`festival install` on top of a package install unless you pass `--force`; that
+plants a second copy under `~/.obey/installer`.
 
 ## Upgrading
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -44,8 +44,14 @@ A hosted workspace keeps your continuity in someone else's account and usually r
 ## 1. Set Up Shell Integration
 
 ```bash
+# Linux packages (AUR festival-bin, deb/rpm/apk obedience-festival)
+source /usr/share/festival/shell/festival.zsh
+
 # Add to ~/.zshrc when installed with install.sh
 source ~/.local/share/festival/shell/festival.zsh
+
+# Homebrew
+source "$(brew --prefix)/share/festival/shell/festival.zsh"
 
 # Or, if no helper file is installed:
 eval "$(camp shell-init zsh)"

--- a/docs/getting-started/shell-setup.md
+++ b/docs/getting-started/shell-setup.md
@@ -19,9 +19,12 @@ source ~/.local/share/festival/shell/festival.zsh
 # Homebrew
 source "$(brew --prefix)/share/festival/shell/festival.zsh"
 
-# Linux packages
+# Linux packages (AUR festival-bin, deb/rpm/apk obedience-festival)
 source /usr/share/festival/shell/festival.zsh
 ```
+
+Package installs do not need `eval "$(festival shell-init zsh)"`; that prepends
+an empty hub-managed bin dir. Source the helper file instead.
 
 For bash, use `festival.bash`. For fish, use `festival.fish`. There is no
 packaged helper file for POSIX sh; use the dynamic fallback below.

--- a/docs/install.md
+++ b/docs/install.md
@@ -61,10 +61,10 @@ Choose your distribution's package format:
 
 | Distribution | Command |
 |-------------|---------|
-| Debian / Ubuntu | `sudo dpkg -i festival_*_amd64.deb` |
-| Fedora / RHEL | `sudo rpm -i festival-*.x86_64.rpm` |
+| Debian / Ubuntu | `sudo dpkg -i obedience-festival_*_amd64.deb` |
+| Fedora / RHEL | `sudo rpm -i obedience-festival-*.x86_64.rpm` |
 | Arch Linux | `yay -S festival-bin` |
-| Alpine | `sudo apk add --allow-untrusted festival_*.apk` |
+| Alpine | `sudo apk add --allow-untrusted obedience-festival_*.apk` |
 
 <a href="https://github.com/Obedience-Corp/festival/releases/latest" class="btn btn--primary">Download Linux Packages</a>
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -46,7 +46,9 @@ shell-helper assets under `share/festival/` inside the installed npm
 package.
 
 The npm installer does not edit shell startup files. Source the packaged helper
-(not `camp shell-init` / `fest shell-init`):
+(not `camp shell-init` / `fest shell-init`). Helpers live under
+`share/festival/shell` inside the installed package. Walk up from the binary
+or use `npm root -g`:
 
 ```bash
 source "$(npm root -g)/@obedience-corp/festival/share/festival/shell/festival.zsh"


### PR DESCRIPTION
FI0001 PR 7 (docs). **Stacked on #160.**

## Why
Docs advertised `festival doctor` as verify, but a working AUR install failed doctor. Quickstart only showed the install.sh helper.

## Changes
- Verify: doctor **exits 0** on AUR/Homebrew/npm/`obedience-festival`. Marketplace empty is a warn. Do not tell package users to `eval "$(festival shell-init zsh)"`.
- Arch stays `yay -S festival-bin`. Deb/rpm/apk filenames are `obedience-festival_*`.
- Quickstart Step 1 includes `source /usr/share/festival/shell/festival.zsh` first.
- **Migrate from leftover / source installs**: delete leftover **files** in `$HOME/local/bin`, not the directory; `festival uninstall` cannot remove them.
- Edinburgh TTS name clash documented. Old `.deb` named `festival`: `sudo dpkg -r festival` then install `obedience-festival`.

## Merge order
After #160 so package names in docs match the goreleaser rename.