### PR TITLE
Release: pin fest v0.6.6 and festival-installer v0.1.3

### DIFF
--- a/docs/cli-reference/camp/camp_fresh.md
+++ b/docs/cli-reference/camp/camp_fresh.md
@@ -60,6 +60,18 @@ Examples:
   camp fresh --no-follow-up             # Sync without running configured follow-ups
   camp fresh --dry-run                  # Preview what would happen (follow-ups listed, not run)
 
+  camp fresh --branch feat/aggregate-CW0003 --cleanup-stack
+                                        # Switch to an existing aggregate branch and
+                                        # remove child worktrees merged into it
+                                        # (ancestry or squash/patch-id). Refuses
+                                        # main/master unless --allow-default-target.
+                                        # Worktrees whose branches also landed on
+                                        # the default branch are skipped (not stack
+                                        # children). The default-branch prune still
+                                        # runs first; pass --no-prune to skip it.
+  camp fresh --branch feat/aggregate-CW0003 --cleanup-stack --dry-run
+                                        # Preview the stack cleanup plan without removing anything
+
 ```
 camp fresh [project-name] [flags]
 ```
@@ -67,16 +79,18 @@ camp fresh [project-name] [flags]
 ### Options
 
 ```
-  -b, --branch string    Branch to create after syncing (overrides config)
-  -n, --dry-run          Preview without making changes
-  -h, --help             help for fresh
-      --list strings     Comma-separated set of projects to cycle in one run
-      --no-branch        Skip branch creation even if configured
-      --no-drain         Do not wait for camp's queued commits first
-      --no-follow-up     Skip configured follow-up command workflows
-      --no-prune         Skip pruning merged branches
-      --no-push          Skip pushing the new branch upstream
-  -p, --project string   Project name (auto-detected from cwd)
+      --allow-default-target   Permit --cleanup-stack against the default branch (main/master). Without this, cleanup-stack refuses default-branch targets because every merged feature worktree would look like a stack child
+  -b, --branch string          Branch to create after syncing (overrides config)
+      --cleanup-stack          Target an existing aggregate branch and remove child worktrees merged into it by ancestry or squash (requires --branch; refuses the default branch unless --allow-default-target)
+  -n, --dry-run                Preview without making changes
+  -h, --help                   help for fresh
+      --list strings           Comma-separated set of projects to cycle in one run
+      --no-branch              Skip branch creation even if configured
+      --no-drain               Do not wait for camp's queued commits first
+      --no-follow-up           Skip configured follow-up command workflows
+      --no-prune               Skip pruning merged branches
+      --no-push                Skip pushing the new branch upstream
+  -p, --project string         Project name (auto-detected from cwd)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp/camp_fresh_all.md
+++ b/docs/cli-reference/camp/camp_fresh_all.md
@@ -33,13 +33,15 @@ camp fresh all [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --branch string   Branch to create after syncing (overrides config)
-  -n, --dry-run         Preview without making changes
-      --no-branch       Skip branch creation even if configured
-      --no-color        disable colored output
-      --no-follow-up    Skip configured follow-up command workflows
-      --no-prune        Skip pruning merged branches
-      --no-push         Skip pushing the new branch upstream
+      --allow-default-target   Permit --cleanup-stack against the default branch (main/master). Without this, cleanup-stack refuses default-branch targets because every merged feature worktree would look like a stack child
+  -b, --branch string          Branch to create after syncing (overrides config)
+      --cleanup-stack          Target an existing aggregate branch and remove child worktrees merged into it by ancestry or squash (requires --branch; refuses the default branch unless --allow-default-target)
+  -n, --dry-run                Preview without making changes
+      --no-branch              Skip branch creation even if configured
+      --no-color               disable colored output
+      --no-follow-up           Skip configured follow-up command workflows
+      --no-prune               Skip pruning merged branches
+      --no-push                Skip pushing the new branch upstream
 ```
 
 ### SEE ALSO

--- a/docs/cli-reference/camp/camp_fresh_configure.md
+++ b/docs/cli-reference/camp/camp_fresh_configure.md
@@ -58,13 +58,15 @@ camp fresh configure [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --branch string   Branch to create after syncing (overrides config)
-  -n, --dry-run         Preview without making changes
-      --no-branch       Skip branch creation even if configured
-      --no-color        disable colored output
-      --no-follow-up    Skip configured follow-up command workflows
-      --no-prune        Skip pruning merged branches
-      --no-push         Skip pushing the new branch upstream
+      --allow-default-target   Permit --cleanup-stack against the default branch (main/master). Without this, cleanup-stack refuses default-branch targets because every merged feature worktree would look like a stack child
+  -b, --branch string          Branch to create after syncing (overrides config)
+      --cleanup-stack          Target an existing aggregate branch and remove child worktrees merged into it by ancestry or squash (requires --branch; refuses the default branch unless --allow-default-target)
+  -n, --dry-run                Preview without making changes
+      --no-branch              Skip branch creation even if configured
+      --no-color               disable colored output
+      --no-follow-up           Skip configured follow-up command workflows
+      --no-prune               Skip pruning merged branches
+      --no-push                Skip pushing the new branch upstream
 ```
 
 ### SEE ALSO

--- a/docs/cli-reference/camp/camp_fresh_configure_add.md
+++ b/docs/cli-reference/camp/camp_fresh_configure_add.md
@@ -25,13 +25,15 @@ camp fresh configure add <name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --branch string   Branch to create after syncing (overrides config)
-  -n, --dry-run         Preview without making changes
-      --no-branch       Skip branch creation even if configured
-      --no-color        disable colored output
-      --no-follow-up    Skip configured follow-up command workflows
-      --no-prune        Skip pruning merged branches
-      --no-push         Skip pushing the new branch upstream
+      --allow-default-target   Permit --cleanup-stack against the default branch (main/master). Without this, cleanup-stack refuses default-branch targets because every merged feature worktree would look like a stack child
+  -b, --branch string          Branch to create after syncing (overrides config)
+      --cleanup-stack          Target an existing aggregate branch and remove child worktrees merged into it by ancestry or squash (requires --branch; refuses the default branch unless --allow-default-target)
+  -n, --dry-run                Preview without making changes
+      --no-branch              Skip branch creation even if configured
+      --no-color               disable colored output
+      --no-follow-up           Skip configured follow-up command workflows
+      --no-prune               Skip pruning merged branches
+      --no-push                Skip pushing the new branch upstream
 ```
 
 ### SEE ALSO

--- a/docs/cli-reference/camp/camp_fresh_configure_move.md
+++ b/docs/cli-reference/camp/camp_fresh_configure_move.md
@@ -24,13 +24,15 @@ camp fresh configure move <name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --branch string   Branch to create after syncing (overrides config)
-  -n, --dry-run         Preview without making changes
-      --no-branch       Skip branch creation even if configured
-      --no-color        disable colored output
-      --no-follow-up    Skip configured follow-up command workflows
-      --no-prune        Skip pruning merged branches
-      --no-push         Skip pushing the new branch upstream
+      --allow-default-target   Permit --cleanup-stack against the default branch (main/master). Without this, cleanup-stack refuses default-branch targets because every merged feature worktree would look like a stack child
+  -b, --branch string          Branch to create after syncing (overrides config)
+      --cleanup-stack          Target an existing aggregate branch and remove child worktrees merged into it by ancestry or squash (requires --branch; refuses the default branch unless --allow-default-target)
+  -n, --dry-run                Preview without making changes
+      --no-branch              Skip branch creation even if configured
+      --no-color               disable colored output
+      --no-follow-up           Skip configured follow-up command workflows
+      --no-prune               Skip pruning merged branches
+      --no-push                Skip pushing the new branch upstream
 ```
 
 ### SEE ALSO

--- a/docs/cli-reference/camp/camp_fresh_configure_remove.md
+++ b/docs/cli-reference/camp/camp_fresh_configure_remove.md
@@ -22,13 +22,15 @@ camp fresh configure remove <name> [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --branch string   Branch to create after syncing (overrides config)
-  -n, --dry-run         Preview without making changes
-      --no-branch       Skip branch creation even if configured
-      --no-color        disable colored output
-      --no-follow-up    Skip configured follow-up command workflows
-      --no-prune        Skip pruning merged branches
-      --no-push         Skip pushing the new branch upstream
+      --allow-default-target   Permit --cleanup-stack against the default branch (main/master). Without this, cleanup-stack refuses default-branch targets because every merged feature worktree would look like a stack child
+  -b, --branch string          Branch to create after syncing (overrides config)
+      --cleanup-stack          Target an existing aggregate branch and remove child worktrees merged into it by ancestry or squash (requires --branch; refuses the default branch unless --allow-default-target)
+  -n, --dry-run                Preview without making changes
+      --no-branch              Skip branch creation even if configured
+      --no-color               disable colored output
+      --no-follow-up           Skip configured follow-up command workflows
+      --no-prune               Skip pruning merged branches
+      --no-push                Skip pushing the new branch upstream
 ```
 
 ### SEE ALSO

--- a/docs/cli-reference/camp/camp_fresh_configure_show.md
+++ b/docs/cli-reference/camp/camp_fresh_configure_show.md
@@ -21,13 +21,15 @@ camp fresh configure show [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --branch string   Branch to create after syncing (overrides config)
-  -n, --dry-run         Preview without making changes
-      --no-branch       Skip branch creation even if configured
-      --no-color        disable colored output
-      --no-follow-up    Skip configured follow-up command workflows
-      --no-prune        Skip pruning merged branches
-      --no-push         Skip pushing the new branch upstream
+      --allow-default-target   Permit --cleanup-stack against the default branch (main/master). Without this, cleanup-stack refuses default-branch targets because every merged feature worktree would look like a stack child
+  -b, --branch string          Branch to create after syncing (overrides config)
+      --cleanup-stack          Target an existing aggregate branch and remove child worktrees merged into it by ancestry or squash (requires --branch; refuses the default branch unless --allow-default-target)
+  -n, --dry-run                Preview without making changes
+      --no-branch              Skip branch creation even if configured
+      --no-color               disable colored output
+      --no-follow-up           Skip configured follow-up command workflows
+      --no-prune               Skip pruning merged branches
+      --no-push                Skip pushing the new branch upstream
 ```
 
 ### SEE ALSO

--- a/docs/cli-reference/camp/camp_fresh_show-workflow.md
+++ b/docs/cli-reference/camp/camp_fresh_show-workflow.md
@@ -29,13 +29,15 @@ camp fresh show-workflow [project-name] [flags]
 ### Options inherited from parent commands
 
 ```
-  -b, --branch string   Branch to create after syncing (overrides config)
-  -n, --dry-run         Preview without making changes
-      --no-branch       Skip branch creation even if configured
-      --no-color        disable colored output
-      --no-follow-up    Skip configured follow-up command workflows
-      --no-prune        Skip pruning merged branches
-      --no-push         Skip pushing the new branch upstream
+      --allow-default-target   Permit --cleanup-stack against the default branch (main/master). Without this, cleanup-stack refuses default-branch targets because every merged feature worktree would look like a stack child
+  -b, --branch string          Branch to create after syncing (overrides config)
+      --cleanup-stack          Target an existing aggregate branch and remove child worktrees merged into it by ancestry or squash (requires --branch; refuses the default branch unless --allow-default-target)
+  -n, --dry-run                Preview without making changes
+      --no-branch              Skip branch creation even if configured
+      --no-color               disable colored output
+      --no-follow-up           Skip configured follow-up command workflows
+      --no-prune               Skip pruning merged branches
+      --no-push                Skip pushing the new branch upstream
 ```
 
 ### SEE ALSO

--- a/docs/cli-reference/camp/camp_gather_design.md
+++ b/docs/cli-reference/camp/camp_gather_design.md
@@ -23,7 +23,8 @@ The gather process:
      the rename)
   3. Stamp gathered_into/gathered_at on each source .workitem
   4. Migrate manual priority state and re-home workitem links
-  5. Commit the move (unless --no-commit)
+  5. Rewrite campaign markdown and quest links that pointed at the sources
+  6. Commit the move (unless --no-commit)
 
 Moved sources stop appearing as separate workitems because discovery only
 scans the top level of workflow/design/.

--- a/docs/cli-reference/camp/camp_gather_explore.md
+++ b/docs/cli-reference/camp/camp_gather_explore.md
@@ -23,7 +23,8 @@ The gather process:
      the rename)
   3. Stamp gathered_into/gathered_at on each source .workitem
   4. Migrate manual priority state and re-home workitem links
-  5. Commit the move (unless --no-commit)
+  5. Rewrite campaign markdown and quest links that pointed at the sources
+  6. Commit the move (unless --no-commit)
 
 Moved sources stop appearing as separate workitems because discovery only
 scans the top level of workflow/explore/.

--- a/docs/cli-reference/camp/camp_machine.md
+++ b/docs/cli-reference/camp/camp_machine.md
@@ -84,4 +84,5 @@ camp machine [flags]
 * [camp machine adopt](../camp_machine_adopt/)	 - Register the machine this session was hopped from
 * [camp machine diagnose](../camp_machine_diagnose/)	 - Inspect machine auth, probe line, and ssh ControlMaster sockets
 * [camp machine list](../camp_machine_list/)	 - List configured machines
+* [camp machine pair](../camp_machine_pair/)	 - Exchange ssh keys with a machine so hops work both ways
 * [camp machine remove](../camp_machine_remove/)	 - Remove a machine

--- a/docs/cli-reference/camp/camp_machine_pair.md
+++ b/docs/cli-reference/camp/camp_machine_pair.md
@@ -1,0 +1,53 @@
+---
+title: "camp machine pair"
+linkTitle: "camp machine pair"
+description: "Exchange ssh keys with a machine so hops work both ways"
+---
+
+## camp machine pair
+
+Exchange ssh keys with a machine so hops work both ways
+
+### Synopsis
+
+Exchange ssh keys with a registered machine so hops work in both directions,
+after showing you exactly what will be written on each side.
+
+Run this from the machine that can ALREADY reach the other one. One working
+direction is enough to pair both: camp installs this machine's key over there,
+reads that machine's key back, and installs it here. That is what makes a GUI
+macOS peer reachable afterwards, since it cannot serve Tailscale SSH at all.
+
+Camp creates dedicated ed25519 keys under ~/.obey/keys, one per direction of
+one pair, so a pairing can be revoked on its own. It never touches ~/.ssh/id_*,
+and it never enables a login service: if the reverse direction needs sshd or
+macOS Remote Login turned on, camp tells you and stops.
+
+Pairing is an explicit, interactive act. There is no flag that skips the
+confirmation, and it cannot run without a terminal.
+
+```
+camp machine pair <machine> [flags]
+```
+
+### Examples
+
+```
+  camp machine pair mac-studio    # from the machine that can already reach it
+```
+
+### Options
+
+```
+  -h, --help   help for pair
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp machine](../camp_machine/)	 - Manage remote machines (~/.obey/machines.yaml)

--- a/docs/cli-reference/camp/camp_project_commit.md
+++ b/docs/cli-reference/camp/camp_project_commit.md
@@ -15,9 +15,12 @@ Commit changes within a project submodule.
 Auto-detects the current project from your working directory,
 or use --project to specify a project by name.
 
-Commit tags use explicit --workitem or context from the current path. They do
-not inherit the per-machine current workitem selection, which can be stale;
-use --workitem or a primary workitem link for WI- tag scoping.
+Commit tags are traceability-aware: when the current project or cwd resolves
+to an active festival or workitem (via path links, ancestor .workitem
+markers, or festival-scoped links), the commit message carries the same
+FE-<ref> / WI-<ref> tracking components that `fest commit` would
+include. Use --workitem to override cwd-based resolution. When no
+festival/workitem context resolves, the tag is the bare campaign tag.
 
 Examples:
   # From within a project directory

--- a/docs/cli-reference/camp/camp_project_worktree_add.md
+++ b/docs/cli-reference/camp/camp_project_worktree_add.md
@@ -20,6 +20,10 @@ The worktree will be created at: projects/worktrees/<project>/<name>/
 By default, creates a new branch with the worktree name based on the current branch.
 Use --branch to checkout an existing branch instead.
 
+If origin/<name> exists and no local branch does, camp refuses rather than
+forking a divergent local branch from HEAD. Use --track origin/<name> (or
+--branch <name>) instead.
+
 Examples:
   # Create worktree with new branch based on current branch (default)
   camp project worktree add feature-auth

--- a/docs/cli-reference/camp/camp_triage_status.md
+++ b/docs/cli-reference/camp/camp_triage_status.md
@@ -17,6 +17,11 @@ data and never walks the filesystem, so it is instant and keeps meaning even
 after the campaign moves underneath the run. Comparing a run against the
 current state of the campaign is what camp triage refresh does.
 
+When the last refresh is older than the campaign's runs.stale_after_days
+threshold, or workitems have changed since, it also prints the same one-line
+notice high-traffic commands share (from the cached verdict, not a discovery
+walk).
+
 Exits 0 when there is no run: a campaign that has not triaged yet is a state,
 not an error.
 

--- a/docs/cli-reference/camp/camp_workitem.md
+++ b/docs/cli-reference/camp/camp_workitem.md
@@ -36,11 +36,13 @@ camp workitem [flags]
       --json                          Output as JSON
       --limit int                     Maximum items to return
       --list                          Output a compact grouped list
+      --no-tokens                     Skip token count annotation
       --print                         Print path only
       --query string                  Filter by search query
       --show-parked                   Include parked workitems
       --stage stringArray             Filter by lifecycle stage
-      --status stringArray            Filter by displayed status
+      --status stringArray            Deprecated: use --stage and/or --attention-stage
+      --token-model string            Tokenizer model for token counts (default "gpt-4o")
       --type stringArray              Filter by workflow type
 ```
 
@@ -56,6 +58,8 @@ camp workitem [flags]
 * [camp workitem adopt](../camp_workitem_adopt/)	 - Adopt an existing directory or file as a workitem
 * [camp workitem commit](../camp_workitem_commit/)	 - Commit changes scoped to a workitem
 * [camp workitem commits](../camp_workitem_commits/)	 - List commits referencing a workitem
+* [camp workitem completion](../camp_workitem_completion/)	 - Set completed-run review behavior for a workitem
+* [camp workitem convert](../camp_workitem_convert/)	 - Move a workitem to another workflow type
 * [camp workitem create](../camp_workitem_create/)	 - Create workitem tracking metadata
 * [camp workitem demote](../camp_workitem_demote/)	 - Move a rail resident back to its type root
 * [camp workitem doctor](../camp_workitem_doctor/)	 - Report link-registry health issues

--- a/docs/cli-reference/camp/camp_workitem_completion.md
+++ b/docs/cli-reference/camp/camp_workitem_completion.md
@@ -1,0 +1,40 @@
+---
+title: "camp workitem completion"
+linkTitle: "camp workitem completion"
+description: "Set completed-run review behavior for a workitem"
+---
+
+## camp workitem completion
+
+Set completed-run review behavior for a workitem
+
+### Synopsis
+
+Set how completed standalone workflow runs affect one workitem.
+
+review restores the default and clears any one-run acknowledgement.
+acknowledge keeps the workitem active and suppresses only its latest completed
+run. recurring keeps the workitem active and suppresses every completed-run
+review until review is restored. Persistent decisions live in the versioned
+.workitem marker and apply to both camp fresh and camp workitem sweep.
+
+```
+camp workitem completion <selector> <review|acknowledge|recurring> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for completion
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_convert.md
+++ b/docs/cli-reference/camp/camp_workitem_convert.md
@@ -1,0 +1,61 @@
+---
+title: "camp workitem convert"
+linkTitle: "camp workitem convert"
+description: "Move a workitem to another workflow type"
+---
+
+## camp workitem convert
+
+Move a workitem to another workflow type
+
+### Synopsis
+
+Convert the workitem matched by <selector> from its current workflow
+type root to --type, keeping the same basename. Identity is preserved: the
+stable id, ref, and title do not change. The directory (or file) moves from
+workflow/<old-type>/<name> to workflow/<new-type>/<name>, and the marker
+(or file frontmatter) type field is updated to match.
+
+References are repaired in the same commit as the move, using the same
+rewrites as camp workitem rename:
+  - relative markdown links pointing at the workitem are rewritten
+  - the workitem link registry (links.yaml) key and any scope paths under the
+    moved directory are updated
+  - manual priority and attention-stage entries are re-keyed on disk
+
+Festivals and intents are managed by their own tooling and cannot be converted
+here. Workitems already in a dungeon cannot be converted; restore them first.
+This is not a rename: the basename stays put. Use camp workitem rename to
+change the name without changing type.
+
+```
+camp workitem convert <selector> [flags]
+```
+
+### Examples
+
+```
+  camp workitem convert camp-triage --type design
+  camp workitem convert WI-36e2a6 --type design --json
+  camp workitem convert explore-notes --type design --dry-run
+```
+
+### Options
+
+```
+      --dry-run       Print the planned conversion, change nothing
+  -h, --help          help for convert
+      --json          Output result as a single JSON object
+      --no-commit     Skip the auto-commit
+      --type string   Destination workflow type
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](../camp_workitem/)	 - View active campaign work items

--- a/docs/cli-reference/camp/camp_workitem_doctor.md
+++ b/docs/cli-reference/camp/camp_workitem_doctor.md
@@ -14,8 +14,9 @@ Report health issues in the campaign workitem link registry.
 
 The command reads .campaign/workitems/links.yaml, scans .workitem metadata on
 disk, and checks current-workitem and priority stores for stale or inconsistent
-references. Use --fix to apply auto-repairs for supported findings. Use --json
-for machine-readable findings and stable finding codes.
+references. Use --fix to apply auto-repairs for supported findings, including
+rewriting projects: entries whose path git recorded as a project rename. Use
+--json for machine-readable findings and stable finding codes.
 
 ```
 camp workitem doctor [flags]

--- a/docs/cli-reference/camp/camp_workitem_list.md
+++ b/docs/cli-reference/camp/camp_workitem_list.md
@@ -24,7 +24,8 @@ Examples:
   camp workitem list active
   camp workitem list --category research --query auth
   camp workitem list --tag public-launch --tag schema
-  camp workitem list festival --status ready --json
+  camp workitem list festival --stage ready --json
+  camp workitem list --attention-stage active --json
 
 ```
 camp workitem list [type|status|category] [flags]
@@ -40,12 +41,14 @@ camp workitem list [type|status|category] [flags]
   -h, --help                          help for list
       --json                          Output as JSON
       --limit int                     Maximum number of items to return (non-interactive / --json only)
+      --no-tokens                     Skip token count annotation
       --project stringArray           Filter by related project (repeat for OR)
       --query string                  Search query to filter items
       --show-parked                   Include parked attention-stage workitems
       --stage stringArray             Filter by lifecycle stage (repeat for OR)
-      --status stringArray            Filter by displayed status: current, next, active, parked, inbox, ready, plan, ritual, chains, none (repeat for OR)
+      --status stringArray            Deprecated: use --stage and/or --attention-stage
       --tag stringArray               Filter by tag (repeat; item must have ALL given tags)
+      --token-model string            Tokenizer model for token counts (default "gpt-4o")
       --type stringArray              Filter by workflow type (repeat for OR)
 ```
 

--- a/docs/cli-reference/fest/fest_list.md
+++ b/docs/cli-reference/fest/fest_list.md
@@ -14,10 +14,10 @@ List festivals filtered by status.
 
 Works from anywhere - finds the festivals workspace automatically.
 
-STATUS can be: active, ready, planning, ritual, completed, all,
+STATUS can be: active, ready, planning, parked, ritual, completed, all,
 dungeon, dungeon/completed, dungeon/archived, dungeon/someday
 
-By default, shows active, ready, planning, and ritual festivals.
+By default, shows active, ready, planning, parked, and ritual festivals.
 Use 'fest list all' (or --all) to include completed and dungeon festivals.
 
 Use --watch to refresh the multi-festival status board when festival progress

--- a/docs/cli-reference/fest/fest_promote.md
+++ b/docs/cli-reference/fest/fest_promote.md
@@ -42,7 +42,7 @@ fest promote [festival] [flags]
       --force            skip readiness validation
   -h, --help             help for promote
       --json             output as JSON
-      --no-commit        skip auto-commit after promotion
+      --no-commit        skip auto-commit after promotion (rejected when agent.require_auto_commit is enabled)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/fest/fest_ritual.md
+++ b/docs/cli-reference/fest/fest_ritual.md
@@ -26,4 +26,5 @@ Manage repeatable ritual festivals
 ### SEE ALSO
 
 * [fest](../fest/)	 - Festival Methodology CLI - goal-oriented project management for AI agents
+* [fest ritual convert](../fest_ritual_convert/)	 - Convert a festival into a reusable ritual template
 * [fest ritual run](../fest_ritual_run/)	 - Create a new run of a ritual festival in active/

--- a/docs/cli-reference/fest/fest_ritual_convert.md
+++ b/docs/cli-reference/fest/fest_ritual_convert.md
@@ -1,0 +1,51 @@
+---
+title: "fest ritual convert"
+linkTitle: "fest ritual convert"
+description: "Convert a festival into a reusable ritual template"
+---
+
+## fest ritual convert
+
+Convert a festival into a reusable ritual template
+
+### Synopsis
+
+Copy an existing festival into ritual/ as a repeatable ritual template.
+
+The source festival is preserved by default. The copy is placed in ritual/
+with an RI-XX0001 ID suffix, its fest.yaml metadata.festival_type is set to
+"ritual", and a ritual_config block with run_count: 0 is added.
+
+Progress artifacts and task completion state are stripped from the copy by
+default so fest ritual run starts clean. Pass --reset-progress=false to keep them.
+
+Use --move-source to archive the original after conversion.
+
+```
+fest ritual convert <festival-name-or-id> [flags]
+```
+
+### Options
+
+```
+      --dry-run            Show what would change without writing
+      --frequency string   Ritual frequency hint (e.g. weekly, quarterly); stored in ritual_config.schedule
+  -h, --help               help for convert
+      --json               output as JSON
+      --move-source        Move the source festival to dungeon/archived after conversion (default: preserve source)
+      --name string        Override the festival name in the new ritual template (defaults to source name)
+      --reset-progress     Strip progress artifacts and task completion state from the copy (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/fest/config.json)
+      --debug           enable debug logging
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [fest ritual](../fest_ritual/)	 - Manage repeatable ritual festivals

--- a/docs/cli-reference/fest/fest_status_set.md
+++ b/docs/cli-reference/fest/fest_status_set.md
@@ -16,7 +16,7 @@ CONTEXT-AWARE BEHAVIOR:
 When no explicit level flag is provided, the command auto-detects the
 appropriate level based on your current directory:
 
-  Festival root  → Sets festival status (planning/active/completed/dungeon)
+  Festival root  → Sets festival status (planning/parked/active/completed/dungeon)
   Phase directory → Sets phase status (pending/in_progress/completed)
   Sequence directory → Sets sequence status (pending/in_progress/completed)
   Task directory → Shows hint (task status requires explicit --task flag)
@@ -63,7 +63,7 @@ fest status set <status> [flags]
   -h, --help              help for set
   -i, --interactive       force interactive festival selection
       --json              output in JSON format
-      --no-commit         skip auto-commit after status change
+      --no-commit         skip auto-commit after status change (rejected when agent.require_auto_commit is enabled)
       --path string       explicit file path for status change
       --phase string      target phase by name or number (e.g., '001_CRITICAL' or '001')
       --sequence string   target sequence by name (e.g., '01_api_design' or '002/01')

--- a/docs/cli-reference/fest/fest_validate.md
+++ b/docs/cli-reference/fest/fest_validate.md
@@ -19,10 +19,15 @@ this command validates METHODOLOGY COMPLIANCE:
   • Implementation sequences have TASK FILES (not just goals)
   • Quality gates are present in implementation sequences
   • Naming conventions are followed
-  • Templates have been filled out (no [FILL:] markers)
+  • Unfilled [REPLACE:]/[FILL:] markers are reported as "markers pending"
+    (they do not fail structure validation or zero the score)
 
 AI agents execute TASK FILES, not goals. If your sequences only have
 SEQUENCE_GOAL.md without task files, agents won't know HOW to execute.
+
+Unfilled template markers after scaffolding are expected. Fill them as you
+write real content: do not paste filler to restore a score. Missing files,
+missing task files, and missing quality gates still fail validation.
 
 Use --fix to automatically apply safe fixes (like adding quality gates).
 

--- a/docs/cli-reference/festival/festival_doctor.md
+++ b/docs/cli-reference/festival/festival_doctor.md
@@ -6,10 +6,7 @@ description: "Diagnose installer state (PATH, sources, receipts)"
 
 ## festival doctor
 
-Diagnose installer state (PATH, sources, receipts). On a coherent package
-install (AUR `festival-bin`, Homebrew, npm, or `obedience-festival`) doctor
-exits 0 when camp/fest/festival are on PATH; `no marketplaces registered` is a
-warn, not a failure. Doctor does not require `~/.obey/installer/bin` on PATH.
+Diagnose installer state (PATH, sources, receipts)
 
 ```
 festival doctor [flags]

--- a/docs/cli-reference/festival/festival_install.md
+++ b/docs/cli-reference/festival/festival_install.md
@@ -25,6 +25,7 @@ festival install <festival|camp|fest> [flags]
 ```
       --allow-unverified   allow installing unsigned content without prompting
       --channel string     release channel (stable|rc|dev) (default "stable")
+      --force              install a hub copy even when a package-manager suite is already on PATH
   -h, --help               help for install
       --json               emit JSON output
 ```

--- a/docs/cli-reference/festival/festival_shell-init.md
+++ b/docs/cli-reference/festival/festival_shell-init.md
@@ -6,9 +6,7 @@ description: "Print shell code to put the installer-managed bin dir on PATH"
 
 ## festival shell-init
 
-Print origin-aware shell code. Package installs print `source` of the packaged
-helper (not `export PATH=` for `~/.obey/installer/bin`). Hub-managed installs
-still prepend the managed bin dir.
+Print shell code to put the installer-managed bin dir on PATH
 
 ```
 festival shell-init <zsh|bash|fish> [flags]

--- a/docs/cli-reference/festival/festival_update.md
+++ b/docs/cli-reference/festival/festival_update.md
@@ -16,6 +16,10 @@ The target argument is optional and defaults to "festival", which updates the wh
 suite. camp and fest are accepted as aliases: they are not published independently, so
 passing either one still updates the whole suite and prints a notice saying so.
 
+A package-manager install (AUR, Homebrew, npm, distro packages) is never replaced with
+~/.obey/installer. update reports whether a newer suite exists and prints the package
+manager upgrade command instead.
+
 ```
 festival update [festival|camp|fest] [flags]
 ```
@@ -25,6 +29,7 @@ festival update [festival|camp|fest] [flags]
 ```
       --allow-unverified   allow updating from unsigned content without prompting
       --channel string     override the release channel (default: the installed channel)
+      --force              update/install a hub copy even when a package-manager suite is already on PATH
   -h, --help               help for update
       --json               emit JSON output
 ```


### PR DESCRIPTION
Release: pin fest v0.6.6 and festival-installer v0.1.3.

Created by the release operator: main only accepts changes through pull requests, so the pin commit ships through this PR. After the squash merge, the operator tags v0.3.4 on main to trigger release CI.