### PR TITLE
fix(ci): clear stuck Dependabot alerts on gitlink go.mod paths

### DIFF
--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -10,10 +10,13 @@ on:
       - camp
       - fest
       - festival-installer
+      - scripts/submit-go-dependency-snapshot.sh
   workflow_dispatch:
 
 # A user-submitted snapshot takes precedence over GitHub's stale automatic
 # analysis of the go.mod files behind the camp and fest gitlinks.
+# Submit with the real go.mod path as the manifest name so Dependabot alerts
+# attached to fest/go.mod / camp/go.mod can auto-resolve.
 permissions:
   contents: write
 
@@ -59,6 +62,7 @@ jobs:
           }
 
           require_module_at_least 'golang.org/x/crypto' 'v0.54.0'
+          require_module_at_least 'github.com/moby/go-archive' 'v0.3.0'
           require_module_at_least 'go.opentelemetry.io/otel' 'v1.43.0'
           require_module_at_least 'go.opentelemetry.io/otel/sdk' 'v1.43.0'
 
@@ -68,12 +72,10 @@ jobs:
           fi
 
       - name: Submit dependency snapshot
-        # Node 24 revision of GitHub's action; pinned until its next release.
-        uses: actions/go-dependency-submission@58a892e48687d602add5889d7aa09e32efeb19a7
         env:
           GOWORK: "off"
-        with:
-          go-mod-path: fest/go.mod
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/submit-go-dependency-snapshot.sh fest/go.mod
 
   submit-camp:
     name: Submit Camp dependencies
@@ -92,13 +94,45 @@ jobs:
           go-version-file: camp/go.mod
           cache-dependency-path: camp/go.sum
 
-      - name: Submit dependency snapshot
-        # Node 24 revision of GitHub's action; pinned until its next release.
-        uses: actions/go-dependency-submission@58a892e48687d602add5889d7aa09e32efeb19a7
+      - name: Verify repaired dependency graph
         env:
           GOWORK: "off"
-        with:
-          go-mod-path: camp/go.mod
+        run: |
+          modules="$RUNNER_TEMP/camp-modules.txt"
+          go -C camp list -m all | tee "$modules"
+
+          require_module_at_least() {
+            module="$1"
+            minimum="$2"
+            actual="$(awk -v module="$module" '$1 == module { print $2 }' "$modules")"
+
+            if [[ -z "$actual" ]]; then
+              echo "Required module $module is missing from the Camp graph." >&2
+              exit 1
+            fi
+
+            earliest="$(printf '%s\n%s\n' "$minimum" "$actual" | sort -V | head -n 1)"
+            if [[ "$earliest" != "$minimum" ]]; then
+              echo "$module must be at least $minimum; resolved $actual." >&2
+              exit 1
+            fi
+          }
+
+          require_module_at_least 'golang.org/x/crypto' 'v0.54.0'
+          require_module_at_least 'github.com/moby/go-archive' 'v0.3.0'
+          require_module_at_least 'go.opentelemetry.io/otel' 'v1.43.0'
+          require_module_at_least 'go.opentelemetry.io/otel/sdk' 'v1.43.0'
+
+          if grep -Eq '^github\.com/docker/docker( |$)' "$modules"; then
+            echo 'Legacy github.com/docker/docker module remains in the Camp graph.' >&2
+            exit 1
+          fi
+
+      - name: Submit dependency snapshot
+        env:
+          GOWORK: "off"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/submit-go-dependency-snapshot.sh camp/go.mod
 
   submit-festival-installer:
     name: Submit Festival Installer dependencies
@@ -118,9 +152,7 @@ jobs:
           cache-dependency-path: festival-installer/go.sum
 
       - name: Submit dependency snapshot
-        # Node 24 revision of GitHub's action; pinned until its next release.
-        uses: actions/go-dependency-submission@58a892e48687d602add5889d7aa09e32efeb19a7
         env:
           GOWORK: "off"
-        with:
-          go-mod-path: festival-installer/go.mod
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/submit-go-dependency-snapshot.sh festival-installer/go.mod

--- a/scripts/submit-go-dependency-snapshot.sh
+++ b/scripts/submit-go-dependency-snapshot.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Submit a Go module graph to GitHub's dependency submission API.
+#
+# actions/go-dependency-submission names the manifest after go-build-target
+# (default "all"). For gitlink go.mod files, Dependabot alerts stay attached to
+# paths like fest/go.mod, so the snapshot must use that path as the manifest
+# name/source_location or stale alerts never auto-resolve.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <path-to-go.mod>" >&2
+  exit 2
+fi
+
+go_mod_path="$1"
+if [[ "$(basename "$go_mod_path")" != "go.mod" || ! -f "$go_mod_path" ]]; then
+  echo "$go_mod_path is not an existing go.mod file" >&2
+  exit 1
+fi
+
+go_mod_dir="$(dirname "$go_mod_path")"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_SHA:?GITHUB_SHA is required}"
+: "${GITHUB_REF:?GITHUB_REF is required}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+: "${GITHUB_RUN_ID:=local}"
+: "${GITHUB_WORKFLOW:=submit-go-dependency-snapshot}"
+: "${GITHUB_JOB:=submit}"
+export GITHUB_REPOSITORY GITHUB_SHA GITHUB_REF GITHUB_TOKEN GITHUB_RUN_ID GITHUB_WORKFLOW GITHUB_JOB
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+GOWORK=off go -C "$go_mod_dir" list -m -json all >"$tmp"
+
+snapshot="$(GOWORK=off python3 - "$go_mod_path" "$tmp" <<'PY'
+import json, os, sys, datetime
+from pathlib import Path
+
+go_mod_path = sys.argv[1]
+modules_path = Path(sys.argv[2])
+
+mods = []
+buf = []
+for line in modules_path.read_text().splitlines(True):
+    buf.append(line)
+    if line.strip() == "}":
+        mods.append(json.loads("".join(buf)))
+        buf = []
+
+resolved = {}
+for mod in mods:
+    path = mod.get("Path")
+    version = mod.get("Version")
+    if not path or not version:
+        continue
+    purl = f"pkg:golang/{path}@{version}"
+    resolved[purl] = {
+        "package_url": purl,
+        "relationship": "indirect" if mod.get("Indirect") else "direct",
+        "scope": "runtime",
+        "dependencies": [],
+    }
+
+now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+snapshot = {
+    "version": 0,
+    "sha": os.environ["GITHUB_SHA"],
+    "ref": os.environ["GITHUB_REF"],
+    "job": {
+        "correlator": f'{os.environ["GITHUB_WORKFLOW"]}-{os.environ["GITHUB_JOB"]}-{go_mod_path}',
+        "id": str(os.environ["GITHUB_RUN_ID"]),
+    },
+    "detector": {
+        "name": "festival-submit-go-dependency-snapshot",
+        "version": "1.0.0",
+        "url": "https://github.com/Obedience-Corp/festival",
+    },
+    "scanned": now,
+    "manifests": {
+        go_mod_path: {
+            "name": go_mod_path,
+            "file": {"source_location": go_mod_path},
+            "resolved": resolved,
+        }
+    },
+}
+print(json.dumps(snapshot))
+PY
+)"
+
+owner="${GITHUB_REPOSITORY%/*}"
+repo="${GITHUB_REPOSITORY#*/}"
+
+package_count="$(
+  SNAPSHOT_JSON="$snapshot" GO_MOD_PATH="$go_mod_path" python3 - <<'PY'
+import json, os
+snapshot = json.loads(os.environ["SNAPSHOT_JSON"])
+print(len(snapshot["manifests"][os.environ["GO_MOD_PATH"]]["resolved"]))
+PY
+)"
+echo "Submitting dependency snapshot for ${go_mod_path} (${package_count} packages)"
+
+response="$(
+  curl -fsSL \
+    -X POST \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    -H "Content-Type: application/json" \
+    --data "$snapshot" \
+    "https://api.github.com/repos/${owner}/${repo}/dependency-graph/snapshots"
+)"
+
+RESPONSE_JSON="$response" python3 - <<'PY'
+import json, os
+result = json.loads(os.environ["RESPONSE_JSON"])
+print(
+    f"result={result.get('result')} "
+    f"created_at={result.get('created_at')} "
+    f"message={result.get('message')}"
+)
+PY


### PR DESCRIPTION
## Summary
- Festival still showed 23 open Dependabot alerts on `fest/go.mod` even though the pinned fest v0.6.6 graph already has the patched versions (`golang.org/x/crypto@v0.54.0`, `github.com/moby/go-archive@v0.3.0`, `go.opentelemetry.io/otel{,/sdk}@v1.43.0`, and no `github.com/docker/docker`).
- Those paths are gitlinks. GitHub's automatic scan cannot re-resolve them (`dependenciesCount: 0`), and `actions/go-dependency-submission` was submitting manifests named `all`, so the patched pins never cleared the alerts.
- Replace that action with `scripts/submit-go-dependency-snapshot.sh`, which submits the selected `go list -m` graph using the real `fest/go.mod` / `camp/go.mod` / `festival-installer/go.mod` manifest names.
- Add the same security gates for camp, including `github.com/moby/go-archive >= v0.3.0`.

## Alert status
Independently verified against the fest v0.6.6 pin with `go list -m all`, then dismissed the 23 stuck alerts as inaccurate with per-package verification comments. No dependency bump PR was needed; the vulnerable packages are already gone/patched in the current pin.

## Test plan
- [x] Local smoke: script submits a snapshot (ACCEPTED on non-default branch)
- [ ] After merge, Actions `Submit Go dependencies` succeeds on main
- [ ] Future alerts on `fest/go.mod` / `camp/go.mod` can auto-resolve from the named snapshot