### PR TITLE
Fix marketplace release validator module path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -305,6 +305,13 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
+      # Recovery checks out the immutable release tag, which may contain the
+      # bug being recovered from. Build the validator explicitly and inject
+      # the script's supported override so post-publish does not depend on the
+      # tag's fallback `go run` invocation.
+      - name: Build marketplace metadata validator
+        run: go -C festival-installer build -o "${RUNNER_TEMP}/festival-metadata" ./cmd/festival-metadata
+
       - name: Require published GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -369,4 +376,5 @@ jobs:
           GH_TOKEN: ${{ secrets.MARKETPLACE_PUBLISH_TOKEN }}
           FESTIVAL_TAG: v${{ inputs.version }}
           RELEASE_CHANNEL: ${{ inputs.release_mode }}
+          FESTIVAL_METADATA_BIN: ${{ runner.temp }}/festival-metadata
         run: scripts/publish_marketplace_entry.sh

--- a/scripts/publish_marketplace_entry.sh
+++ b/scripts/publish_marketplace_entry.sh
@@ -16,7 +16,7 @@ fi
 if [ -n "${FESTIVAL_METADATA_BIN:-}" ]; then
   "${FESTIVAL_METADATA_BIN}" validate --kind manifest dist/marketplace/obey-package.json
 else
-  go run ./festival-installer/cmd/festival-metadata validate --kind manifest dist/marketplace/obey-package.json
+  go -C festival-installer run ./cmd/festival-metadata validate --kind manifest ../dist/marketplace/obey-package.json
 fi
 
 # gh authenticates from GH_TOKEN. Reuse the marketplace publish token so the

--- a/scripts/test_marketplace_publish.sh
+++ b/scripts/test_marketplace_publish.sh
@@ -20,8 +20,9 @@ set -euo pipefail
 #     (see results/ for sequence 02, task 01).
 #
 # Schema coverage: the generated obey-package.json is checked with the real
-# festival-metadata validate command (FESTIVAL_METADATA_BIN). Case "schema
-# invalid" asserts an empty published_at fails the release and pushes nothing.
+# festival-metadata validate command. Case "schema invalid" deliberately
+# leaves FESTIVAL_METADATA_BIN unset so it exercises the exact module-aware
+# fallback used by release CI. The remaining cases inject the built binary.
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 work="$(mktemp -d)"
@@ -40,6 +41,7 @@ mkdir -p "${staged_repo}/scripts" "${staged_repo}/dist/marketplace"
 cp "${repo_root}/scripts/publish_marketplace_entry.sh" "${staged_repo}/scripts/publish_marketplace_entry.sh"
 cp "${repo_root}/scripts/upsert_marketplace_index.py" "${staged_repo}/scripts/upsert_marketplace_index.py"
 chmod +x "${staged_repo}/scripts/publish_marketplace_entry.sh"
+cp -R "${repo_root}/festival-installer" "${staged_repo}/festival-installer"
 
 new_release_manifest() {
   # The v9.9.9 entry this test publishes. Distinct from the fixture's seeded
@@ -158,6 +160,11 @@ run_script() {
     bash "${repo_root}/scripts/publish_marketplace_entry.sh")
 }
 
+run_script_with_module_validator() {
+  (cd "${staged_repo}" && env -u MARKETPLACE_PUBLISH_TOKEN -u FESTIVAL_METADATA_BIN \
+    bash "${repo_root}/scripts/publish_marketplace_entry.sh")
+}
+
 # --- Case 0: ERROR, generated entry fails hub schema ---------------------
 # Empty published_at is the v0.2.17 defect: release-operator used to emit it
 # and the failure only showed up at install time.
@@ -170,7 +177,7 @@ p.write_text(json.dumps(doc, indent=2) + "\n")
 PY
 make_fixture "${work}/bare-schema-bad.git"
 out="$(FIXTURE_VERIFY_EXIT=0 MARKETPLACE_REPO_URL="${work}/bare-schema-bad.git" \
-  FESTIVAL_TAG=v9.9.9 RELEASE_CHANNEL=stable run_script 2>&1 || true)"
+  FESTIVAL_TAG=v9.9.9 RELEASE_CHANNEL=stable run_script_with_module_validator 2>&1 || true)"
 grep -q "published_at" <<<"${out}" || fail "missing published_at schema error: ${out}"
 [ -z "$(git --git-dir="${work}/bare-schema-bad.git" branch --list 'release/*')" ] \
   || fail "a branch was pushed despite the schema refusal"


### PR DESCRIPTION
## Summary

- run festival-metadata from the festival-installer module with go -C
- resolve the generated manifest relative to that module working directory
- exercise the exact non-injected release fallback in the marketplace publish fixture
- make post-publish recovery build and inject a validator binary from the immutable release checkout

## Failure fixed

Festival v0.3.2 published its GitHub release and npm package, then failed Publish marketplace entry with: go: cannot find main module. The superproject intentionally has no root go.mod.

The recovery workflow checks out immutable v0.3.2 source, so it explicitly injects the tagged script’s already-supported FESTIVAL_METADATA_BIN override. No tag rewrite is required.

## Verification

- just test marketplace-publish
- containerized scripts/test_marketplace_publish.sh
- schema-invalid regression reaches festival-metadata and refuses before pushing
- happy-path fixture publishes only a release branch and leaves marketplace main untouched
- actionlint parses the workflow; it reports only pre-existing SC2155 at release.yaml:139

After merge, run the v0.3.2 post-publish recovery workflow.