### PR TITLE
Fix release auth with multiple GitHub profiles

### DIFF
--- a/tools/release-operator/commands.go
+++ b/tools/release-operator/commands.go
@@ -1287,7 +1287,12 @@ func ghSecretNames(dir string) ([]string, error) {
 }
 
 func ghAuthenticated() bool {
-	cmd := exec.Command("gh", "auth", "status")
+	// `gh auth status` reports every stored account and exits non-zero when
+	// any inactive profile has an expired token. That is not the question the
+	// release operator needs answered, and it breaks valid per-command
+	// GH_TOKEN injection on multi-account machines. Query the authenticated
+	// viewer instead so success reflects the credentials gh will actually use.
+	cmd := exec.Command("gh", "api", "user", "--jq", ".login")
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
 	return cmd.Run() == nil

--- a/tools/release-operator/commands_test.go
+++ b/tools/release-operator/commands_test.go
@@ -67,6 +67,25 @@ func TestShipsViaPullRequest(t *testing.T) {
 	}
 }
 
+func TestGHAuthenticatedChecksTheActiveAPIViewer(t *testing.T) {
+	binDir := t.TempDir()
+	gh := filepath.Join(binDir, "gh")
+	script := `#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$3" = "--jq" ] && [ "$4" = ".login" ]; then
+  exit 0
+fi
+exit 42
+`
+	if err := os.WriteFile(gh, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if !ghAuthenticated() {
+		t.Fatal("expected authenticated viewer API probe to succeed")
+	}
+}
+
 // tagMap builds a component-keyed tag map for fest and camp, the two
 // components these tests care about; festival-installer is intentionally
 // absent, since a missing key on both sides of a current/selected pair


### PR DESCRIPTION
## Summary

- probe the authenticated GitHub API viewer instead of aggregating every stored gh profile
- allow valid per-command GH_TOKEN injection even when an inactive stored account has expired credentials
- add a regression test that requires the exact gh api user probe

## Why

The stable release operator incorrectly reported “gh is not authenticated” because gh auth status exits nonzero if any stored profile is invalid. The injected personal token was valid and gh api user succeeded.

## Verification

- just test release-operator
- containerized go test ./... for tools/release-operator
- reproduced valid GH_TOKEN plus invalid inactive profile behavior locally