### PR TITLE
chore: bump camp/fest submodule pins post CC0008 rename

### DIFF
--- a/docs/cli-reference/camp/camp.md
+++ b/docs/cli-reference/camp/camp.md
@@ -1,35 +1,40 @@
 ---
 title: "camp"
 linkTitle: "camp"
-description: "Campaign management CLI for multi-project AI workspaces"
+description: "Manage your camps and the projects and festivals inside them"
 ---
 
 ## camp
 
-Campaign management CLI for multi-project AI workspaces
+Manage your camps and the projects and festivals inside them
 
 ### Synopsis
 
-Camp manages multi-project AI workspaces with fast navigation.
+Camp manages your camps.
 
-Camp provides structure and navigation for AI-powered development workflows.
-It creates standardized campaign directories, manages git submodules as projects,
-and enables lightning-fast navigation through category shortcuts and TUI fuzzy finding.
+A camp is one context in your life: your job, a side project, your taxes. Each
+camp holds the projects you work on and hosts the festivals you run in them.
+Camp creates camps, manages git submodules as projects, and gives you
+lightning-fast navigation through category shortcuts and TUI fuzzy finding.
+
+Camp stores each camp's state in the .campaign/ directory. That name is
+stable, so do not rename it. The separate .camp file is an attachment marker
+for linked external directories, not a replacement for .campaign/.
 
 GETTING STARTED:
-  camp init               Initialize a new campaign in the current directory
-  camp project list       List all projects in the campaign
-  camp list               Show all registered campaigns
+  camp init               Initialize a new camp in the current directory
+  camp project list       List all projects in the camp
+  camp list               Show all registered camps
 
 NAVIGATION (using cgo shell function):
-  cgo                     Navigate to campaign root
+  cgo                     Navigate to camp root
   cgo p                   Navigate to projects directory
   cgo f                   Navigate to festivals directory
   cgo <name>              Fuzzy find and navigate to any target
 
 COMMON WORKFLOWS:
   camp project add <url>  Add a git repo as a project submodule
-  camp run <command>      Run command from campaign root directory
+  camp run <command>      Run command from camp root directory
   camp shortcuts          View all available navigation shortcuts
 
 Run 'camp shell-init' to enable the cgo navigation function.
@@ -48,61 +53,61 @@ camp [flags]
 ### SEE ALSO
 
 * [camp artifacts](../camp_artifacts/)	 - Manage declared artifact roots (.campaign/artifacts.yaml)
-* [camp attach](../camp_attach/)	 - Attach an external directory to a campaign
+* [camp attach](../camp_attach/)	 - Attach an external directory to a camp
 * [camp cache](../camp_cache/)	 - Manage the navigation index cache
-* [camp clone](../camp_clone/)	 - Clone a campaign with full submodule setup
-* [camp commit](../camp_commit/)	 - Commit changes in the campaign root
+* [camp clone](../camp_clone/)	 - Clone a camp with full submodule setup
+* [camp commit](../camp_commit/)	 - Commit changes in the camp root
 * [camp completion](../camp_completion/)	 - Generate the autocompletion script for the specified shell
 * [camp concepts](../camp_concepts/)	 - List configured concepts
-* [camp copy](../camp_copy/)	 - Copy a file or directory within the campaign
-* [camp create](../camp_create/)	 - Create a new campaign at the default campaigns directory
+* [camp copy](../camp_copy/)	 - Copy a file or directory within the camp
+* [camp create](../camp_create/)	 - Create a new camp at the default camps directory
 * [camp date](../camp_date/)	 - Append date suffix to file or directory name
-* [camp detach](../camp_detach/)	 - Remove the current campaign's attachment binding
-* [camp doctor](../camp_doctor/)	 - Diagnose and fix campaign health issues
-* [camp dungeon](../camp_dungeon/)	 - Manage the campaign dungeon
-* [camp festivals](../camp_festivals/)	 - List festivals across campaigns, filtered by org/tag
+* [camp detach](../camp_detach/)	 - Remove the current camp's attachment binding
+* [camp doctor](../camp_doctor/)	 - Diagnose and fix camp health issues
+* [camp dungeon](../camp_dungeon/)	 - Manage the camp dungeon
+* [camp festivals](../camp_festivals/)	 - List festivals across camps, filtered by org/tag
 * [camp fresh](../camp_fresh/)	 - Post-merge branch cycling: sync to default branch and optionally create a new working branch
 * [camp gather](../camp_gather/)	 - Gather related work into unified items
-* [camp go](../camp_go/)	 - Navigate to campaign directories
-* [camp id](../camp_id/)	 - Print the current campaign ID
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
-* [camp init](../camp_init/)	 - Initialize a new campaign
+* [camp go](../camp_go/)	 - Navigate to camp directories
+* [camp id](../camp_id/)	 - Print the current camp ID
+* [camp idea](../camp_idea/)	 - Manage camp ideas
+* [camp init](../camp_init/)	 - Initialize a new camp
 * [camp jobs](../camp_jobs/)	 - Inspect and run camp's deferred commit queue
-* [camp leverage](../camp_leverage/)	 - Compute leverage scores for campaign projects
-* [camp lifecycle](../camp_lifecycle/)	 - Manage campaign lifecycle status
-* [camp list](../camp_list/)	 - List all registered campaigns
-* [camp log](../camp_log/)	 - Show git log of the campaign
+* [camp leverage](../camp_leverage/)	 - Compute leverage scores for the camp's projects
+* [camp lifecycle](../camp_lifecycle/)	 - Manage camp lifecycle status
+* [camp list](../camp_list/)	 - List all registered camps
+* [camp log](../camp_log/)	 - Show git log of the camp
 * [camp machine](../camp_machine/)	 - Manage remote machines (~/.obey/machines.yaml)
-* [camp move](../camp_move/)	 - Move a file or directory within the campaign
-* [camp notify](../camp_notify/)	 - Manage campaign state notices
-* [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp move](../camp_move/)	 - Move a file or directory within the camp
+* [camp notify](../camp_notify/)	 - Manage camp state notices
+* [camp org](../camp_org/)	 - Group camps into orgs
 * [camp pack](../camp_pack/)	 - Pack a directory into a portable .festival bundle
 * [camp pin](../camp_pin/)	 - Pin a directory
 * [camp pins](../camp_pins/)	 - List all pinned directories
 * [camp plugins](../camp_plugins/)	 - List discovered camp plugins on PATH
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects
 * [camp promote](../camp_promote/)	 - Promote any intent, workitem, or festival (universal front door)
 * [camp pull](../camp_pull/)	 - Pull latest changes from remote
-* [camp push](../camp_push/)	 - Push campaign changes to remote
-* [camp refs-sync](../camp_refs-sync/)	 - Sync submodule ref pointers in campaign root
-* [camp register](../camp_register/)	 - Register campaign in global registry
-* [camp registry](../camp_registry/)	 - Manage the campaign registry
-* [camp root](../camp_root/)	 - Print the current campaign root
-* [camp run](../camp_run/)	 - Execute command from campaign root, or just recipe in a project
+* [camp push](../camp_push/)	 - Push camp changes to remote
+* [camp refs-sync](../camp_refs-sync/)	 - Sync submodule ref pointers in camp root
+* [camp register](../camp_register/)	 - Register a camp in the global registry
+* [camp registry](../camp_registry/)	 - Manage the camp registry
+* [camp root](../camp_root/)	 - Print the current camp root
+* [camp run](../camp_run/)	 - Execute command from camp root, or just recipe in a project
 * [camp settings](../camp_settings/)	 - Manage camp configuration
 * [camp shell-init](../camp_shell-init/)	 - Output shell initialization code
 * [camp shortcuts](../camp_shortcuts/)	 - List all available shortcuts
-* [camp skills](../camp_skills/)	 - Manage campaign skill directory links
-* [camp stage](../camp_stage/)	 - Stage changes in the campaign root
-* [camp status](../camp_status/)	 - Show git status of the campaign
-* [camp switch](../camp_switch/)	 - Switch to a different campaign
+* [camp skills](../camp_skills/)	 - Manage camp skill directory links
+* [camp stage](../camp_stage/)	 - Stage changes in the camp root
+* [camp status](../camp_status/)	 - Show git status of the camp
+* [camp switch](../camp_switch/)	 - Switch to a different camp
 * [camp sync](../camp_sync/)	 - Safely synchronize submodules
-* [camp tag](../camp_tag/)	 - Label campaigns with tags
-* [camp transfer](../camp_transfer/)	 - Copy files between campaigns (and machines)
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp tag](../camp_tag/)	 - Label camps with tags
+* [camp transfer](../camp_transfer/)	 - Copy files between camps (and machines)
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session
 * [camp unbundle](../camp_unbundle/)	 - Unbundle a .festival archive into a directory
 * [camp unpin](../camp_unpin/)	 - Remove a saved pin
-* [camp unregister](../camp_unregister/)	 - Remove campaign from registry
+* [camp unregister](../camp_unregister/)	 - Remove a camp from the registry
 * [camp version](../camp_version/)	 - Show version information
 * [camp workflow](../camp_workflow/)	 - Manage workflow collections
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_artifacts.md
+++ b/docs/cli-reference/camp/camp_artifacts.md
@@ -10,12 +10,12 @@ Manage declared artifact roots (.campaign/artifacts.yaml)
 
 ### Synopsis
 
-Manage the campaign's declared artifact roots: directories of heavy non-git
+Manage the camp's declared artifact roots: directories of heavy non-git
 payloads (media, renders, datasets) that 'camp sync --from <machine>' moves
 between your machines with rsync instead of git.
 
 The declaration file (.campaign/artifacts.yaml) is committed, so every
-machine knows what belongs to the campaign. Declared roots should be
+machine knows what belongs to the camp. Declared roots should be
 gitignored: a root that is also git-tracked would make the same bytes both
 git content and artifact content. Manifests and per-peer sync snapshots are
 machine-local derived state under .campaign/cache (gitignored).
@@ -44,7 +44,7 @@ machine-local derived state under .campaign/cache (gitignored).
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp artifacts add](../camp_artifacts_add/)	 - Declare an artifact root
 * [camp artifacts list](../camp_artifacts_list/)	 - List declared artifact roots
 * [camp artifacts manifest](../camp_artifacts_manifest/)	 - Print a declared root's manifest as JSON

--- a/docs/cli-reference/camp/camp_artifacts_add.md
+++ b/docs/cli-reference/camp/camp_artifacts_add.md
@@ -10,7 +10,7 @@ Declare an artifact root
 
 ### Synopsis
 
-Declare a campaign-relative directory as an artifact root.
+Declare a camp-relative directory as an artifact root.
 
 Policy 'always' (default) syncs the root on every 'camp sync --from
 <machine>'; 'on-demand' syncs it only when artifacts are requested

--- a/docs/cli-reference/camp/camp_attach.md
+++ b/docs/cli-reference/camp/camp_attach.md
@@ -1,34 +1,34 @@
 ---
 title: "camp attach"
 linkTitle: "camp attach"
-description: "Attach an external directory to a campaign"
+description: "Attach an external directory to a camp"
 ---
 
 ## camp attach
 
-Attach an external directory to a campaign
+Attach an external directory to a camp
 
 ### Synopsis
 
-Attach a non-project directory to a campaign by writing a .camp marker.
+Attach a non-project directory to a camp by writing a .camp marker.
 
 The user manages the symlink (if any). camp attach only writes the marker at
 the resolved target so commands run from inside that directory can recover
-campaign context. Attachment markers may be shared by multiple campaigns;
-running attach again from another campaign adds that campaign to the marker.
+camp context. Attachment markers may be shared by multiple camps;
+running attach again from another camp adds that camp to the marker.
 
 If the target is reached through a symlink, camp follows it once and writes
 the marker at the final directory.
 
-When several campaigns share one attachment, which campaign a command resolves
-depends on how the directory is reached: entering through a campaign-local
-symlink resolves that campaign, while a bare cd into the shared target itself
-resolves to the first campaign it was attached to.
+When several camps share one attachment, which camp a command resolves
+depends on how the directory is reached: entering through a camp-local
+symlink resolves that camp, while a bare cd into the shared target itself
+resolves to the first camp it was attached to.
 
-Campaign selection:
-  - inside a campaign, omit --campaign to attach to the current campaign
-  - outside a campaign in an interactive terminal, omit --campaign to pick
-  - use a bare --campaign to force the picker even inside a campaign
+Camp selection:
+  - inside a camp, omit --campaign to attach to the current camp
+  - outside a camp in an interactive terminal, omit --campaign to pick
+  - use a bare --campaign to force the picker even inside a camp
   - use --campaign <name-or-id> for scripts or to skip the picker
 
 Examples:
@@ -44,7 +44,7 @@ camp attach <path> [flags]
 ### Options
 
 ```
-  -c, --campaign string   Target campaign by name or ID; omit value to pick interactively
+  -c, --campaign string   Target camp by name or ID; omit value to pick interactively
       --force             Rewrite an existing attachment marker
   -h, --help              help for attach
 ```
@@ -57,4 +57,4 @@ camp attach <path> [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_cache.md
+++ b/docs/cli-reference/camp/camp_cache.md
@@ -30,7 +30,7 @@ camp cache [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp cache clear](../camp_cache_clear/)	 - Delete the navigation cache
 * [camp cache info](../camp_cache_info/)	 - Show cache status and metadata
 * [camp cache rebuild](../camp_cache_rebuild/)	 - Force rebuild the navigation cache

--- a/docs/cli-reference/camp/camp_clone.md
+++ b/docs/cli-reference/camp/camp_clone.md
@@ -1,21 +1,21 @@
 ---
 title: "camp clone"
 linkTitle: "camp clone"
-description: "Clone a campaign with full submodule setup"
+description: "Clone a camp with full submodule setup"
 ---
 
 ## camp clone
 
-Clone a campaign with full submodule setup
+Clone a camp with full submodule setup
 
 ### Synopsis
 
-Clone a campaign repository and initialize all submodules.
+Clone a camp repository and initialize all submodules.
 
 This command provides a single-step setup for new devices:
 
   1. CLONE REPOSITORY
-     Clones the campaign repository with recursive submodules.
+     Clones the camp repository with recursive submodules.
 
   2. SYNCHRONIZE URLs
      Copies URLs from .gitmodules to .git/config, ensuring
@@ -28,25 +28,25 @@ This command provides a single-step setup for new devices:
      Verifies all submodules are initialized, at correct commits,
      and have matching URLs.
 
-  5. REGISTER CAMPAIGN
-     If .campaign/campaign.yaml exists, registers the campaign
+  5. REGISTER CAMP
+     If .campaign/campaign.yaml exists, registers the camp
      in the global registry for navigation and discovery.
 
 EXIT CODES:
   0  Success
-  1  Runtime failure (clone failed before usable campaign)
+  1  Runtime failure (clone failed before usable camp)
   2  Usage error (bad flags or args)
   3  Partial success or validation failed
 
 EXAMPLES:
-  # Clone a campaign (default: SSH)
+  # Clone a camp (default: SSH)
   camp clone git@github.com:Obedience-Corp/obey-campaign.git
 
   # Clone with HTTPS
   camp clone https://github.com/Obedience-Corp/obey-campaign.git
 
   # Clone to a specific directory
-  camp clone git@github.com:org/repo.git my-campaign
+  camp clone git@github.com:org/repo.git my-camp
 
   # Clone a specific branch
   camp clone git@github.com:org/repo.git --branch develop
@@ -85,7 +85,7 @@ camp clone <url> [directory] [flags]
       --from string     Seed git objects from this machine (id from ~/.obey/machines.yaml), then fetch the delta from origin
   -h, --help            help for clone
       --json            Output results as JSON for scripting
-      --no-register     Skip auto-registration in global campaign registry
+      --no-register     Skip auto-registration in global camp registry
       --no-submodules   Skip submodule initialization
       --no-validate     Skip post-clone validation
   -p, --parallel int    Number of parallel submodule initializations (default 4)
@@ -100,4 +100,4 @@ camp clone <url> [directory] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_commit.md
+++ b/docs/cli-reference/camp/camp_commit.md
@@ -1,21 +1,21 @@
 ---
 title: "camp commit"
 linkTitle: "camp commit"
-description: "Commit changes in the campaign root"
+description: "Commit changes in the camp root"
 ---
 
 ## camp commit
 
-Commit changes in the campaign root
+Commit changes in the camp root
 
 ### Synopsis
 
-Commit changes in the campaign root directory.
+Commit changes in the camp root directory.
 
 Automatically stages all changes and creates a commit. Handles
 stale lock files from crashed processes.
 
-At the campaign root, submodule ref changes (projects/*) are excluded
+At the camp root, submodule ref changes (projects/*) are excluded
 from staging by default to prevent accidental ref conflicts across
 machines. Use --include-refs to stage them explicitly.
 
@@ -46,7 +46,7 @@ camp commit [flags]
       --commit-large          Commit over-threshold files instead of keeping them out of git
       --commit-nested         Commit undeclared nested git repositories as gitlinks instead of keeping them out of git
   -h, --help                  help for commit
-      --include-refs          Include submodule ref changes when staging at campaign root
+      --include-refs          Include submodule ref changes when staging at camp root
       --json                  Emit a JSON result on stdout; human output goes to stderr
   -m, --message stringArray   Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)
       --no-drain              Do not wait for camp's queued commits first
@@ -64,4 +64,4 @@ camp commit [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_completion.md
+++ b/docs/cli-reference/camp/camp_completion.md
@@ -28,7 +28,7 @@ See each sub-command's help for details on how to use the generated script.
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp completion bash](../camp_completion_bash/)	 - Generate the autocompletion script for bash
 * [camp completion fish](../camp_completion_fish/)	 - Generate the autocompletion script for fish
 * [camp completion powershell](../camp_completion_powershell/)	 - Generate the autocompletion script for powershell

--- a/docs/cli-reference/camp/camp_concepts.md
+++ b/docs/cli-reference/camp/camp_concepts.md
@@ -27,4 +27,4 @@ camp concepts [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_copy.md
+++ b/docs/cli-reference/camp/camp_copy.md
@@ -1,22 +1,22 @@
 ---
 title: "camp copy"
 linkTitle: "camp copy"
-description: "Copy a file or directory within the campaign"
+description: "Copy a file or directory within the camp"
 ---
 
 ## camp copy
 
-Copy a file or directory within the campaign
+Copy a file or directory within the camp
 
 ### Synopsis
 
-Copy a file or directory within the current campaign.
+Copy a file or directory within the current camp.
 
 Paths are resolved relative to the current directory, matching standard
 'cp' behavior and tab completion.
 
-Use @ prefix for campaign shortcuts (e.g., @p/fest, @f/active/).
-Available shortcuts are defined in campaign config.
+Use @ prefix for camp shortcuts (e.g., @p/fest, @f/active/).
+Available shortcuts are defined in camp config.
 
 If the destination is an existing directory or ends with '/', the source
 is placed inside it with the same basename. Directories are copied
@@ -49,4 +49,4 @@ camp copy <src> <dest> [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_create.md
+++ b/docs/cli-reference/camp/camp_create.md
@@ -1,16 +1,16 @@
 ---
 title: "camp create"
 linkTitle: "camp create"
-description: "Create a new campaign at the default campaigns directory"
+description: "Create a new camp at the default camps directory"
 ---
 
 ## camp create
 
-Create a new campaign at the default campaigns directory
+Create a new camp at the default camps directory
 
 ### Synopsis
 
-Create a new campaign at <campaigns_dir>/<name>/, using the same scaffolding as 'camp init'. The default campaigns directory is ~/campaigns/ and can be configured via 'camp settings' or by editing the campaigns_dir field in ~/.obey/campaign/config.json.
+Create a new camp at <campaigns_dir>/<name>/, using the same scaffolding as 'camp init'. The default camps directory is ~/campaigns/ and can be configured via 'camp settings' or by editing the campaigns_dir field in ~/.obey/campaign/config.json.
 
 ```
 camp create <name> [flags]
@@ -28,16 +28,16 @@ camp create <name> [flags]
 ### Options
 
 ```
-  -d, --description string   Campaign description
+  -d, --description string   Camp description
       --dry-run              Show what would be done without creating anything
   -h, --help                 help for create
-  -m, --mission string       Campaign mission statement
-  -n, --name string          Campaign display name (defaults to <name> positional)
+  -m, --mission string       Camp mission statement
+  -n, --name string          Camp display name (defaults to <name> positional)
       --no-git               Skip git repository initialization
-      --no-skills            Skip linking campaign skills into .claude/skills and .agents/skills
-      --org string           Assign the new campaign to this org (created if new; defaults to the fallback org)
-      --path string          Override the base campaigns directory (campaign created at <path>/<name>/)
-  -t, --type string          Campaign type (product, research, tools, personal) (default "product")
+      --no-skills            Skip linking camp skills into .claude/skills and .agents/skills
+      --org string           Assign the new camp to this org (created if new; defaults to the fallback org)
+      --path string          Override the base camps directory (camp created at <path>/<name>/)
+  -t, --type string          Camp type (product, research, tools, personal) (default "product")
 ```
 
 ### Options inherited from parent commands
@@ -48,4 +48,4 @@ camp create <name> [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_date.md
+++ b/docs/cli-reference/camp/camp_date.md
@@ -51,4 +51,4 @@ camp date <path> [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_detach.md
+++ b/docs/cli-reference/camp/camp_detach.md
@@ -1,25 +1,25 @@
 ---
 title: "camp detach"
 linkTitle: "camp detach"
-description: "Remove the current campaign's attachment binding"
+description: "Remove the current camp's attachment binding"
 ---
 
 ## camp detach
 
-Remove the current campaign's attachment binding
+Remove the current camp's attachment binding
 
 ### Synopsis
 
-Remove the current campaign's binding from the .camp attachment marker.
+Remove the current camp's binding from the .camp attachment marker.
 
 Refuses on linked-project markers; use 'camp project unlink' for those.
-The user-managed symlink (if any) is not modified. If run outside any campaign,
+The user-managed symlink (if any) is not modified. If run outside any camp,
 the entire attachment marker is removed.
 
-On an attachment shared by several campaigns this removes only the current
-campaign's binding; the others keep resolving. Detaching the campaign that a
+On an attachment shared by several camps this removes only the current
+camp's binding; the others keep resolving. Detaching the camp that a
 bare cd into the shared target resolved to shifts that fallback to the next
-remaining campaign.
+remaining camp.
 
 Examples:
   camp detach docs/examples/external-repo
@@ -43,4 +43,4 @@ camp detach <path> [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_doctor.md
+++ b/docs/cli-reference/camp/camp_doctor.md
@@ -1,16 +1,16 @@
 ---
 title: "camp doctor"
 linkTitle: "camp doctor"
-description: "Diagnose and fix campaign health issues"
+description: "Diagnose and fix camp health issues"
 ---
 
 ## camp doctor
 
-Diagnose and fix campaign health issues
+Diagnose and fix camp health issues
 
 ### Synopsis
 
-Check campaign for common issues and optionally fix them.
+Check camp for common issues and optionally fix them.
 
 CHECKS PERFORMED:
   orphan      Orphaned gitlinks in index (no .gitmodules entry)
@@ -68,4 +68,4 @@ camp doctor [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_dungeon.md
+++ b/docs/cli-reference/camp/camp_dungeon.md
@@ -1,16 +1,16 @@
 ---
 title: "camp dungeon"
 linkTitle: "camp dungeon"
-description: "Manage the campaign dungeon"
+description: "Manage the camp dungeon"
 ---
 
 ## camp dungeon
 
-Manage the campaign dungeon
+Manage the camp dungeon
 
 ### Synopsis
 
-Manage the campaign dungeon - a holding area for uncertain work.
+Manage the camp dungeon - a holding area for uncertain work.
 
 The dungeon is where you put work you're unsure about or want out of the way.
 It keeps items visible without them competing for your attention.
@@ -46,9 +46,9 @@ camp dungeon [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp dungeon add](../camp_dungeon_add/)	 - Initialize dungeon structure
 * [camp dungeon crawl](../camp_dungeon_crawl/)	 - Interactive dungeon review
 * [camp dungeon list](../camp_dungeon_list/)	 - List dungeon items
-* [camp dungeon migrate](../camp_dungeon_migrate/)	 - Convert every campaign dungeon to the hidden .dungeon spelling
+* [camp dungeon migrate](../camp_dungeon_migrate/)	 - Convert every camp dungeon to the hidden .dungeon spelling
 * [camp dungeon move](../camp_dungeon_move/)	 - Move dungeon items between statuses

--- a/docs/cli-reference/camp/camp_dungeon_add.md
+++ b/docs/cli-reference/camp/camp_dungeon_add.md
@@ -51,4 +51,4 @@ camp dungeon add [flags]
 
 ### SEE ALSO
 
-* [camp dungeon](../camp_dungeon/)	 - Manage the campaign dungeon
+* [camp dungeon](../camp_dungeon/)	 - Manage the camp dungeon

--- a/docs/cli-reference/camp/camp_dungeon_crawl.md
+++ b/docs/cli-reference/camp/camp_dungeon_crawl.md
@@ -20,7 +20,7 @@ Without flags, auto-detects what to crawl:
 Use --triage or --inner to force a specific mode.
 
 For each item, you'll be prompted to decide its fate.
-Triage mode includes a route-to-docs action for existing campaign-root docs/<subdirectory>.
+Triage mode includes a route-to-docs action for existing camp-root docs/<subdirectory>.
 Statistics are gathered when available (requires scc or fest).
 All decisions are logged to crawl.jsonl for history.
 
@@ -49,4 +49,4 @@ camp dungeon crawl [flags]
 
 ### SEE ALSO
 
-* [camp dungeon](../camp_dungeon/)	 - Manage the campaign dungeon
+* [camp dungeon](../camp_dungeon/)	 - Manage the camp dungeon

--- a/docs/cli-reference/camp/camp_dungeon_list.md
+++ b/docs/cli-reference/camp/camp_dungeon_list.md
@@ -15,7 +15,7 @@ List items in the dungeon or parent items eligible for triage.
 By default, lists items at the dungeon root (items already in the dungeon).
 Use --triage to list parent directory items that could be moved into the dungeon.
 The command resolves dungeon context by walking from the current directory up to
-campaign root and using the nearest available dungeon.
+camp root and using the nearest available dungeon.
 
 OUTPUT FORMATS:
   table (default)   Human-readable table with columns
@@ -51,4 +51,4 @@ camp dungeon list [flags]
 
 ### SEE ALSO
 
-* [camp dungeon](../camp_dungeon/)	 - Manage the campaign dungeon
+* [camp dungeon](../camp_dungeon/)	 - Manage the camp dungeon

--- a/docs/cli-reference/camp/camp_dungeon_migrate.md
+++ b/docs/cli-reference/camp/camp_dungeon_migrate.md
@@ -1,20 +1,20 @@
 ---
 title: "camp dungeon migrate"
 linkTitle: "camp dungeon migrate"
-description: "Convert every campaign dungeon to the hidden .dungeon spelling"
+description: "Convert every camp dungeon to the hidden .dungeon spelling"
 ---
 
 ## camp dungeon migrate
 
-Convert every campaign dungeon to the hidden .dungeon spelling
+Convert every camp dungeon to the hidden .dungeon spelling
 
 ### Synopsis
 
-Convert every dungeon in this campaign from "dungeon" to ".dungeon".
+Convert every dungeon in this camp from "dungeon" to ".dungeon".
 
-New campaigns hide the dungeon so it stops being the first thing newcomers ask
-about. This converts a campaign made before that change. A campaign uses one
-spelling throughout, so the sweep covers every dungeon at once: the campaign
+New camps hide the dungeon so it stops being the first thing newcomers ask
+about. This converts a camp made before that change. A camp uses one
+spelling throughout, so the sweep covers every dungeon at once: the camp
 root, festivals/, .campaign/intents/, .campaign/quests/, and each workflow
 type. Dungeons are discovered on disk, so locations added since this command
 was written are included too.
@@ -23,10 +23,10 @@ The move goes through git, so history and rename detection survive, and lands
 as a single commit you can revert.
 
 projects/ is never touched. Projects own their own trees, and a source
-directory named "dungeon" inside one is not a campaign dungeon.
+directory named "dungeon" inside one is not a camp dungeon.
 
-Release ordering matters when a campaign contains festivals/: this command
-also renames festivals/dungeon. Do not run it against a campaign used by a
+Release ordering matters when a camp contains festivals/: this command
+also renames festivals/dungeon. Do not run it against a camp used by a
 fest build that does not understand .dungeon. Land fest#274 and ship a fest
 release with the matching support before making this migration available to
 users.
@@ -63,4 +63,4 @@ camp dungeon migrate [flags]
 
 ### SEE ALSO
 
-* [camp dungeon](../camp_dungeon/)	 - Manage the campaign dungeon
+* [camp dungeon](../camp_dungeon/)	 - Manage the camp dungeon

--- a/docs/cli-reference/camp/camp_dungeon_move.md
+++ b/docs/cli-reference/camp/camp_dungeon_move.md
@@ -16,8 +16,8 @@ By default, moves an item already in the dungeon root to a status directory.
 When the item exists in the parent directory and not in the dungeon root, the
 command automatically treats it as triage work and moves it into the dungeon.
 Use --triage to force a parent-directory move.
-With --triage and --to-docs, routes items to an existing campaign-root docs/<subdirectory>.
-With --workitem, resolves a campaign workitem from anywhere and moves its directory
+With --triage and --to-docs, routes items to an existing camp-root docs/<subdirectory>.
+With --workitem, resolves a camp workitem from anywhere and moves its directory
 into the workitem type's local dungeon.
 Moves are always auto-committed so dungeon history remains auditable.
 
@@ -52,9 +52,9 @@ camp dungeon move <item>... [status] [flags]
       --dry-run          Preview the move(s) without touching the filesystem or creating a commit
   -h, --help             help for move
       --json             Emit the dry-run plan as JSON (requires --dry-run)
-      --to-docs string   Route triage item into an existing campaign-root docs/<subdir> (requires --triage)
+      --to-docs string   Route triage item into an existing camp-root docs/<subdir> (requires --triage)
       --triage           Move from parent directory (not from dungeon root)
-      --workitem         Resolve item as a campaign workitem and move its directory to the local dungeon
+      --workitem         Resolve item as a camp workitem and move its directory to the local dungeon
 ```
 
 ### Options inherited from parent commands
@@ -65,4 +65,4 @@ camp dungeon move <item>... [status] [flags]
 
 ### SEE ALSO
 
-* [camp dungeon](../camp_dungeon/)	 - Manage the campaign dungeon
+* [camp dungeon](../camp_dungeon/)	 - Manage the camp dungeon

--- a/docs/cli-reference/camp/camp_festivals.md
+++ b/docs/cli-reference/camp/camp_festivals.md
@@ -1,24 +1,24 @@
 ---
 title: "camp festivals"
 linkTitle: "camp festivals"
-description: "List festivals across campaigns, filtered by org/tag"
+description: "List festivals across camps, filtered by org/tag"
 ---
 
 ## camp festivals
 
-List festivals across campaigns, filtered by org/tag
+List festivals across camps, filtered by org/tag
 
 ### Synopsis
 
-Aggregate festivals across campaigns, filtered by campaign org/tag.
+Aggregate festivals across camps, filtered by camp org/tag.
 
-Selects campaigns from the registry by --org and --tag (AND), then composes
-'fest list --json' in each matching campaign and aggregates the result. The
-campaign set defaults to active campaigns; --all-campaigns includes inactive and
-reference campaigns. Festival-level flags (--status, --all, --since, --until,
+Selects camps from the registry by --org and --tag (AND), then composes
+'fest list --json' in each matching camp and aggregates the result. The
+camp set defaults to active camps; --all-campaigns includes inactive and
+reference camps. Festival-level flags (--status, --all, --since, --until,
 --sort) are passed through to each underlying 'fest list'.
 
-Runs one 'fest list' per matching campaign (sequentially); campaigns without a
+Runs one 'fest list' per matching camp (sequentially); camps without a
 festivals/ workspace contribute nothing. Read-only.
 
 ```
@@ -37,15 +37,15 @@ camp festivals [flags]
 
 ```
       --all             Include completed/dungeon festivals, passed to fest list
-      --all-campaigns   Include inactive/reference campaigns (default: active only)
+      --all-campaigns   Include inactive/reference camps (default: active only)
   -h, --help            help for festivals
   -i, --interactive     Open the interactive festivals browser
       --json            Output as JSON
-      --org string      Only campaigns in this org
+      --org string      Only camps in this org
       --since string    Festivals created on or after this date, passed to fest list
       --sort string     Festival sort, passed to fest list
       --status string   Festival status filter, passed to fest list
-      --tag strings     Only campaigns carrying this tag (repeat for AND)
+      --tag strings     Only camps carrying this tag (repeat for AND)
       --until string    Festivals created on or before this date, passed to fest list
 ```
 
@@ -57,4 +57,4 @@ camp festivals [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_fresh.md
+++ b/docs/cli-reference/camp/camp_fresh.md
@@ -18,7 +18,7 @@ branches, and optionally create a new working branch.
 
 Auto-detects the current project from your working directory, or accepts a
 single project name. Use --list to cycle a specific set of projects in one
-run, or 'camp fresh all' to cycle every project submodule in the campaign.
+run, or 'camp fresh all' to cycle every project submodule in the camp.
 
 Without configuration, syncs to the default branch and prunes.
 Configure .campaign/settings/fresh.yaml to set a default working branch, or
@@ -30,7 +30,7 @@ WORKITEM COMPLETION
 
 Two fresh.yaml settings decide what happens to workitems whose work looks done:
 
-  completed_runs     Tier 1, once per run, campaign-root scoped. "prompt"
+  completed_runs     Tier 1, once per run, camp-root scoped. "prompt"
                      (default) asks per workitem on a TTY and reports otherwise,
                      "report" prints a read-only banner and the reason for every
                      non-move, "sweep" promotes automatically (the pre-2026-08
@@ -101,7 +101,7 @@ camp fresh [project-name] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp fresh all](../camp_fresh_all/)	 - Run fresh across all project submodules
 * [camp fresh configure](../camp_fresh_configure/)	 - Configure the camp fresh workflow
 * [camp fresh show-workflow](../camp_fresh_show-workflow/)	 - Show the fresh cycle and configured follow-up steps

--- a/docs/cli-reference/camp/camp_fresh_all.md
+++ b/docs/cli-reference/camp/camp_fresh_all.md
@@ -11,7 +11,7 @@ Run fresh across all project submodules
 ### Synopsis
 
 Run the fresh cycle (fetch and safely sync default, prune, optional branch)
-across every project submodule in the campaign.
+across every project submodule in the camp.
 
 Examples:
   camp fresh all                     # Sync all projects

--- a/docs/cli-reference/camp/camp_fresh_configure.md
+++ b/docs/cli-reference/camp/camp_fresh_configure.md
@@ -11,7 +11,7 @@ Configure the camp fresh workflow
 ### Synopsis
 
 Configure what camp fresh does after a merge. Configuration lives in
-.campaign/settings/fresh.yaml, as campaign-wide defaults plus optional
+.campaign/settings/fresh.yaml, as camp-wide defaults plus optional
 per-project overrides.
 
 Run without a subcommand to open the interactive setup for humans, which
@@ -22,7 +22,7 @@ groups the fresh sequence by what you can change about each step:
   Follow-ups  your own commands, run after a successful cycle
 
 Press enter on a settings step to change it, and a/e/d/K/J on a follow-up to
-add, edit, delete, or reorder it. prune and prune_remote are campaign-wide,
+add, edit, delete, or reorder it. prune and prune_remote are camp-wide,
 so they are changed under Global defaults rather than under a project.
 
 The subcommands below cover follow-ups only, for scripts and agents; edit the

--- a/docs/cli-reference/camp/camp_gather.md
+++ b/docs/cli-reference/camp/camp_gather.md
@@ -37,7 +37,7 @@ camp gather [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp gather design](../camp_gather_design/)	 - Combine selected design workitems into one gathered package
 * [camp gather explore](../camp_gather_explore/)	 - Combine selected explore workitems into one gathered package
 * [camp gather feedback](../camp_gather_feedback/)	 - Gather feedback observations from festivals into intents

--- a/docs/cli-reference/camp/camp_gather_design.md
+++ b/docs/cli-reference/camp/camp_gather_design.md
@@ -23,7 +23,7 @@ The gather process:
      the rename)
   3. Stamp gathered_into/gathered_at on each source .workitem
   4. Migrate manual priority state and re-home workitem links
-  5. Rewrite campaign markdown and quest links that pointed at the sources
+  5. Rewrite camp markdown and quest links that pointed at the sources
   6. Commit the move (unless --no-commit)
 
 Moved sources stop appearing as separate workitems because discovery only

--- a/docs/cli-reference/camp/camp_gather_explore.md
+++ b/docs/cli-reference/camp/camp_gather_explore.md
@@ -23,7 +23,7 @@ The gather process:
      the rename)
   3. Stamp gathered_into/gathered_at on each source .workitem
   4. Migrate manual priority state and re-home workitem links
-  5. Rewrite campaign markdown and quest links that pointed at the sources
+  5. Rewrite camp markdown and quest links that pointed at the sources
   6. Commit the move (unless --no-commit)
 
 Moved sources stop appearing as separate workitems because discovery only

--- a/docs/cli-reference/camp/camp_go.md
+++ b/docs/cli-reference/camp/camp_go.md
@@ -1,20 +1,20 @@
 ---
 title: "camp go"
 linkTitle: "camp go"
-description: "Navigate to campaign directories"
+description: "Navigate to camp directories"
 ---
 
 ## camp go
 
-Navigate to campaign directories
+Navigate to camp directories
 
 ### Synopsis
 
-Navigate within the campaign using shortcuts.
+Navigate within the camp using shortcuts.
 
 Usage patterns:
-  camp go           Toggle between campaign root and last location
-  camp go --root    Jump to campaign root (ignore toggle)
+  camp go           Toggle between camp root and last location
+  camp go --root    Jump to camp root (ignore toggle)
   camp go t         Jump to last visited location (cd - equivalent)
   camp go p         Jump to projects/
   camp go f         Jump to festivals/
@@ -22,8 +22,8 @@ Usage patterns:
   camp go p api     Fuzzy search projects/ for "api"
 
 Toggle behavior (no args):
-  - From anywhere: jump to campaign root, save current location
-  - From campaign root: jump back to saved location
+  - From anywhere: jump to camp root, save current location
+  - From camp root: jump back to saved location
 
 Toggle keyword (t / toggle):
   - Jump to the last visited location regardless of where you are
@@ -55,7 +55,7 @@ camp go [shortcut] [query...] [flags]
 
 ```
   camp go               # Toggle: root ↔ last location
-  camp go --root        # Force jump to campaign root
+  camp go --root        # Force jump to camp root
   camp go t             # Jump to last visited location (cd -)
   camp go p             # Jump to projects/
   camp go design        # Jump to exact pin "design"
@@ -73,7 +73,7 @@ camp go [shortcut] [query...] [flags]
   -h, --help                  help for go
   -l, --list                  List available sub-shortcuts for a project
       --print                 Print path only (for shell integration)
-      --root                  Jump to campaign root (ignore last location)
+      --root                  Jump to camp root (ignore last location)
 ```
 
 ### Options inherited from parent commands
@@ -84,4 +84,4 @@ camp go [shortcut] [query...] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_id.md
+++ b/docs/cli-reference/camp/camp_id.md
@@ -1,16 +1,16 @@
 ---
 title: "camp id"
 linkTitle: "camp id"
-description: "Print the current campaign ID"
+description: "Print the current camp ID"
 ---
 
 ## camp id
 
-Print the current campaign ID
+Print the current camp ID
 
 ### Synopsis
 
-Print the current campaign ID from .campaign/campaign.yaml.
+Print the current camp ID from .campaign/campaign.yaml.
 
 ```
 camp id [flags]
@@ -36,4 +36,4 @@ camp id [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_idea.md
+++ b/docs/cli-reference/camp/camp_idea.md
@@ -1,12 +1,12 @@
 ---
 title: "camp idea"
 linkTitle: "camp idea"
-description: "Manage campaign ideas"
+description: "Manage camp ideas"
 ---
 
 ## camp idea
 
-Manage campaign ideas
+Manage camp ideas
 
 ### Synopsis
 
@@ -58,7 +58,7 @@ camp idea [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp idea add](../camp_idea_add/)	 - Create a new idea
 * [camp idea archive](../camp_idea_archive/)	 - Archive an idea
 * [camp idea claim](../camp_idea_claim/)	 - Claim an intent for an agent or session
@@ -69,7 +69,7 @@ camp idea [flags]
 * [camp idea explore](../camp_idea_explore/)	 - Interactive idea explorer
 * [camp idea find](../camp_idea_find/)	 - Search for ideas by title or content
 * [camp idea gather](../camp_idea_gather/)	 - Gather related ideas into a unified document
-* [camp idea list](../camp_idea_list/)	 - List ideas in the campaign
+* [camp idea list](../camp_idea_list/)	 - List ideas in the camp
 * [camp idea move](../camp_idea_move/)	 - Move idea to a different status
 * [camp idea note](../camp_idea_note/)	 - Capture a quick note
 * [camp idea notes](../camp_idea_notes/)	 - Manage the note store (folders, moves, meetings)

--- a/docs/cli-reference/camp/camp_idea_add.md
+++ b/docs/cli-reference/camp/camp_idea_add.md
@@ -37,7 +37,7 @@ Examples:
   camp idea add "Add dark mode"        Ultra-fast capture
   camp idea add -c obey-campaign "Add dark mode"
   camp idea add                        Fast TUI (3-step form)
-  camp idea add --campaign             Pick a target campaign interactively
+  camp idea add --campaign             Pick a target camp interactively
   camp idea add --full                 Full TUI (includes body)
   camp idea add --note                 Note TUI (title + body, no type/concept)
   camp idea add --note "Meeting note" --body "Follow up next week"
@@ -57,7 +57,7 @@ camp idea add [title] [flags]
       --author string      Override the default author attribution
       --body string        Set idea body as a literal string
       --body-file string   Read idea body from file (- for stdin, 10 MiB cap)
-  -c, --campaign string    Target campaign by name or ID; omit value to pick interactively
+  -c, --campaign string    Target camp by name or ID; omit value to pick interactively
       --concept string     Set the concept field (e.g., projects/camp)
   -e, --edit               Open in $EDITOR for deep capture
       --full               Full TUI mode with body textarea
@@ -77,4 +77,4 @@ camp idea add [title] [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_archive.md
+++ b/docs/cli-reference/camp/camp_idea_archive.md
@@ -42,4 +42,4 @@ camp idea archive <id> [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_claim.md
+++ b/docs/cli-reference/camp/camp_idea_claim.md
@@ -10,7 +10,7 @@ Claim an intent for an agent or session
 
 ### Synopsis
 
-Assign an intent to an agent so the campaign tracks who is working it.
+Assign an intent to an agent so the camp tracks who is working it.
 
 Stamps assigned_to and assigned_at, and merges any --ref values (a PR URL,
 branch, or festival path) into work_ref. Calling claim again on an
@@ -47,4 +47,4 @@ camp idea claim <id> [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_convert.md
+++ b/docs/cli-reference/camp/camp_idea_convert.md
@@ -40,4 +40,4 @@ camp idea convert <id> [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_count.md
+++ b/docs/cli-reference/camp/camp_idea_count.md
@@ -40,4 +40,4 @@ camp idea count [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_crawl.md
+++ b/docs/cli-reference/camp/camp_idea_crawl.md
@@ -47,4 +47,4 @@ camp idea crawl [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_edit.md
+++ b/docs/cli-reference/camp/camp_idea_edit.md
@@ -87,4 +87,4 @@ camp idea edit [id] [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_explore.md
+++ b/docs/cli-reference/camp/camp_idea_explore.md
@@ -72,4 +72,4 @@ camp idea explore [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_find.md
+++ b/docs/cli-reference/camp/camp_idea_find.md
@@ -47,4 +47,4 @@ camp idea find [query] [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_gather.md
+++ b/docs/cli-reference/camp/camp_idea_gather.md
@@ -75,4 +75,4 @@ camp idea gather [ids...] [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_list.md
+++ b/docs/cli-reference/camp/camp_idea_list.md
@@ -1,12 +1,12 @@
 ---
 title: "camp idea list"
 linkTitle: "camp idea list"
-description: "List ideas in the campaign"
+description: "List ideas in the camp"
 ---
 
 ## camp idea list
 
-List ideas in the campaign
+List ideas in the camp
 
 ### Synopsis
 
@@ -58,4 +58,4 @@ camp idea list [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_move.md
+++ b/docs/cli-reference/camp/camp_idea_move.md
@@ -53,4 +53,4 @@ camp idea move <id> <status> [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_note.md
+++ b/docs/cli-reference/camp/camp_idea_note.md
@@ -49,4 +49,4 @@ camp idea note [text] [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_notes.md
+++ b/docs/cli-reference/camp/camp_idea_notes.md
@@ -10,7 +10,7 @@ Manage the note store (folders, moves, meetings)
 
 ### Synopsis
 
-Manage the campaign note store under .campaign/intents/notes/.
+Manage the camp note store under .campaign/intents/notes/.
 
 Use "camp idea note" to capture a note. This command group manages folders
 and placement of notes already in the store.
@@ -41,7 +41,7 @@ camp idea notes [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas
 * [camp idea notes folders](../camp_idea_notes_folders/)	 - List note folders
 * [camp idea notes import-meeting](../camp_idea_notes_import-meeting/)	 - Import a meeting bundle into notes/meetings/
 * [camp idea notes mv](../camp_idea_notes_mv/)	 - Move a note into a folder

--- a/docs/cli-reference/camp/camp_idea_promote.md
+++ b/docs/cli-reference/camp/camp_idea_promote.md
@@ -48,4 +48,4 @@ camp idea promote <id> [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_release.md
+++ b/docs/cli-reference/camp/camp_idea_release.md
@@ -36,4 +36,4 @@ camp idea release <id> [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_rename.md
+++ b/docs/cli-reference/camp/camp_idea_rename.md
@@ -38,4 +38,4 @@ camp idea rename <id> <new title> [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_show.md
+++ b/docs/cli-reference/camp/camp_idea_show.md
@@ -48,4 +48,4 @@ camp idea show <id> [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_idea_sync.md
+++ b/docs/cli-reference/camp/camp_idea_sync.md
@@ -44,4 +44,4 @@ camp idea sync [flags]
 
 ### SEE ALSO
 
-* [camp idea](../camp_idea/)	 - Manage campaign ideas
+* [camp idea](../camp_idea/)	 - Manage camp ideas

--- a/docs/cli-reference/camp/camp_init.md
+++ b/docs/cli-reference/camp/camp_init.md
@@ -1,19 +1,19 @@
 ---
 title: "camp init"
 linkTitle: "camp init"
-description: "Initialize a new campaign"
+description: "Initialize a new camp"
 ---
 
 ## camp init
 
-Initialize a new campaign
+Initialize a new camp
 
 ### Synopsis
 
-Initialize a new campaign directory structure.
+Initialize a new camp directory structure.
 
-Creates the standard campaign directories:
-  .campaign/              - Campaign configuration and metadata
+Creates the standard camp directories:
+  .campaign/              - Camp configuration and metadata
   .campaign/intents/      - System-managed intent state
   projects/               - Project repositories (submodules or worktrees)
   projects/worktrees/     - Git worktrees for parallel development
@@ -30,6 +30,10 @@ Also creates:
 
 Initializes a git repository if not already inside one.
 
+Camp metadata lives in the directory named .campaign/. That name is stable and
+Camp expects it, so do not rename it. The separate .camp file is an attachment
+marker for linked external directories, not a replacement for .campaign/.
+
 Use --no-git to skip git initialization.
 
 ```
@@ -40,8 +44,8 @@ camp init [path] [flags]
 
 ```
   camp init                      Initialize current directory
-  camp init my-campaign          Create and initialize new directory
-  camp init --name "My Project"  Set custom campaign name
+  camp init my-camp          Create and initialize new directory
+  camp init --name "My Project"  Set custom camp name
   camp init --no-git             Skip git initialization
   camp init --dry-run            Preview without creating anything
 ```
@@ -49,18 +53,18 @@ camp init [path] [flags]
 ### Options
 
 ```
-  -d, --description string   Campaign description
+  -d, --description string   Camp description
       --dry-run              Show what would be done without creating anything
   -f, --force                Initialize in non-empty directory without prompting
   -h, --help                 help for init
-  -m, --mission string       Campaign mission statement
-  -n, --name string          Campaign name (defaults to directory name)
+  -m, --mission string       Camp mission statement
+  -n, --name string          Camp name (defaults to directory name)
       --no-git               Skip git repository initialization
       --no-register          Don't add to global registry
-      --no-skills            Skip linking campaign skills into .claude/skills and .agents/skills
-      --org string           Assign the new campaign to this org (created if new; defaults to the fallback org)
-      --repair               Add missing files to existing campaign
-  -t, --type string          Campaign type (product, research, tools, personal) (default "product")
+      --no-skills            Skip linking camp skills into .claude/skills and .agents/skills
+      --org string           Assign the new camp to this org (created if new; defaults to the fallback org)
+      --repair               Add missing files to existing camp
+  -t, --type string          Camp type (product, research, tools, personal) (default "product")
   -v, --verbose              Show skipped optional setup details
       --yes                  Skip repair confirmation prompt (for scripting)
 ```
@@ -73,4 +77,4 @@ camp init [path] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_jobs.md
+++ b/docs/cli-reference/camp/camp_jobs.md
@@ -21,7 +21,8 @@ normal use: workers start themselves, and every command that touches git
 history waits for the queue before it runs.
 
 Examples:
-  camp jobs                    # what is queued, running, or failed
+  camp jobs                    # interactive browser in a TTY; table otherwise
+  camp jobs --plain            # always print the table
   camp jobs --json             # the same, for scripts and agents
   camp jobs retry all          # requeue everything that failed
   camp jobs drop <id>          # give up on one job, keeping its content
@@ -34,8 +35,10 @@ camp jobs [flags]
 ### Options
 
 ```
-  -h, --help   help for jobs
-      --json   Emit a structured JSON result
+  -h, --help          help for jobs
+  -i, --interactive   Open the interactive jobs browser (prints the table when stdout is not a terminal)
+      --json          Emit a structured JSON result
+      --plain         Print the table even when stdout is a terminal
 ```
 
 ### Options inherited from parent commands
@@ -46,7 +49,7 @@ camp jobs [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp jobs drain](../camp_jobs_drain/)	 - Wait until every lane is empty
 * [camp jobs drop](../camp_jobs_drop/)	 - Give up on failed jobs, keeping their content
 * [camp jobs retry](../camp_jobs_retry/)	 - Requeue failed jobs

--- a/docs/cli-reference/camp/camp_jobs_drain.md
+++ b/docs/cli-reference/camp/camp_jobs_drain.md
@@ -10,7 +10,7 @@ Wait until every lane is empty
 
 ### Synopsis
 
-Block until no queued commit is outstanding anywhere in the campaign.
+Block until no queued commit is outstanding anywhere in the camp.
 
 Commands that touch git history already do this for the repo they act on, so
 this is for the cases that are not one command: before archiving a machine,

--- a/docs/cli-reference/camp/camp_jobs_run.md
+++ b/docs/cli-reference/camp/camp_jobs_run.md
@@ -28,7 +28,7 @@ camp jobs run [flags]
 ### Options
 
 ```
-      --campaign string   Campaign root to serve (defaults to the detected campaign)
+      --campaign string   Camp root to serve (defaults to the detected camp)
   -h, --help              help for run
 ```
 

--- a/docs/cli-reference/camp/camp_leverage.md
+++ b/docs/cli-reference/camp/camp_leverage.md
@@ -1,12 +1,12 @@
 ---
 title: "camp leverage"
 linkTitle: "camp leverage"
-description: "Compute leverage scores for campaign projects"
+description: "Compute leverage scores for the camp's projects"
 ---
 
 ## camp leverage
 
-Compute leverage scores for campaign projects
+Compute leverage scores for the camp's projects
 
 ### Synopsis
 
@@ -18,6 +18,11 @@ traditional estimation models predict for the same team and time.
 
   FullLeverage   = (EstimatedPeople x EstimatedMonths) / (ActualPeople x ElapsedMonths)
   SimpleLeverage = EstimatedPeople / ActualPeople
+
+Leverage commands commit the data they write under .campaign/leverage so the
+score history stays versioned without extra steps. Nothing outside that
+directory is staged. Pass --no-commit to skip it once, or run
+'camp leverage config --autocommit=false' to turn it off for the camp.
 
 Examples:
   camp leverage                              Show team leverage (auto-detect authors from git)
@@ -38,9 +43,10 @@ camp leverage [directory] [flags]
 ```
       --author string    filter by author email (git substring match: 'alice@co' matches 'alice@co.com')
       --by-author        show per-author leverage breakdown
-      --dir string       score a specific directory (skips campaign project resolution)
+      --dir string       score a specific directory (skips camp project resolution)
   -h, --help             help for leverage
       --json             output as JSON
+      --no-commit        skip the automatic commit of .campaign/leverage data
       --no-legend        hide the leverage formula legend
       --people int       override team size (0 = auto-detect from git)
   -p, --project string   filter by project name
@@ -55,7 +61,7 @@ camp leverage [directory] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp leverage backfill](../camp_leverage_backfill/)	 - Reconstruct historical leverage data from git history
 * [camp leverage config](../camp_leverage_config/)	 - View or update leverage configuration
 * [camp leverage history](../camp_leverage_history/)	 - Show leverage score history over time

--- a/docs/cli-reference/camp/camp_leverage_backfill.md
+++ b/docs/cli-reference/camp/camp_leverage_backfill.md
@@ -33,6 +33,7 @@ camp leverage backfill [flags]
 
 ```
   -h, --help             help for backfill
+      --no-commit        skip the automatic commit of .campaign/leverage data
   -p, --project string   backfill a single project
       --since string     start date (YYYY-MM-DD), overrides config project_start
   -w, --workers int      number of parallel workers (default 4)
@@ -46,4 +47,4 @@ camp leverage backfill [flags]
 
 ### SEE ALSO
 
-* [camp leverage](../camp_leverage/)	 - Compute leverage scores for campaign projects
+* [camp leverage](../camp_leverage/)	 - Compute leverage scores for the camp's projects

--- a/docs/cli-reference/camp/camp_leverage_config.md
+++ b/docs/cli-reference/camp/camp_leverage_config.md
@@ -21,6 +21,7 @@ Configuration parameters:
   --cocomo-type  COCOMO project type (organic, semi-detached, embedded)
   --exclude      Exclude a project from leverage scoring
   --include      Include a previously excluded project
+  --autocommit   Commit .campaign/leverage data automatically (default true)
 
 Examples:
   camp leverage config                         Show current config
@@ -28,6 +29,7 @@ Examples:
   camp leverage config --start 2025-01-01      Set project start date
   camp leverage config --exclude obey-daemon   Exclude a project
   camp leverage config --include obey-daemon   Re-include a project
+  camp leverage config --autocommit=false      Stop auto-committing leverage data
 
 ```
 camp leverage config [flags]
@@ -37,10 +39,12 @@ camp leverage config [flags]
 
 ```
       --author-email string   default author email for personal leverage (empty = team view)
+      --autocommit            commit .campaign/leverage data automatically after leverage commands (default true)
       --cocomo-type string    COCOMO project type (organic, semi-detached, embedded)
       --exclude string        exclude a project from leverage scoring
   -h, --help                  help for config
       --include string        include a previously excluded project
+      --no-commit             skip the automatic commit of .campaign/leverage data
       --people int            number of developers on the team (0 = auto-detect from git)
       --start string          project start date (YYYY-MM-DD)
 ```
@@ -53,4 +57,4 @@ camp leverage config [flags]
 
 ### SEE ALSO
 
-* [camp leverage](../camp_leverage/)	 - Compute leverage scores for campaign projects
+* [camp leverage](../camp_leverage/)	 - Compute leverage scores for the camp's projects

--- a/docs/cli-reference/camp/camp_leverage_history.md
+++ b/docs/cli-reference/camp/camp_leverage_history.md
@@ -48,4 +48,4 @@ camp leverage history [flags]
 
 ### SEE ALSO
 
-* [camp leverage](../camp_leverage/)	 - Compute leverage scores for campaign projects
+* [camp leverage](../camp_leverage/)	 - Compute leverage scores for the camp's projects

--- a/docs/cli-reference/camp/camp_leverage_reset.md
+++ b/docs/cli-reference/camp/camp_leverage_reset.md
@@ -28,6 +28,7 @@ camp leverage reset [flags]
 
 ```
   -h, --help             help for reset
+      --no-commit        skip the automatic commit of .campaign/leverage data
   -p, --project string   clear snapshots for a single project
 ```
 
@@ -39,4 +40,4 @@ camp leverage reset [flags]
 
 ### SEE ALSO
 
-* [camp leverage](../camp_leverage/)	 - Compute leverage scores for campaign projects
+* [camp leverage](../camp_leverage/)	 - Compute leverage scores for the camp's projects

--- a/docs/cli-reference/camp/camp_leverage_snapshot.md
+++ b/docs/cli-reference/camp/camp_leverage_snapshot.md
@@ -31,6 +31,7 @@ camp leverage snapshot [flags]
 
 ```
   -h, --help             help for snapshot
+      --no-commit        skip the automatic commit of .campaign/leverage data
   -p, --project string   snapshot a specific project only
 ```
 
@@ -42,4 +43,4 @@ camp leverage snapshot [flags]
 
 ### SEE ALSO
 
-* [camp leverage](../camp_leverage/)	 - Compute leverage scores for campaign projects
+* [camp leverage](../camp_leverage/)	 - Compute leverage scores for the camp's projects

--- a/docs/cli-reference/camp/camp_lifecycle.md
+++ b/docs/cli-reference/camp/camp_lifecycle.md
@@ -1,23 +1,23 @@
 ---
 title: "camp lifecycle"
 linkTitle: "camp lifecycle"
-description: "Manage campaign lifecycle status"
+description: "Manage camp lifecycle status"
 ---
 
 ## camp lifecycle
 
-Manage campaign lifecycle status
+Manage camp lifecycle status
 
 ### Synopsis
 
-Manage a campaign's lifecycle status.
+Manage a camp's lifecycle status.
 
 The status is one of a fixed set:
   active      in current use (default); shown in 'camp list'
   inactive    paused or shelved; hidden from default 'camp list'
   reference   preserved read-only context; hidden from default views
 
-Setting inactive or reference does not unregister the campaign; use
+Setting inactive or reference does not unregister the camp; use
 'camp unregister' to remove it from the registry entirely.
 
 This group is 'camp lifecycle', not 'camp status' ('camp status' is the git
@@ -48,6 +48,6 @@ camp lifecycle [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp lifecycle list](../camp_lifecycle_list/)	 - List status counts across the registry
-* [camp lifecycle set](../camp_lifecycle_set/)	 - Set a campaign's lifecycle status
+* [camp lifecycle set](../camp_lifecycle_set/)	 - Set a camp's lifecycle status

--- a/docs/cli-reference/camp/camp_lifecycle_list.md
+++ b/docs/cli-reference/camp/camp_lifecycle_list.md
@@ -33,4 +33,4 @@ camp lifecycle list [flags]
 
 ### SEE ALSO
 
-* [camp lifecycle](../camp_lifecycle/)	 - Manage campaign lifecycle status
+* [camp lifecycle](../camp_lifecycle/)	 - Manage camp lifecycle status

--- a/docs/cli-reference/camp/camp_lifecycle_set.md
+++ b/docs/cli-reference/camp/camp_lifecycle_set.md
@@ -1,22 +1,22 @@
 ---
 title: "camp lifecycle set"
 linkTitle: "camp lifecycle set"
-description: "Set a campaign's lifecycle status"
+description: "Set a camp's lifecycle status"
 ---
 
 ## camp lifecycle set
 
-Set a campaign's lifecycle status
+Set a camp's lifecycle status
 
 ### Synopsis
 
-Transition a campaign to one of: active, inactive, reference.
+Transition a camp to one of: active, inactive, reference.
 
 Any other value is rejected. Setting inactive or reference does not unregister
-the campaign.
+the camp.
 
 ```
-camp lifecycle set <campaign> <status> [flags]
+camp lifecycle set <camp> <status> [flags]
 ```
 
 ### Examples
@@ -40,4 +40,4 @@ camp lifecycle set <campaign> <status> [flags]
 
 ### SEE ALSO
 
-* [camp lifecycle](../camp_lifecycle/)	 - Manage campaign lifecycle status
+* [camp lifecycle](../camp_lifecycle/)	 - Manage camp lifecycle status

--- a/docs/cli-reference/camp/camp_list.md
+++ b/docs/cli-reference/camp/camp_list.md
@@ -1,24 +1,24 @@
 ---
 title: "camp list"
 linkTitle: "camp list"
-description: "List all registered campaigns"
+description: "List all registered camps"
 ---
 
 ## camp list
 
-List all registered campaigns
+List all registered camps
 
 ### Synopsis
 
-List all campaigns registered in the global registry.
+List all camps registered in the global registry.
 
-Campaigns are registered when created with 'camp init' or manually
+Camps are registered when created with 'camp init' or manually
 with 'camp register'. The registry lives at ~/.obey/campaign/registry.json.
 
 In a terminal, 'camp list' (with no flags) opens an interactive browser where you
-can deactivate/reactivate campaigns (cycle lifecycle status), reassign their org,
+can deactivate/reactivate camps (cycle lifecycle status), reassign their org,
 and copy paths. When machines are configured in ~/.obey/machines.yaml, press 'r'
-to load remote campaigns into the browser (not on open). Pass an org as a
+to load remote camps into the browser (not on open). Pass an org as a
 positional argument to open the browser filtered to that org. Piped, with
 --json/--count, or with any filter/sort flag it prints the table instead. Home
 paths display as '~'.
@@ -33,7 +33,7 @@ Bourne shell that is not bash or zsh; the bash script will not parse there.
 
 Output formats:
   table   - Aligned columns with headers (default)
-  simple  - Campaign names only, one per line
+  simple  - camp names only, one per line
   json    - JSON array for scripting
 
 Sorting options:
@@ -43,15 +43,15 @@ Sorting options:
   org      - By org (fallback first, then alphabetical), then by name
 
 Examples:
-  camp list                  List all campaigns
-  camp list obey             Browse campaigns in the obey org
+  camp list                  List all camps
+  camp list obey             Browse camps in the obey org
   camp list --json           Output as JSON
   camp list --format json    Output as JSON
   camp list --sort name      Sort by name
   camp list --sort org       Sort by org, then name
   camp list --format simple  Names only for scripting
-  camp list --count          Print only the total number of campaigns
-  camp list --remote         Also list campaigns on machines in ~/.obey/machines.yaml
+  camp list --count          Print only the total number of camps
+  camp list --remote         Also list camps on machines in ~/.obey/machines.yaml
 
 --remote runs each machine's own 'camp list --json' through that account's
 configured login shell ($SHELL -lc) so its login-profile PATH is picked up; when
@@ -60,7 +60,7 @@ locations (~/.local/bin, $GOBIN, $GOPATH/bin, ~/go/bin, Homebrew) before giving
 up. If camp lives somewhere else on a machine, set CAMP_REMOTE_CAMP_PATH to its
 exact path there. 'camp machine diagnose' shows which binary a hop would run.
 
-For interactive hop to a remote campaign from the picker, use csw after
+For interactive hop to a remote camp from the picker, use csw after
 shell-init (see 'camp switch --help').
 
 ```
@@ -71,18 +71,18 @@ camp list [org] [flags]
 
 ```
       --all              Show all statuses (default hides inactive/reference)
-      --count            Print only the total number of campaigns
+      --count            Print only the total number of camps
   -f, --format string    Output format (table, simple, json) (default "table")
       --group            Force org grouping
   -h, --help             help for list
-  -i, --interactive      Open the interactive campaign browser (prints the table when stdout is not a terminal)
+  -i, --interactive      Open the interactive camp browser (prints the table when stdout is not a terminal)
       --json             Output as JSON (shorthand for --format json)
       --no-group         Suppress org grouping
-      --org string       Only campaigns in this org
-      --remote           Also list campaigns on machines in ~/.obey/machines.yaml (ssh)
+      --org string       Only camps in this org
+      --remote           Also list camps on machines in ~/.obey/machines.yaml (ssh)
   -s, --sort string      Sort by (name, accessed, type, org) (default "accessed")
-      --status string    Only campaigns in this status (active, inactive, reference)
-      --tag strings      Only campaigns carrying this tag (repeat for AND)
+      --status string    Only camps in this status (active, inactive, reference)
+      --tag strings      Only camps carrying this tag (repeat for AND)
       --verify-verbose   Show detailed verification output
 ```
 
@@ -94,4 +94,4 @@ camp list [org] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_log.md
+++ b/docs/cli-reference/camp/camp_log.md
@@ -1,19 +1,19 @@
 ---
 title: "camp log"
 linkTitle: "camp log"
-description: "Show git log of the campaign"
+description: "Show git log of the camp"
 ---
 
 ## camp log
 
-Show git log of the campaign
+Show git log of the camp
 
 ### Synopsis
 
-Show git log of the campaign root repository.
+Show git log of the camp root repository.
 
-Works from anywhere within the campaign - always shows the log
-of the campaign root repository.
+Works from anywhere within the camp - always shows the log
+of the camp root repository.
 
 Use --sub to show log of the submodule detected from your current directory.
 Use --project/-p to show log of a specific project.
@@ -44,4 +44,4 @@ camp log [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_machine.md
+++ b/docs/cli-reference/camp/camp_machine.md
@@ -41,7 +41,7 @@ instead) and docs/transfer.md for the machine-first transfer grammar.
 
 Run without a subcommand in a terminal to manage the fleet interactively: add,
 discover, edit, and remove machines, see each one's socket state, and press
-enter to pick a campaign on the selected machine and hop to it. Hopping needs
+enter to pick a camp on the selected machine and hop to it. Hopping needs
 the shell wrapper ('eval "$(camp shell-init zsh)"'), because no subprocess can
 replace the shell it was run from; without it the screen says so rather than
 appearing to work. The subcommands stay the interface for scripts and agents,
@@ -79,7 +79,7 @@ camp machine [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp machine add](../camp_machine_add/)	 - Add or update a machine
 * [camp machine adopt](../camp_machine_adopt/)	 - Register the machine this session was hopped from
 * [camp machine diagnose](../camp_machine_diagnose/)	 - Inspect machine auth, probe line, and ssh ControlMaster sockets

--- a/docs/cli-reference/camp/camp_move.md
+++ b/docs/cli-reference/camp/camp_move.md
@@ -1,22 +1,22 @@
 ---
 title: "camp move"
 linkTitle: "camp move"
-description: "Move a file or directory within the campaign"
+description: "Move a file or directory within the camp"
 ---
 
 ## camp move
 
-Move a file or directory within the campaign
+Move a file or directory within the camp
 
 ### Synopsis
 
-Move a file or directory within the current campaign.
+Move a file or directory within the current camp.
 
 Paths are resolved relative to the current directory, matching standard
 'mv' behavior and tab completion.
 
-Use @ prefix for campaign shortcuts (e.g., @p/fest, @f/active/).
-Available shortcuts are defined in campaign config.
+Use @ prefix for camp shortcuts (e.g., @p/fest, @f/active/).
+Available shortcuts are defined in camp config.
 
 If the destination is an existing directory or ends with '/', the source
 is placed inside it with the same basename.
@@ -48,4 +48,4 @@ camp move <src> <dest> [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_notify.md
+++ b/docs/cli-reference/camp/camp_notify.md
@@ -1,18 +1,18 @@
 ---
 title: "camp notify"
 linkTitle: "camp notify"
-description: "Manage campaign state notices"
+description: "Manage camp state notices"
 ---
 
 ## camp notify
 
-Manage campaign state notices
+Manage camp state notices
 
 ### Synopsis
 
 Manage the advisory notices camp surfaces on commands you already run.
 
-Notices describe campaign state you may not know is true, such as a declared
+Notices describe camp state you may not know is true, such as a declared
 artifact root that has never synced. Each one carries its own dismiss command.
 
 Dismissals are stored in .campaign/notices.yaml, which is committed: a
@@ -33,7 +33,7 @@ artifact declarations it concerns do.
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp notify dismiss](../camp_notify_dismiss/)	 - Stop showing a notice
 * [camp notify list](../camp_notify_list/)	 - List dismissed notices
 * [camp notify restore](../camp_notify_restore/)	 - Show a dismissed notice again

--- a/docs/cli-reference/camp/camp_notify_dismiss.md
+++ b/docs/cli-reference/camp/camp_notify_dismiss.md
@@ -34,4 +34,4 @@ camp notify dismiss <notice-id> [flags]
 
 ### SEE ALSO
 
-* [camp notify](../camp_notify/)	 - Manage campaign state notices
+* [camp notify](../camp_notify/)	 - Manage camp state notices

--- a/docs/cli-reference/camp/camp_notify_list.md
+++ b/docs/cli-reference/camp/camp_notify_list.md
@@ -26,4 +26,4 @@ camp notify list [flags]
 
 ### SEE ALSO
 
-* [camp notify](../camp_notify/)	 - Manage campaign state notices
+* [camp notify](../camp_notify/)	 - Manage camp state notices

--- a/docs/cli-reference/camp/camp_notify_restore.md
+++ b/docs/cli-reference/camp/camp_notify_restore.md
@@ -26,4 +26,4 @@ camp notify restore <notice-id> [flags]
 
 ### SEE ALSO
 
-* [camp notify](../camp_notify/)	 - Manage campaign state notices
+* [camp notify](../camp_notify/)	 - Manage camp state notices

--- a/docs/cli-reference/camp/camp_org.md
+++ b/docs/cli-reference/camp/camp_org.md
@@ -1,31 +1,31 @@
 ---
 title: "camp org"
 linkTitle: "camp org"
-description: "Group campaigns into orgs"
+description: "Group camps into orgs"
 ---
 
 ## camp org
 
-Group campaigns into orgs
+Group camps into orgs
 
 ### Synopsis
 
-Group related campaigns into first-class orgs.
+Group related camps into first-class orgs.
 
-Every campaign belongs to exactly one org (default "default"). Orgs are first-class:
+Every camp belongs to exactly one org (default "default"). Orgs are first-class:
 they persist in the machine-wide registry, can hold zero members, and are deleted
 explicitly with 'camp org delete'.
 
 In a terminal, 'camp org' (no arguments) opens an interactive browser of orgs
-and their members where you can move, create, rename, and return campaigns. When
-piped or with --json it prints the current campaign's org instead; use
+and their members where you can move, create, rename, and return camps. When
+piped or with --json it prints the current camp's org instead; use
 'camp org which' to print the org unconditionally.
 
 Commands:
-  which   Print the current campaign's org
-  create  Create an org (optionally --empty) and optionally join campaigns
-  add     Assign campaigns to an org (also reassigns; single-membership)
-  remove  Return campaigns to the default org
+  which   Print the current camp's org
+  create  Create an org (optionally --empty) and optionally join camps
+  add     Assign camps to an org (also reassigns; single-membership)
+  remove  Return camps to the default org
   delete  Delete an org (empty only unless --force)
 
 ```
@@ -36,11 +36,11 @@ camp org [flags]
 
 ```
   camp org                                       Browse and manage orgs interactively (TTY)
-  camp org which                                 Print the current campaign's org
-  camp org create obey                           Add the current campaign to "obey"
+  camp org which                                 Print the current camp's org
+  camp org create obey                           Add the current camp to "obey"
   camp org create empty-org --empty              Create an org with no members
-  camp org add obey obey-campaign obey-content   Move campaigns into "obey"
-  camp org remove obey-content                   Return a campaign to "default"
+  camp org add obey obey-campaign obey-content   Move camps into "obey"
+  camp org remove obey-content                   Return a camp to "default"
   camp org delete empty-org                      Delete an empty org
 ```
 
@@ -60,14 +60,14 @@ camp org [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
-* [camp org add](../camp_org_add/)	 - Assign campaigns to an org (reassigns; single-membership)
-* [camp org create](../camp_org_create/)	 - Create an org (optionally empty) and join campaigns
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
+* [camp org add](../camp_org_add/)	 - Assign camps to an org (reassigns; single-membership)
+* [camp org create](../camp_org_create/)	 - Create an org (optionally empty) and join camps
 * [camp org delete](../camp_org_delete/)	 - Delete an org (empty only unless --force)
 * [camp org list](../camp_org_list/)	 - List orgs with member and active counts
-* [camp org next](../camp_org_next/)	 - Switch to the next campaign in the current campaign's org
-* [camp org remove](../camp_org_remove/)	 - Return campaigns to the default org
+* [camp org next](../camp_org_next/)	 - Switch to the next camp in the current camp's org
+* [camp org remove](../camp_org_remove/)	 - Return camps to the default org
 * [camp org rename](../camp_org_rename/)	 - Rename an org, reassigning all members atomically
-* [camp org show](../camp_org_show/)	 - Show an org's member campaigns
-* [camp org toggle](../camp_org_toggle/)	 - Toggle back to the last-visited campaign in the current org
-* [camp org which](../camp_org_which/)	 - Print the current campaign's org
+* [camp org show](../camp_org_show/)	 - Show an org's member camps
+* [camp org toggle](../camp_org_toggle/)	 - Toggle back to the last-visited camp in the current org
+* [camp org which](../camp_org_which/)	 - Print the current camp's org

--- a/docs/cli-reference/camp/camp_org_add.md
+++ b/docs/cli-reference/camp/camp_org_add.md
@@ -1,23 +1,23 @@
 ---
 title: "camp org add"
 linkTitle: "camp org add"
-description: "Assign campaigns to an org (reassigns; single-membership)"
+description: "Assign camps to an org (reassigns; single-membership)"
 ---
 
 ## camp org add
 
-Assign campaigns to an org (reassigns; single-membership)
+Assign camps to an org (reassigns; single-membership)
 
 ### Synopsis
 
-Assign one or more campaigns to <org>.
+Assign one or more camps to <org>.
 
-Membership is single, so this is also the reassign verb: a campaign added to a
+Membership is single, so this is also the reassign verb: a camp added to a
 new org leaves its previous org in the same step. The org is created implicitly.
-Adding a campaign already in <org> is a no-op for that campaign.
+Adding a camp already in <org> is a no-op for that camp.
 
 ```
-camp org add <org> <campaign>... [flags]
+camp org add <org> <camp>... [flags]
 ```
 
 ### Examples
@@ -42,4 +42,4 @@ camp org add <org> <campaign>... [flags]
 
 ### SEE ALSO
 
-* [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp org](../camp_org/)	 - Group camps into orgs

--- a/docs/cli-reference/camp/camp_org_create.md
+++ b/docs/cli-reference/camp/camp_org_create.md
@@ -1,32 +1,32 @@
 ---
 title: "camp org create"
 linkTitle: "camp org create"
-description: "Create an org (optionally empty) and join campaigns"
+description: "Create an org (optionally empty) and join camps"
 ---
 
 ## camp org create
 
-Create an org (optionally empty) and join campaigns
+Create an org (optionally empty) and join camps
 
 ### Synopsis
 
-Create a first-class org, optionally joining campaigns to it.
+Create a first-class org, optionally joining camps to it.
 
-Run inside a campaign with no campaign arguments to add the current campaign:
+Run inside a camp with no camp arguments to add the current camp:
   camp org create obey
 
-Or name the campaigns explicitly:
+Or name the camps explicitly:
   camp org create obey obey-campaign obey-content
 
-Create an empty org with no members (works outside a campaign):
+Create an empty org with no members (works outside a camp):
   camp org create obey --empty
 
 Orgs are first-class: they persist in the registry even with zero members.
 Joining an org that already has members is allowed; there is no "already exists"
-error, and a campaign already in the org is reported as unchanged.
+error, and a camp already in the org is reported as unchanged.
 
 ```
-camp org create <org> [campaign...] [flags]
+camp org create <org> [camp...] [flags]
 ```
 
 ### Examples
@@ -40,7 +40,7 @@ camp org create <org> [campaign...] [flags]
 ### Options
 
 ```
-      --empty   Create the org with no members (do not join any campaign)
+      --empty   Create the org with no members (do not join any camp)
   -h, --help    help for create
       --json    Output as JSON
 ```
@@ -53,4 +53,4 @@ camp org create <org> [campaign...] [flags]
 
 ### SEE ALSO
 
-* [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp org](../camp_org/)	 - Group camps into orgs

--- a/docs/cli-reference/camp/camp_org_delete.md
+++ b/docs/cli-reference/camp/camp_org_delete.md
@@ -45,4 +45,4 @@ camp org delete <name> [flags]
 
 ### SEE ALSO
 
-* [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp org](../camp_org/)	 - Group camps into orgs

--- a/docs/cli-reference/camp/camp_org_list.md
+++ b/docs/cli-reference/camp/camp_org_list.md
@@ -33,4 +33,4 @@ camp org list [flags]
 
 ### SEE ALSO
 
-* [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp org](../camp_org/)	 - Group camps into orgs

--- a/docs/cli-reference/camp/camp_org_next.md
+++ b/docs/cli-reference/camp/camp_org_next.md
@@ -1,26 +1,26 @@
 ---
 title: "camp org next"
 linkTitle: "camp org next"
-description: "Switch to the next campaign in the current campaign's org"
+description: "Switch to the next camp in the current camp's org"
 ---
 
 ## camp org next
 
-Switch to the next campaign in the current campaign's org
+Switch to the next camp in the current camp's org
 
 ### Synopsis
 
-Switch to the next campaign in the current campaign's org.
+Switch to the next camp in the current camp's org.
 
 Members are ordered by name, so the cycle is stable and predictable
-(a -> b -> c -> a). By default only active campaigns are cycled; use --all to
-include inactive and reference campaigns.
+(a -> b -> c -> a). By default only active camps are cycled; use --all to
+include inactive and reference camps.
 
 Use with the corg shell function for instant navigation:
-  corg        # cd to the next campaign in this org
+  corg        # cd to the next camp in this org
 
 The --print flag outputs just the target path for shell integration, and --json
-emits the resolved source and target campaigns.
+emits the resolved source and target camps.
 
 ```
 camp org next [flags]
@@ -29,18 +29,18 @@ camp org next [flags]
 ### Examples
 
 ```
-  camp org next            # Print cd to the next org campaign
+  camp org next            # Print cd to the next org camp
   camp org next --print    # Print the target path only
-  camp org next --all      # Include inactive/reference campaigns
+  camp org next --all      # Include inactive/reference camps
   camp org next --json
 ```
 
 ### Options
 
 ```
-      --all     Include inactive and reference campaigns in the cycle
+      --all     Include inactive and reference camps in the cycle
   -h, --help    help for next
-      --json    Output the resolved source and target campaigns as JSON
+      --json    Output the resolved source and target camps as JSON
       --print   Print the target path only (for shell integration)
 ```
 
@@ -52,4 +52,4 @@ camp org next [flags]
 
 ### SEE ALSO
 
-* [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp org](../camp_org/)	 - Group camps into orgs

--- a/docs/cli-reference/camp/camp_org_remove.md
+++ b/docs/cli-reference/camp/camp_org_remove.md
@@ -1,22 +1,22 @@
 ---
 title: "camp org remove"
 linkTitle: "camp org remove"
-description: "Return campaigns to the default org"
+description: "Return camps to the default org"
 ---
 
 ## camp org remove
 
-Return campaigns to the default org
+Return camps to the default org
 
 ### Synopsis
 
-Return one or more campaigns to the "default" org.
+Return one or more camps to the "default" org.
 
-Since a campaign is always in exactly one org, you do not name the org.
-Removing a campaign already in "default" is a no-op.
+Since a camp is always in exactly one org, you do not name the org.
+Removing a camp already in "default" is a no-op.
 
 ```
-camp org remove <campaign>... [flags]
+camp org remove <camp>... [flags]
 ```
 
 ### Examples
@@ -41,4 +41,4 @@ camp org remove <campaign>... [flags]
 
 ### SEE ALSO
 
-* [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp org](../camp_org/)	 - Group camps into orgs

--- a/docs/cli-reference/camp/camp_org_rename.md
+++ b/docs/cli-reference/camp/camp_org_rename.md
@@ -40,4 +40,4 @@ camp org rename <old> <new> [flags]
 
 ### SEE ALSO
 
-* [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp org](../camp_org/)	 - Group camps into orgs

--- a/docs/cli-reference/camp/camp_org_show.md
+++ b/docs/cli-reference/camp/camp_org_show.md
@@ -1,12 +1,12 @@
 ---
 title: "camp org show"
 linkTitle: "camp org show"
-description: "Show an org's member campaigns"
+description: "Show an org's member camps"
 ---
 
 ## camp org show
 
-Show an org's member campaigns
+Show an org's member camps
 
 ```
 camp org show <org> [flags]
@@ -33,4 +33,4 @@ camp org show <org> [flags]
 
 ### SEE ALSO
 
-* [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp org](../camp_org/)	 - Group camps into orgs

--- a/docs/cli-reference/camp/camp_org_toggle.md
+++ b/docs/cli-reference/camp/camp_org_toggle.md
@@ -1,24 +1,24 @@
 ---
 title: "camp org toggle"
 linkTitle: "camp org toggle"
-description: "Toggle back to the last-visited campaign in the current org"
+description: "Toggle back to the last-visited camp in the current org"
 ---
 
 ## camp org toggle
 
-Toggle back to the last-visited campaign in the current org
+Toggle back to the last-visited camp in the current org
 
 ### Synopsis
 
-Toggle back to the most recently visited other campaign in the current org.
+Toggle back to the most recently visited other camp in the current org.
 
 "Most recently visited" is tracked by last-access time, which camp updates on
 every 'camp switch' and 'camp org next'/'toggle'. Paired with 'camp org next',
 this gives a natural A <-> B toggle within an org. By default only active
-campaigns are considered; use --all to include inactive and reference campaigns.
+camps are considered; use --all to include inactive and reference camps.
 
 Use with the corg shell function for instant navigation:
-  corg t      # cd back to the last org campaign you were in
+  corg t      # cd back to the last org camp you were in
 
 ```
 camp org toggle [flags]
@@ -27,7 +27,7 @@ camp org toggle [flags]
 ### Examples
 
 ```
-  camp org toggle          # Print cd to the last-visited org campaign
+  camp org toggle          # Print cd to the last-visited org camp
   camp org toggle --print  # Print the target path only
   camp org toggle --json
 ```
@@ -35,9 +35,9 @@ camp org toggle [flags]
 ### Options
 
 ```
-      --all     Include inactive and reference campaigns in the cycle
+      --all     Include inactive and reference camps in the cycle
   -h, --help    help for toggle
-      --json    Output the resolved source and target campaigns as JSON
+      --json    Output the resolved source and target camps as JSON
       --print   Print the target path only (for shell integration)
 ```
 
@@ -49,4 +49,4 @@ camp org toggle [flags]
 
 ### SEE ALSO
 
-* [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp org](../camp_org/)	 - Group camps into orgs

--- a/docs/cli-reference/camp/camp_org_which.md
+++ b/docs/cli-reference/camp/camp_org_which.md
@@ -1,12 +1,12 @@
 ---
 title: "camp org which"
 linkTitle: "camp org which"
-description: "Print the current campaign's org"
+description: "Print the current camp's org"
 ---
 
 ## camp org which
 
-Print the current campaign's org
+Print the current camp's org
 
 ```
 camp org which [flags]
@@ -33,4 +33,4 @@ camp org which [flags]
 
 ### SEE ALSO
 
-* [camp org](../camp_org/)	 - Group campaigns into orgs
+* [camp org](../camp_org/)	 - Group camps into orgs

--- a/docs/cli-reference/camp/camp_pack.md
+++ b/docs/cli-reference/camp/camp_pack.md
@@ -37,4 +37,4 @@ camp pack [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_pin.md
+++ b/docs/cli-reference/camp/camp_pin.md
@@ -41,4 +41,4 @@ camp pin <name> [path] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_pins.md
+++ b/docs/cli-reference/camp/camp_pins.md
@@ -30,4 +30,4 @@ camp pins [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_plugins.md
+++ b/docs/cli-reference/camp/camp_plugins.md
@@ -26,4 +26,4 @@ camp plugins [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_project.md
+++ b/docs/cli-reference/camp/camp_project.md
@@ -1,25 +1,25 @@
 ---
 title: "camp project"
 linkTitle: "camp project"
-description: "Manage campaign projects"
+description: "Manage camp projects"
 ---
 
 ## camp project
 
-Manage campaign projects
+Manage camp projects
 
 ### Synopsis
 
-Manage git submodules and project repositories in the campaign.
+Manage git submodules and project repositories in the camp.
 
 A project can be:
   - a git repository tracked as a submodule under projects/
   - a machine-local linked workspace attached via symlink under projects/
-  - an ordinary campaign-owned directory tracked by the campaign repository
+  - an ordinary camp-owned directory tracked by the camp repository
 
 Use 'camp project add' for submodules and 'camp project link' / 'camp project unlink'
 for linked workspaces. Use 'camp project run' (or the 'cr -p' shell shorthand)
-to run a command inside a project from anywhere in the campaign.
+to run a command inside a project from anywhere in the camp.
 
 Examples:
   camp project list                    List all projects
@@ -50,17 +50,17 @@ camp project [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
-* [camp project add](../camp_project_add/)	 - Add a project to campaign
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
+* [camp project add](../camp_project_add/)	 - Add a project to camp
 * [camp project commit](../camp_project_commit/)	 - Commit changes in a project submodule
-* [camp project link](../camp_project_link/)	 - Link an existing local project into a campaign
-* [camp project list](../camp_project_list/)	 - List projects in campaign
-* [camp project new](../camp_project_new/)	 - Create a new project in campaign
+* [camp project link](../camp_project_link/)	 - Link an existing local project into a camp
+* [camp project list](../camp_project_list/)	 - List projects in camp
+* [camp project new](../camp_project_new/)	 - Create a new project in camp
 * [camp project prune](../camp_project_prune/)	 - Delete merged branches in a project
 * [camp project remote](../camp_project_remote/)	 - Manage remotes for a project
-* [camp project remove](../camp_project_remove/)	 - Remove a project from campaign
+* [camp project remove](../camp_project_remove/)	 - Remove a project from camp
 * [camp project rename](../camp_project_rename/)	 - Rename a managed project
 * [camp project run](../camp_project_run/)	 - Run a command inside a project directory, like cr but project-scoped
 * [camp project stage](../camp_project_stage/)	 - Stage changes in a project submodule
-* [camp project unlink](../camp_project_unlink/)	 - Unlink a linked project from a campaign
+* [camp project unlink](../camp_project_unlink/)	 - Unlink a linked project from a camp
 * [camp project worktree](../camp_project_worktree/)	 - Manage worktrees for a project

--- a/docs/cli-reference/camp/camp_project_add.md
+++ b/docs/cli-reference/camp/camp_project_add.md
@@ -1,23 +1,24 @@
 ---
 title: "camp project add"
 linkTitle: "camp project add"
-description: "Add a project to campaign"
+description: "Add a project to camp"
 ---
 
 ## camp project add
 
-Add a project to campaign
+Add a project to camp
 
 ### Synopsis
 
-Add a git repository as a project in the campaign.
+Add a git repository as a project in the camp.
 
 The project is cloned as a git submodule into the projects/ directory.
 A worktree directory is also created for future parallel development.
+The camp commit is always created so .gitmodules and the submodule pointer land together.
 
-If you're already inside a campaign, that campaign is used by default.
-Outside a campaign, use --campaign <name-or-id> or a bare --campaign to
-select a registered target campaign.
+If you're already inside a camp, that camp is used by default.
+Outside a camp, use --campaign <name-or-id> or a bare --campaign to
+select a registered target camp.
 
 Source can be:
   - SSH URL:   git@github.com:org/repo.git
@@ -28,7 +29,7 @@ Examples:
   camp project add git@github.com:org/api.git           # Add remote repo
   camp project add https://github.com/org/web.git       # Add via HTTPS
   camp project add --local ./my-repo --name my-project  # Add existing local repo
-  camp project add --campaign platform --local ./my-repo # Add outside current campaign
+  camp project add --campaign platform --local ./my-repo # Add outside current camp
   camp project add git@github.com:org/api.git --name backend  # Custom name
 
 ```
@@ -38,11 +39,10 @@ camp project add [source] [flags]
 ### Options
 
 ```
-  -c, --campaign string   Target campaign by name or ID; omit value to pick interactively
+  -c, --campaign string   Target camp by name or ID; omit value to pick interactively
   -h, --help              help for add
   -l, --local string      Add existing local repository instead of cloning
   -n, --name string       Override project name (defaults to repo name)
-      --no-commit         Skip automatic git commit
   -p, --path string       Override destination path (defaults to projects/<name>)
 ```
 
@@ -54,4 +54,4 @@ camp project add [source] [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects

--- a/docs/cli-reference/camp/camp_project_commit.md
+++ b/docs/cli-reference/camp/camp_project_commit.md
@@ -20,7 +20,7 @@ to an active festival or workitem (via path links, ancestor .workitem
 markers, or festival-scoped links), the commit message carries the same
 FE-<ref> / WI-<ref> tracking components that `fest commit` would
 include. Use --workitem to override cwd-based resolution. When no
-festival/workitem context resolves, the tag is the bare campaign tag.
+festival/workitem context resolves, the tag is the bare camp tag.
 
 Examples:
   # From within a project directory
@@ -47,7 +47,7 @@ camp project commit [flags]
       --no-drain              Do not wait for camp's queued commits first
       --no-sync               Do not sync submodule ref even if settings enable it
   -p, --project string        Project name (auto-detected from cwd if not specified)
-      --sync                  Sync submodule ref at campaign root after commit (also enabled by commit.sync_project_refs setting)
+      --sync                  Sync submodule ref at camp root after commit (also enabled by commit.sync_project_refs setting)
       --workitem string       explicit workitem selector for the commit tag (overrides cwd-based resolution)
 ```
 
@@ -59,4 +59,4 @@ camp project commit [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects

--- a/docs/cli-reference/camp/camp_project_link.md
+++ b/docs/cli-reference/camp/camp_project_link.md
@@ -1,31 +1,31 @@
 ---
 title: "camp project link"
 linkTitle: "camp project link"
-description: "Link an existing local project into a campaign"
+description: "Link an existing local project into a camp"
 ---
 
 ## camp project link
 
-Link an existing local project into a campaign
+Link an existing local project into a camp
 
 ### Synopsis
 
-Link an existing local directory into a campaign.
+Link an existing local directory into a camp.
 
 If path is omitted, camp links the current working directory.
 
-If you're already inside a campaign, camp uses that campaign automatically.
-If you're outside a campaign in an interactive terminal, camp opens a picker
-so you can choose a registered campaign. Use --campaign <name-or-id> to skip
+If you're already inside a camp, camp uses that camp automatically.
+If you're outside a camp in an interactive terminal, camp opens a picker
+so you can choose a registered camp. Use --campaign <name-or-id> to skip
 the picker or for non-interactive scripts.
 
 This creates a symlink at projects/<name> and writes .camp with the selected
-campaign ID.
+camp ID.
 
 Examples:
   camp project link                          # Link current directory
   camp project link ~/code/my-project        # Link another directory
-  camp project link --campaign platform      # Link current directory to a specific campaign
+  camp project link --campaign platform      # Link current directory to a specific camp
   camp project link ~/code/my-project --campaign platform
   camp project link ~/code/my-project --name backend
 
@@ -36,7 +36,7 @@ camp project link [path] [flags]
 ### Options
 
 ```
-  -c, --campaign string   Target campaign by name or ID; defaults to current campaign or interactive picker
+  -c, --campaign string   Target camp by name or ID; defaults to current camp or interactive picker
   -h, --help              help for link
   -n, --name string       Override project name (defaults to directory name)
       --no-commit         Skip automatic git commit
@@ -50,4 +50,4 @@ camp project link [path] [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects

--- a/docs/cli-reference/camp/camp_project_list.md
+++ b/docs/cli-reference/camp/camp_project_list.md
@@ -1,16 +1,16 @@
 ---
 title: "camp project list"
 linkTitle: "camp project list"
-description: "List projects in campaign"
+description: "List projects in camp"
 ---
 
 ## camp project list
 
-List projects in campaign
+List projects in camp
 
 ### Synopsis
 
-List all projects in the current campaign.
+List all projects in the current camp.
 
 Projects are discovered from the projects/ directory. They may be regular
 git-backed entries or linked external directories.
@@ -62,4 +62,4 @@ camp project list [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects

--- a/docs/cli-reference/camp/camp_project_new.md
+++ b/docs/cli-reference/camp/camp_project_new.md
@@ -1,19 +1,20 @@
 ---
 title: "camp project new"
 linkTitle: "camp project new"
-description: "Create a new project in campaign"
+description: "Create a new project in camp"
 ---
 
 ## camp project new
 
-Create a new project in campaign
+Create a new project in camp
 
 ### Synopsis
 
-Create a new local project as a git submodule in the campaign.
+Create a new local project as a git submodule in the camp.
 
 The project is initialized as a git repository with an initial commit,
 then added as a submodule under projects/. No remote repository is required.
+The camp commit is always created so .gitmodules and the submodule pointer land together.
 
 You can add a remote later:
   cd projects/<name>
@@ -21,7 +22,6 @@ You can add a remote later:
 
 Examples:
   camp project new my-service             # Create new project
-  camp project new my-service --no-commit # Skip auto-commit to campaign
 
 ```
 camp project new <name> [flags]
@@ -31,7 +31,6 @@ camp project new <name> [flags]
 
 ```
   -h, --help          help for new
-      --no-commit     Skip automatic git commit
   -p, --path string   Override destination path (defaults to projects/<name>)
 ```
 
@@ -43,4 +42,4 @@ camp project new <name> [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects

--- a/docs/cli-reference/camp/camp_project_prune.md
+++ b/docs/cli-reference/camp/camp_project_prune.md
@@ -49,5 +49,5 @@ camp project prune [project-name] [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects
 * [camp project prune all](../camp_project_prune_all/)	 - Delete merged branches across all projects

--- a/docs/cli-reference/camp/camp_project_prune_all.md
+++ b/docs/cli-reference/camp/camp_project_prune_all.md
@@ -11,7 +11,7 @@ Delete merged branches across all projects
 ### Synopsis
 
 Delete local branches that have been merged into the default branch,
-across every project submodule in the campaign.
+across every project submodule in the camp.
 
 Produces a per-project summary showing what was (or would be) pruned.
 

--- a/docs/cli-reference/camp/camp_project_remote.md
+++ b/docs/cli-reference/camp/camp_project_remote.md
@@ -10,7 +10,7 @@ Manage remotes for a project
 
 ### Synopsis
 
-Manage git remotes for a campaign project.
+Manage git remotes for a camp project.
 
 Auto-detects the current project from your working directory, or use --project
 to specify explicitly.
@@ -53,7 +53,7 @@ camp project remote [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects
 * [camp project remote add](../camp_project_remote_add/)	 - Add a new remote to the project
 * [camp project remote list](../camp_project_remote_list/)	 - List remotes for the project
 * [camp project remote remove](../camp_project_remote_remove/)	 - Remove a remote from the project

--- a/docs/cli-reference/camp/camp_project_remote_remove.md
+++ b/docs/cli-reference/camp/camp_project_remote_remove.md
@@ -16,7 +16,7 @@ Removing the "origin" remote is blocked by default because it is the
 canonical remote for submodule tracking. Use --force to override.
 
 When --force is used to remove origin from a submodule project, the
-.gitmodules entry is also cleaned up to keep the campaign consistent.
+.gitmodules entry is also cleaned up to keep the camp consistent.
 
 Note: if you want to change the canonical URL instead of removing it,
 use "camp project remote set-url".

--- a/docs/cli-reference/camp/camp_project_remote_set-url.md
+++ b/docs/cli-reference/camp/camp_project_remote_set-url.md
@@ -14,7 +14,7 @@ Update a remote URL across all tracked locations with automatic rollback.
 
 For submodule projects, updates three locations in order:
   1. .gitmodules  (canonical, tracked in git)
-  2. local git submodule config (.git/config of the campaign root)
+  2. local git submodule config (.git/config of the camp root)
   3. remote config inside the project repo
 
 If any step fails, previous steps are automatically rolled back to keep

--- a/docs/cli-reference/camp/camp_project_remove.md
+++ b/docs/cli-reference/camp/camp_project_remove.md
@@ -1,16 +1,16 @@
 ---
 title: "camp project remove"
 linkTitle: "camp project remove"
-description: "Remove a project from campaign"
+description: "Remove a project from camp"
 ---
 
 ## camp project remove
 
-Remove a project from campaign
+Remove a project from camp
 
 ### Synopsis
 
-Remove a project from the campaign.
+Remove a project from the camp.
 
 By default, this only removes the project from git submodule tracking.
 The project directory is removed from the working tree by git rm. Pass --delete
@@ -50,4 +50,4 @@ camp project remove <name> [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects

--- a/docs/cli-reference/camp/camp_project_rename.md
+++ b/docs/cli-reference/camp/camp_project_rename.md
@@ -13,7 +13,7 @@ Rename a managed project
 Rename a managed project and migrate its active Camp references.
 
 Supported projects are declared Git submodules, linked workspace symlinks,
-and ordinary campaign-owned directories tracked by the campaign repository.
+and ordinary camp-owned directories tracked by the camp repository.
 Dirty project checkouts and linked worktrees are preserved. Destination
 collisions and unmanaged directories are rejected before mutation.
 
@@ -34,11 +34,11 @@ camp project rename <current> <new> [flags]
 ### Options
 
 ```
-  -c, --campaign string     Target campaign by name or ID; omit value to pick interactively
+  -c, --campaign string     Target camp by name or ID; omit value to pick interactively
       --dry-run             Print the complete plan without writing
   -h, --help                help for rename
       --json                Output a versioned JSON plan or result
-      --no-commit           Apply the rename without a campaign commit
+      --no-commit           Apply the rename without a camp commit
       --no-verify           Skip remote connectivity verification
       --remote-url string   Explicitly update the project's origin URL
 ```
@@ -51,4 +51,4 @@ camp project rename <current> <new> [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects

--- a/docs/cli-reference/camp/camp_project_run.md
+++ b/docs/cli-reference/camp/camp_project_run.md
@@ -10,10 +10,10 @@ Run a command inside a project directory, like cr but project-scoped
 
 ### Synopsis
 
-Run any shell command inside a project directory from anywhere in the campaign.
+Run any shell command inside a project directory from anywhere in the camp.
 
 This is the project-scoped counterpart to 'camp run' (cr): cr runs from the
-campaign root, camp project run (cr -p) runs inside a project.
+camp root, camp project run (cr -p) runs inside a project.
 
 The project is resolved in this order:
   1. --project / -p flag (explicit project name, tab-completes registered projects)
@@ -59,4 +59,4 @@ camp project run [--project <name>] [--] <command> [args...] [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects

--- a/docs/cli-reference/camp/camp_project_stage.md
+++ b/docs/cli-reference/camp/camp_project_stage.md
@@ -46,4 +46,4 @@ camp project stage [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects

--- a/docs/cli-reference/camp/camp_project_unlink.md
+++ b/docs/cli-reference/camp/camp_project_unlink.md
@@ -1,16 +1,16 @@
 ---
 title: "camp project unlink"
 linkTitle: "camp project unlink"
-description: "Unlink a linked project from a campaign"
+description: "Unlink a linked project from a camp"
 ---
 
 ## camp project unlink
 
-Unlink a linked project from a campaign
+Unlink a linked project from a camp
 
 ### Synopsis
 
-Remove a linked project symlink from a campaign without touching the
+Remove a linked project symlink from a camp without touching the
 external workspace contents.
 
 If name is omitted, the current linked project is inferred from the working
@@ -18,11 +18,11 @@ directory.
 
 Use this for linked workspaces added with 'camp project link'. This command
 removes the symlink entry from projects/ and cleans up the linked repo's local
-.camp marker when it belongs to the selected campaign.
+.camp marker when it belongs to the selected camp.
 
-If you're already inside a campaign, that campaign is used by default.
-Outside a campaign, use --campaign <name-or-id> or a bare --campaign to
-pick a registered target campaign interactively.
+If you're already inside a camp, that camp is used by default.
+Outside a camp, use --campaign <name-or-id> or a bare --campaign to
+pick a registered target camp interactively.
 
 Examples:
   camp project unlink
@@ -39,7 +39,7 @@ camp project unlink [name] [flags]
 ### Options
 
 ```
-  -c, --campaign string   Target campaign by name or ID; omit value to pick interactively
+  -c, --campaign string   Target camp by name or ID; omit value to pick interactively
       --dry-run           Show what would be done without making changes
   -h, --help              help for unlink
       --no-commit         Skip automatic git commit
@@ -53,4 +53,4 @@ camp project unlink [name] [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects

--- a/docs/cli-reference/camp/camp_project_worktree.md
+++ b/docs/cli-reference/camp/camp_project_worktree.md
@@ -54,7 +54,7 @@ camp project worktree [flags]
 
 ### SEE ALSO
 
-* [camp project](../camp_project/)	 - Manage campaign projects
+* [camp project](../camp_project/)	 - Manage camp projects
 * [camp project worktree add](../camp_project_worktree_add/)	 - Create a new worktree for the project
 * [camp project worktree list](../camp_project_worktree_list/)	 - List worktrees for the project
 * [camp project worktree remove](../camp_project_worktree_remove/)	 - Remove a worktree

--- a/docs/cli-reference/camp/camp_promote.md
+++ b/docs/cli-reference/camp/camp_promote.md
@@ -34,4 +34,4 @@ camp promote [id] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_pull.md
+++ b/docs/cli-reference/camp/camp_pull.md
@@ -12,8 +12,8 @@ Pull latest changes from remote
 
 Pull latest changes from the remote repository.
 
-Works from anywhere within the campaign - always pulls to
-the campaign root repository.
+Works from anywhere within the camp - always pulls to
+the camp root repository.
 
 Use --sub to pull the submodule detected from your current directory.
 Use --project to pull a specific project.
@@ -48,5 +48,5 @@ camp pull [flags] [remote] [branch]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp pull all](../camp_pull_all/)	 - Pull latest changes for all repos

--- a/docs/cli-reference/camp/camp_pull_all.md
+++ b/docs/cli-reference/camp/camp_pull_all.md
@@ -10,9 +10,9 @@ Pull latest changes for all repos
 
 ### Synopsis
 
-Pull latest changes for all repositories in the campaign.
+Pull latest changes for all repositories in the camp.
 
-Scans the campaign root and all submodules, checks which have a tracking
+Scans the camp root and all submodules, checks which have a tracking
 branch with upstream, and pulls them. Any extra flags are passed through
 to git pull for each repo.
 

--- a/docs/cli-reference/camp/camp_push.md
+++ b/docs/cli-reference/camp/camp_push.md
@@ -1,19 +1,19 @@
 ---
 title: "camp push"
 linkTitle: "camp push"
-description: "Push campaign changes to remote"
+description: "Push camp changes to remote"
 ---
 
 ## camp push
 
-Push campaign changes to remote
+Push camp changes to remote
 
 ### Synopsis
 
-Push campaign changes to the remote repository.
+Push camp changes to the remote repository.
 
-Works from anywhere within the campaign - always pushes from
-the campaign root repository.
+Works from anywhere within the camp - always pushes from
+the camp root repository.
 
 Use --sub to push from the submodule detected from your current directory.
 Use --project to push from a specific project.
@@ -47,5 +47,5 @@ camp push [flags] [remote] [branch]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp push all](../camp_push_all/)	 - Push all repos with unpushed commits

--- a/docs/cli-reference/camp/camp_push_all.md
+++ b/docs/cli-reference/camp/camp_push_all.md
@@ -10,9 +10,9 @@ Push all repos with unpushed commits
 
 ### Synopsis
 
-Push all repositories in the campaign that have unpushed commits.
+Push all repositories in the camp that have unpushed commits.
 
-Scans all submodules and the campaign root, checks which have commits
+Scans all submodules and the camp root, checks which have commits
 ahead of their upstream, and pushes them. Any extra flags are passed
 through to git push for each repo.
 
@@ -43,4 +43,4 @@ camp push all [git push flags] [flags]
 
 ### SEE ALSO
 
-* [camp push](../camp_push/)	 - Push campaign changes to remote
+* [camp push](../camp_push/)	 - Push camp changes to remote

--- a/docs/cli-reference/camp/camp_refs-sync.md
+++ b/docs/cli-reference/camp/camp_refs-sync.md
@@ -1,16 +1,16 @@
 ---
 title: "camp refs-sync"
 linkTitle: "camp refs-sync"
-description: "Sync submodule ref pointers in campaign root"
+description: "Sync submodule ref pointers in camp root"
 ---
 
 ## camp refs-sync
 
-Sync submodule ref pointers in campaign root
+Sync submodule ref pointers in camp root
 
 ### Synopsis
 
-Update the campaign root's recorded submodule pointers to match
+Update the camp root's recorded submodule pointers to match
 each submodule's current HEAD. Creates a single atomic commit.
 
 Without arguments, syncs all submodules. Specify paths to sync specific ones.
@@ -40,4 +40,4 @@ camp refs-sync [submodule...] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_register.md
+++ b/docs/cli-reference/camp/camp_register.md
@@ -1,31 +1,31 @@
 ---
 title: "camp register"
 linkTitle: "camp register"
-description: "Register campaign in global registry"
+description: "Register a camp in the global registry"
 ---
 
 ## camp register
 
-Register campaign in global registry
+Register a camp in the global registry
 
 ### Synopsis
 
-Register an existing campaign in the global registry.
+Register an existing camp in the global registry.
 
-This adds the campaign to the registry at ~/.obey/campaign/registry.json,
+This adds the camp to the registry at ~/.obey/campaign/registry.json,
 enabling it to appear in 'camp list' and be accessible via navigation commands.
 
-Note: 'camp init' automatically registers new campaigns. This command is for
-registering existing campaigns that weren't created with camp or were unregistered.
+Note: 'camp init' automatically registers new camps. This command is for
+registering existing camps that weren't created with camp or were unregistered.
 
-If the specified path is not a campaign (has no .campaign/ directory),
+If the specified path is not a camp (has no .campaign/ directory),
 you'll be offered the option to initialize it.
 
 Examples:
   camp register                          # Register current directory
   camp register ~/Dev/my-project         # Register specified path
-  camp register . --name custom-name     # Override the campaign name
-  camp register . --type research        # Override the campaign type
+  camp register . --name custom-name     # Override the camp name
+  camp register . --type research        # Override the camp type
 
 ```
 camp register [path] [flags]
@@ -35,8 +35,8 @@ camp register [path] [flags]
 
 ```
   -h, --help          help for register
-  -n, --name string   Override campaign name
-  -t, --type string   Override campaign type (product, research, tools, personal)
+  -n, --name string   Override camp name
+  -t, --type string   Override camp type (product, research, tools, personal)
 ```
 
 ### Options inherited from parent commands
@@ -47,4 +47,4 @@ camp register [path] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_registry.md
+++ b/docs/cli-reference/camp/camp_registry.md
@@ -1,23 +1,23 @@
 ---
 title: "camp registry"
 linkTitle: "camp registry"
-description: "Manage the campaign registry"
+description: "Manage the camp registry"
 ---
 
 ## camp registry
 
-Manage the campaign registry
+Manage the camp registry
 
 ### Synopsis
 
-Manage the campaign registry at ~/.obey/campaign/registry.json.
+Manage the camp registry at ~/.obey/campaign/registry.json.
 
-The registry tracks all known campaigns for quick navigation and lookup.
+The registry tracks all known camps for quick navigation and lookup.
 Use these commands to maintain registry health and resolve issues.
 
 Commands:
-  prune   Remove stale entries (campaigns that no longer exist)
-  sync    Update registry entry for current campaign
+  prune   Remove stale entries (camps that no longer exist)
+  sync    Update registry entry for current camp
   check   Validate registry integrity
 
 ```
@@ -27,9 +27,9 @@ camp registry [flags]
 ### Examples
 
 ```
-  camp registry prune             Remove entries for non-existent campaigns
+  camp registry prune             Remove entries for non-existent camps
   camp registry prune --dry-run   Show what would be removed
-  camp registry sync              Update path for current campaign
+  camp registry sync              Update path for current camp
   camp registry check             Check for issues
 ```
 
@@ -47,7 +47,7 @@ camp registry [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp registry check](../camp_registry_check/)	 - Check registry integrity
 * [camp registry prune](../camp_registry_prune/)	 - Remove stale registry entries
-* [camp registry sync](../camp_registry_sync/)	 - Sync current campaign with registry
+* [camp registry sync](../camp_registry_sync/)	 - Sync current camp with registry

--- a/docs/cli-reference/camp/camp_registry_check.md
+++ b/docs/cli-reference/camp/camp_registry_check.md
@@ -15,7 +15,7 @@ Validate the registry and report any issues found.
 Checks for:
 - Stale entries (paths that don't exist)
 - Missing .campaign/ directories
-- Campaigns in /tmp/ directories
+- Camps in /tmp/ directories
 - Duplicate entries (multiple IDs pointing to the same path)
 
 Examples:
@@ -39,4 +39,4 @@ camp registry check [flags]
 
 ### SEE ALSO
 
-* [camp registry](../camp_registry/)	 - Manage the campaign registry
+* [camp registry](../camp_registry/)	 - Manage the camp registry

--- a/docs/cli-reference/camp/camp_registry_prune.md
+++ b/docs/cli-reference/camp/camp_registry_prune.md
@@ -10,7 +10,7 @@ Remove stale registry entries
 
 ### Synopsis
 
-Remove registry entries where the campaign no longer exists.
+Remove registry entries where the camp no longer exists.
 
 Checks each registered path and removes entries where:
 - The path no longer exists
@@ -23,7 +23,7 @@ Options:
 Examples:
   camp registry prune             Remove stale entries
   camp registry prune --dry-run   Preview what would be removed
-  camp registry prune --include-temp  Also clean up test campaigns
+  camp registry prune --include-temp  Also clean up test camps
 
 ```
 camp registry prune [flags]
@@ -45,4 +45,4 @@ camp registry prune [flags]
 
 ### SEE ALSO
 
-* [camp registry](../camp_registry/)	 - Manage the campaign registry
+* [camp registry](../camp_registry/)	 - Manage the camp registry

--- a/docs/cli-reference/camp/camp_registry_sync.md
+++ b/docs/cli-reference/camp/camp_registry_sync.md
@@ -1,23 +1,23 @@
 ---
 title: "camp registry sync"
 linkTitle: "camp registry sync"
-description: "Sync current campaign with registry"
+description: "Sync current camp with registry"
 ---
 
 ## camp registry sync
 
-Sync current campaign with registry
+Sync current camp with registry
 
 ### Synopsis
 
-Update the registry entry for the current campaign.
+Update the registry entry for the current camp.
 
-Run this after moving a campaign directory to update its path
-in the registry. Reads the campaign ID from .campaign/campaign.yaml
+Run this after moving a camp directory to update its path
+in the registry. Reads the camp ID from .campaign/campaign.yaml
 and updates (or adds) the registry entry.
 
 Examples:
-  camp registry sync   # Run from inside a campaign
+  camp registry sync   # Run from inside a camp
 
 ```
 camp registry sync [flags]
@@ -37,4 +37,4 @@ camp registry sync [flags]
 
 ### SEE ALSO
 
-* [camp registry](../camp_registry/)	 - Manage the campaign registry
+* [camp registry](../camp_registry/)	 - Manage the camp registry

--- a/docs/cli-reference/camp/camp_root.md
+++ b/docs/cli-reference/camp/camp_root.md
@@ -1,16 +1,16 @@
 ---
 title: "camp root"
 linkTitle: "camp root"
-description: "Print the current campaign root"
+description: "Print the current camp root"
 ---
 
 ## camp root
 
-Print the current campaign root
+Print the current camp root
 
 ### Synopsis
 
-Print the current campaign root relative to the current working directory.
+Print the current camp root relative to the current working directory.
 
 ```
 camp root [flags]
@@ -38,4 +38,4 @@ camp root [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_run.md
+++ b/docs/cli-reference/camp/camp_run.md
@@ -1,16 +1,16 @@
 ---
 title: "camp run"
 linkTitle: "camp run"
-description: "Execute command from campaign root, or just recipe in a project"
+description: "Execute command from camp root, or just recipe in a project"
 ---
 
 ## camp run
 
-Execute command from campaign root, or just recipe in a project
+Execute command from camp root, or just recipe in a project
 
 ### Synopsis
 
-Execute any command from the campaign root directory, or run just recipes
+Execute any command from the camp root directory, or run just recipes
 in a project directory.
 
 If the first argument exactly matches a project name (a directory in projects/
@@ -18,7 +18,7 @@ with a git repo), camp dispatches to 'just' in that project's directory.
 Any remaining arguments are passed as the recipe and arguments to just.
 
 If the first argument does not match a project, it is treated as a shell command
-and executed from the campaign root directory.
+and executed from the camp root directory.
 
 Use @shortcut prefix to run from a shortcut's directory instead of root.
 Only navigation shortcuts (those with paths) can be used.
@@ -38,10 +38,10 @@ camp run [project | @shortcut] [command | recipe] [args...] [flags]
   camp run camp test all     # Run 'just test all' in projects/camp/
   camp run festival build    # Run 'just build' in projects/festival/
 
-  # Raw command from campaign root (first arg is not a project):
+  # Raw command from camp root (first arg is not a project):
   camp run just --list       # Show just recipes from root
-  camp run git status        # Run git status from campaign root
-  camp run ls -la            # List campaign root contents
+  camp run git status        # Run git status from camp root
+  camp run ls -la            # List camp root contents
 
   # Shortcut-based execution:
   camp run @p ls             # List projects/ directory
@@ -62,4 +62,4 @@ camp run [project | @shortcut] [command | recipe] [args...] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_settings.md
+++ b/docs/cli-reference/camp/camp_settings.md
@@ -13,9 +13,9 @@ Manage camp configuration
 Interactive menu for managing camp configuration.
 
 Global settings live in ~/.obey/campaign/config.json and apply to every
-campaign. Local settings live in .campaign/settings/local.json and apply
-only to the current campaign; a local theme override wins over the global
-theme while you are inside that campaign.
+camp. Local settings live in .campaign/settings/local.json and apply
+only to the current camp; a local theme override wins over the global
+theme while you are inside that camp.
 
 For non-interactive access, use 'camp settings get' and
 'camp settings set'. See docs/campaign-settings-files.md in the camp
@@ -48,6 +48,6 @@ camp settings [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp settings get](../camp_settings_get/)	 - Print camp settings
 * [camp settings set](../camp_settings_set/)	 - Set a camp setting

--- a/docs/cli-reference/camp/camp_settings_get.md
+++ b/docs/cli-reference/camp/camp_settings_get.md
@@ -18,18 +18,18 @@ prints just that value.
 Keys:
   global.theme               Color theme in ~/.obey/campaign/config.json
   global.editor              Preferred editor
-  global.campaigns_dir       Where camp create places new campaigns
+  global.campaigns_dir       Where camp create places new camps
   global.verbose             Verbose output
   global.no_color            Disable colored output
-  global.commit.sync_project_refs   When true, camp p commit updates campaign-root submodule pointer (default false)
+  global.commit.sync_project_refs   When true, camp p commit updates camp-root submodule pointer (default false)
   global.commit.disable_commit_tags When true, skip [campaign:…] tags on camp commits (default false; tags on)
-  local.theme_override       Campaign-local theme override (requires a campaign)
-  local.commit.sync_project_refs    Campaign override for project-ref sync (true/false/inherit)
-  local.commit.disable_commit_tags  Campaign override to skip commit subject tags (true/false/inherit)
-  local.campaign.name        Campaign name in .campaign/campaign.yaml
-  local.campaign.description Campaign description
-  local.campaign.mission     Campaign mission
-  local.campaign.type        Campaign type (product, research, tools, personal)
+  local.theme_override       Camp-local theme override (requires a camp)
+  local.commit.sync_project_refs    Camp override for project-ref sync (true/false/inherit)
+  local.commit.disable_commit_tags  Camp override to skip commit subject tags (true/false/inherit)
+  local.campaign.name        Camp name in .campaign/campaign.yaml
+  local.campaign.description Camp description
+  local.campaign.mission     Camp mission
+  local.campaign.type        Camp type (product, research, tools, personal)
   local.campaign.commit_hook Commit-message hook command
   effective.commit.*         Resolved commit prefs (get only; local overrides global)
 

--- a/docs/cli-reference/camp/camp_settings_set.md
+++ b/docs/cli-reference/camp/camp_settings_set.md
@@ -15,7 +15,7 @@ Set a camp setting non-interactively.
 Accepts the same keys as 'camp settings get'. Theme values are one of
 adaptive, light, dark, or high-contrast. Boolean values accept true/false.
 Setting local.theme_override to 'inherit' clears the override; local.* keys
-require running inside a campaign.
+require running inside a camp.
 
 ```
 camp settings set <key> <value> [flags]

--- a/docs/cli-reference/camp/camp_shell-init.md
+++ b/docs/cli-reference/camp/camp_shell-init.md
@@ -43,7 +43,7 @@ The following shell aliases and functions are also installed:
   cie    camp intent explore (interactive intent browser)
 
 The cgo function enables quick navigation:
-  cgo                 Interactive picker or jump to campaign root
+  cgo                 Interactive picker or jump to camp root
   cgo p               Jump to projects/
   cgo p api           Fuzzy find "api" in projects/
   cgo -c p ls         Run "ls" in projects/ directory
@@ -82,4 +82,4 @@ camp shell-init <shell> [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_shortcuts.md
+++ b/docs/cli-reference/camp/camp_shortcuts.md
@@ -13,7 +13,7 @@ List all available shortcuts
 List all navigation and command shortcuts from .campaign/settings/jumps.yaml.
 
 Navigation shortcuts (path-based):
-  These shortcuts jump to directories within the campaign.
+  These shortcuts jump to directories within the camp.
   Usage: camp go <shortcut>
 
 Command shortcuts (command-based):
@@ -49,9 +49,9 @@ camp shortcuts [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
-* [camp shortcuts add](../camp_shortcuts_add/)	 - Add a shortcut (campaign-level or project sub-shortcut)
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
+* [camp shortcuts add](../camp_shortcuts_add/)	 - Add a shortcut (camp-level or project sub-shortcut)
 * [camp shortcuts diff](../camp_shortcuts_diff/)	 - Show differences between current and default shortcuts
 * [camp shortcuts list](../camp_shortcuts_list/)	 - List shortcuts for a specific project
-* [camp shortcuts remove](../camp_shortcuts_remove/)	 - Remove a shortcut (campaign-level or project sub-shortcut)
+* [camp shortcuts remove](../camp_shortcuts_remove/)	 - Remove a shortcut (camp-level or project sub-shortcut)
 * [camp shortcuts reset](../camp_shortcuts_reset/)	 - Reset auto-generated shortcuts to current defaults

--- a/docs/cli-reference/camp/camp_shortcuts_add.md
+++ b/docs/cli-reference/camp/camp_shortcuts_add.md
@@ -1,18 +1,18 @@
 ---
 title: "camp shortcuts add"
 linkTitle: "camp shortcuts add"
-description: "Add a shortcut (campaign-level or project sub-shortcut)"
+description: "Add a shortcut (camp-level or project sub-shortcut)"
 ---
 
 ## camp shortcuts add
 
-Add a shortcut (campaign-level or project sub-shortcut)
+Add a shortcut (camp-level or project sub-shortcut)
 
 ### Synopsis
 
 Add a shortcut for quick navigation.
 
-Campaign-level shortcut (2 args):
+Camp-level shortcut (2 args):
   Adds a navigation shortcut to .campaign/settings/jumps.yaml.
   Usage: camp shortcuts add <name> <path>
 
@@ -31,7 +31,7 @@ camp shortcuts add <name> <path> | <project> <name> <path> [flags]
 
 ```
   camp shortcuts add                                  Interactive TUI mode
-  camp shortcuts add api projects/api-service/        Campaign shortcut
+  camp shortcuts add api projects/api-service/        Camp shortcut
   camp shortcuts add api projects/api/ -d "API svc"   With description
   camp shortcuts add cfg "" -c config                 Concept-only shortcut
   camp shortcuts add camp default cmd/camp/            Project sub-shortcut

--- a/docs/cli-reference/camp/camp_shortcuts_diff.md
+++ b/docs/cli-reference/camp/camp_shortcuts_diff.md
@@ -10,7 +10,7 @@ Show differences between current and default shortcuts
 
 ### Synopsis
 
-Compare your campaign's shortcuts against the current defaults.
+Compare your camp's shortcuts against the current defaults.
 
 Shows:
   + Missing    defaults not in your config (available to add)

--- a/docs/cli-reference/camp/camp_shortcuts_list.md
+++ b/docs/cli-reference/camp/camp_shortcuts_list.md
@@ -12,7 +12,7 @@ List shortcuts for a specific project
 
 List all sub-shortcuts configured for a specific project.
 
-If no project is specified, lists all campaign shortcuts.
+If no project is specified, lists all camp shortcuts.
 
 ```
 camp shortcuts list [project] [flags]

--- a/docs/cli-reference/camp/camp_shortcuts_remove.md
+++ b/docs/cli-reference/camp/camp_shortcuts_remove.md
@@ -1,18 +1,18 @@
 ---
 title: "camp shortcuts remove"
 linkTitle: "camp shortcuts remove"
-description: "Remove a shortcut (campaign-level or project sub-shortcut)"
+description: "Remove a shortcut (camp-level or project sub-shortcut)"
 ---
 
 ## camp shortcuts remove
 
-Remove a shortcut (campaign-level or project sub-shortcut)
+Remove a shortcut (camp-level or project sub-shortcut)
 
 ### Synopsis
 
 Remove a shortcut.
 
-Campaign-level shortcut (1 arg):
+Camp-level shortcut (1 arg):
   Usage: camp shortcuts remove <name>
 
 Project sub-shortcut (2 args):
@@ -25,7 +25,7 @@ camp shortcuts remove <name> or <project> <name> [flags]
 ### Examples
 
 ```
-  camp shortcuts remove api                           Remove campaign shortcut
+  camp shortcuts remove api                           Remove camp shortcut
   camp shortcuts remove festival-methodology cli      Remove project sub-shortcut
 ```
 

--- a/docs/cli-reference/camp/camp_skills.md
+++ b/docs/cli-reference/camp/camp_skills.md
@@ -1,16 +1,16 @@
 ---
 title: "camp skills"
 linkTitle: "camp skills"
-description: "Manage campaign skill directory links"
+description: "Manage camp skill directory links"
 ---
 
 ## camp skills
 
-Manage campaign skill directory links
+Manage camp skill directory links
 
 ### Synopsis
 
-Manage campaign skill bundle projection for tool interoperability.
+Manage camp skill bundle projection for tool interoperability.
 
 Skills are centralized in .campaign/skills/ and projected into tool ecosystems
 (Claude, agents, Grok, etc.) as per-bundle symlinks. This keeps a single source
@@ -19,7 +19,7 @@ of truth while preserving existing provider-native skills directories.
 Project worktrees under projects/worktrees/<project>/<name>/ are also supported:
 'camp project worktree add' projects skills into each new worktree automatically,
 and 'camp skills link --worktrees' repairs all of them. That way harnesses whose
-git root is the worktree (not the campaign root) still discover campaign skills.
+git root is the worktree (not the camp root) still discover camp skills.
 Only git checkouts are projected (directory must contain .git). A loose git root
 at projects/worktrees/<name>/ is accepted; package subdirs under it are not.
 
@@ -54,7 +54,7 @@ camp skills [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
-* [camp skills link](../camp_skills_link/)	 - Project campaign skill bundles into tool-specific skills directories
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
+* [camp skills link](../camp_skills_link/)	 - Project camp skill bundles into tool-specific skills directories
 * [camp skills status](../camp_skills_status/)	 - Show the current state of projected skill bundle symlinks
 * [camp skills unlink](../camp_skills_unlink/)	 - Remove projected skill bundle symlinks

--- a/docs/cli-reference/camp/camp_skills_link.md
+++ b/docs/cli-reference/camp/camp_skills_link.md
@@ -1,16 +1,16 @@
 ---
 title: "camp skills link"
 linkTitle: "camp skills link"
-description: "Project campaign skill bundles into tool-specific skills directories"
+description: "Project camp skill bundles into tool-specific skills directories"
 ---
 
 ## camp skills link
 
-Project campaign skill bundles into tool-specific skills directories
+Project camp skill bundles into tool-specific skills directories
 
 ### Synopsis
 
-Project campaign skill bundles from .campaign/skills/ into tool-specific
+Project camp skill bundles from .campaign/skills/ into tool-specific
 skills directories.
 
 This command creates one symlink per skill bundle. It does not replace entire
@@ -19,8 +19,8 @@ provider skills directories, so existing user skills remain intact.
 With neither --tool nor --path, skills are projected into every registered tool.
 Pass --worktrees with no --tool/--path to also project into every
 projects/worktrees/<project>/<name> git checkout (so Grok/Claude sessions
-opened inside a worktree still see campaign skills). Use --worktrees-only to
-project into worktrees without touching campaign-root tool directories.
+opened inside a worktree still see camp skills). Use --worktrees-only to
+project into worktrees without touching camp-root tool directories.
 
 Worktree discovery only includes directories with a .git file/dir. The normal
 layout is projects/worktrees/<project>/<name>/. A loose git root at
@@ -50,7 +50,7 @@ camp skills link [flags]
   -p, --path string      Custom destination directory
   -t, --tool string      Tool to link: claude, agents
       --worktrees        Also project into every projects/worktrees/*/* worktree
-      --worktrees-only   Project only into project worktrees (skip campaign tool dirs)
+      --worktrees-only   Project only into project worktrees (skip camp tool dirs)
 ```
 
 ### Options inherited from parent commands
@@ -61,4 +61,4 @@ camp skills link [flags]
 
 ### SEE ALSO
 
-* [camp skills](../camp_skills/)	 - Manage campaign skill directory links
+* [camp skills](../camp_skills/)	 - Manage camp skill directory links

--- a/docs/cli-reference/camp/camp_skills_status.md
+++ b/docs/cli-reference/camp/camp_skills_status.md
@@ -10,7 +10,7 @@ Show the current state of projected skill bundle symlinks
 
 ### Synopsis
 
-Show projection status for campaign skill bundles across tool targets.
+Show projection status for camp skill bundles across tool targets.
 
 Reports whether each tool's skills directory has projected entries from
 .campaign/skills/, is partially projected, missing, broken, or blocked.
@@ -39,4 +39,4 @@ camp skills status [flags]
 
 ### SEE ALSO
 
-* [camp skills](../camp_skills/)	 - Manage campaign skill directory links
+* [camp skills](../camp_skills/)	 - Manage camp skill directory links

--- a/docs/cli-reference/camp/camp_skills_unlink.md
+++ b/docs/cli-reference/camp/camp_skills_unlink.md
@@ -42,4 +42,4 @@ camp skills unlink [flags]
 
 ### SEE ALSO
 
-* [camp skills](../camp_skills/)	 - Manage campaign skill directory links
+* [camp skills](../camp_skills/)	 - Manage camp skill directory links

--- a/docs/cli-reference/camp/camp_stage.md
+++ b/docs/cli-reference/camp/camp_stage.md
@@ -1,23 +1,23 @@
 ---
 title: "camp stage"
 linkTitle: "camp stage"
-description: "Stage changes in the campaign root"
+description: "Stage changes in the camp root"
 ---
 
 ## camp stage
 
-Stage changes in the campaign root
+Stage changes in the camp root
 
 ### Synopsis
 
-Stage changes in the campaign root directory without committing.
+Stage changes in the camp root directory without committing.
 
 Runs the same auto-staging logic as 'camp commit' (including stale lock
 file cleanup) but stops before creating a commit, so you can use a
 different commit strategy (interactive 'git commit --patch', a GUI
 client, signing flow, etc.).
 
-At the campaign root, submodule ref changes (projects/*) are excluded
+At the camp root, submodule ref changes (projects/*) are excluded
 from staging by default to prevent accidental ref conflicts across
 machines. Use --include-refs to stage them explicitly.
 
@@ -38,7 +38,7 @@ camp stage [flags]
 
 ```
   -h, --help             help for stage
-      --include-refs     Include submodule ref changes when staging at campaign root
+      --include-refs     Include submodule ref changes when staging at camp root
       --no-drain         Do not wait for camp's queued commits first
   -p, --project string   Operate on a specific project/submodule path
       --sub              Operate on the submodule detected from current directory
@@ -52,4 +52,4 @@ camp stage [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_status.md
+++ b/docs/cli-reference/camp/camp_status.md
@@ -1,19 +1,19 @@
 ---
 title: "camp status"
 linkTitle: "camp status"
-description: "Show git status of the campaign"
+description: "Show git status of the camp"
 ---
 
 ## camp status
 
-Show git status of the campaign
+Show git status of the camp
 
 ### Synopsis
 
-Show git status of the campaign root directory.
+Show git status of the camp root directory.
 
-Works from anywhere within the campaign - always shows the status
-of the campaign root repository.
+Works from anywhere within the camp - always shows the status
+of the camp root repository.
 
 Use --sub to show status of the submodule detected from your current directory.
 Use --project/-p to show status of a specific project.
@@ -39,7 +39,7 @@ camp status [flags] [-- <git-flags>]
       --no-drain         Do not report camp's queued commits first
   -p, --project string   Status of a specific project path
   -s, --short            Give output in short format
-      --show-refs        Show campaign root submodule ref changes
+      --show-refs        Show camp root submodule ref changes
       --sub              Status of the submodule detected from current directory
 ```
 
@@ -51,5 +51,5 @@ camp status [flags] [-- <git-flags>]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp status all](../camp_status_all/)	 - Show git status of all submodules

--- a/docs/cli-reference/camp/camp_status_all.md
+++ b/docs/cli-reference/camp/camp_status_all.md
@@ -10,7 +10,7 @@ Show git status of all submodules
 
 ### Synopsis
 
-Show a visual overview of git status for all submodules in the campaign.
+Show a visual overview of git status for all submodules in the camp.
 
 Displays a table with each submodule's name, branch, clean/dirty state,
 and push status.
@@ -42,4 +42,4 @@ camp status all [flags]
 
 ### SEE ALSO
 
-* [camp status](../camp_status/)	 - Show git status of the campaign
+* [camp status](../camp_status/)	 - Show git status of the camp

--- a/docs/cli-reference/camp/camp_switch.md
+++ b/docs/cli-reference/camp/camp_switch.md
@@ -1,46 +1,46 @@
 ---
 title: "camp switch"
 linkTitle: "camp switch"
-description: "Switch to a different campaign"
+description: "Switch to a different camp"
 ---
 
 ## camp switch
 
-Switch to a different campaign
+Switch to a different camp
 
 ### Synopsis
 
-Switch to a registered campaign by name or ID.
+Switch to a registered camp by name or ID.
 
-Without arguments, opens an interactive picker to select a campaign.
-With an argument, looks up the campaign by name or ID prefix.
+Without arguments, opens an interactive picker to select a camp.
+With an argument, looks up the camp by name or ID prefix.
 Use --org or org/campaign to resolve inside one organization.
 
 Use with the shell-init wrappers for instant navigation (recommended):
   eval "$(camp shell-init zsh)"   # or bash / sh, once per shell
   camp shell-init fish | source   # fish
   csw                            # Interactive picker (local + remote machines)
-  csw my-campaign                # Switch by name
+  csw my-camp                    # Switch by name
   csw a1b2                       # Switch by ID prefix
   csw obey/platform              # Switch by org-scoped selector
-  csw archdtop:lance-arch        # Hop to a remote campaign over ssh
+  csw archdtop:lance-arch        # Hop to a remote camp over ssh
   csw -                          # Hop back to the machine/campaign this session came from
 
 'camp switch -' (csw -) is the hop-back gesture: it returns to the origin
 encoded in CAMP_HOP_ORIGIN by the outbound hop. It is registration-independent:
 the origin need not be in this machine's machines.yaml. Like other remote
 targets it refuses --print/--json. '-' is reserved and is no longer a fuzzy
-campaign query.
+camp query.
 
 The --print flag outputs just the path for shell integration (local only):
   cd "$(camp switch --print)"
 
-Use campaign@tab to navigate to a specific location in the target campaign:
+Use camp@tab to navigate to a specific location in the target camp:
   camp switch obey-campaign@p    # Switch and navigate to projects/
   camp switch obey/platform@f    # Switch inside org and navigate to festivals/
 
-Use machine:campaign to resolve a campaign on a machine registered in
-~/.obey/machines.yaml. The interactive picker also lists remote campaigns when
+Use machine:campaign to resolve a camp on a machine registered in
+~/.obey/machines.yaml. The interactive picker also lists remote camps when
 machines are configured (locals open instantly; remotes append as they load).
 Bare 'command camp switch machine:…' resolves without hopping: use the csw
 shell wrapper (or --shell-connect under shell-init) to hop.
@@ -53,7 +53,7 @@ giving up. If camp lives somewhere else, set CAMP_REMOTE_CAMP_PATH to its exact
 path on that machine. 'camp machine diagnose' shows which binary a hop would run.
 
 ```
-camp switch [campaign] [flags]
+camp switch [camp] [flags]
 ```
 
 ### Examples
@@ -62,26 +62,26 @@ camp switch [campaign] [flags]
   eval "$(camp shell-init zsh)"
   csw                                # Interactive picker (local + remotes)
   csw obey-campaign                  # Switch by name
-  csw archdtop:lance-arch            # Hop to remote campaign
+  csw archdtop:lance-arch            # Hop to remote camp
   csw -                              # Hop back via CAMP_HOP_ORIGIN
   camp switch --org obey platform    # Switch by name within an org
   camp switch obey/platform          # Switch by scoped selector
   camp switch a1b2                   # Switch by ID prefix
   camp switch --print                # Picker, output path only (local)
   camp switch obey-campaign@p        # Switch and navigate to projects/
-  camp switch --all old-reference    # Include inactive/reference campaigns
+  camp switch --all old-reference    # Include inactive/reference camps
   camp switch --org obey platform --json
 ```
 
 ### Options
 
 ```
-      --all             Include inactive and reference campaigns
+      --all             Include inactive and reference camps
   -h, --help            help for switch
-      --json            Output selected campaign and target path as JSON
-      --org string      Only switch among campaigns in this org
+      --json            Output selected camp and target path as JSON
+      --org string      Only switch among camps in this org
       --print           Print path only (for shell integration)
-      --status string   Only switch among campaigns with this lifecycle status
+      --status string   Only switch among camps with this lifecycle status
 ```
 
 ### Options inherited from parent commands
@@ -92,4 +92,4 @@ camp switch [campaign] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_sync.md
+++ b/docs/cli-reference/camp/camp_sync.md
@@ -100,4 +100,4 @@ camp sync [submodule...] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_tag.md
+++ b/docs/cli-reference/camp/camp_tag.md
@@ -1,24 +1,24 @@
 ---
 title: "camp tag"
 linkTitle: "camp tag"
-description: "Label campaigns with tags"
+description: "Label camps with tags"
 ---
 
 ## camp tag
 
-Label campaigns with tags
+Label camps with tags
 
 ### Synopsis
 
-Label campaigns with tags from a single global pool.
+Label camps with tags from a single global pool.
 
-Tags are orthogonal to orgs: any campaign can carry any tag regardless of its
-org, and the same tag can appear across orgs. Tags are a set per campaign
+Tags are orthogonal to orgs: any camp can carry any tag regardless of its
+org, and the same tag can appear across orgs. Tags are a set per camp
 (re-adding is a no-op).
 
 Commands:
-  add   Add tags to a campaign
-  rm    Remove tags from a campaign
+  add   Add tags to a camp
+  rm    Remove tags from a camp
   list  List all tags in use with counts
 
 ```
@@ -47,7 +47,7 @@ camp tag [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
-* [camp tag add](../camp_tag_add/)	 - Add tags to a campaign
-* [camp tag list](../camp_tag_list/)	 - List all tags in use with campaign counts
-* [camp tag rm](../camp_tag_rm/)	 - Remove tags from a campaign
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
+* [camp tag add](../camp_tag_add/)	 - Add tags to a camp
+* [camp tag list](../camp_tag_list/)	 - List all tags in use with camp counts
+* [camp tag rm](../camp_tag_rm/)	 - Remove tags from a camp

--- a/docs/cli-reference/camp/camp_tag_add.md
+++ b/docs/cli-reference/camp/camp_tag_add.md
@@ -1,22 +1,22 @@
 ---
 title: "camp tag add"
 linkTitle: "camp tag add"
-description: "Add tags to a campaign"
+description: "Add tags to a camp"
 ---
 
 ## camp tag add
 
-Add tags to a campaign
+Add tags to a camp
 
 ### Synopsis
 
-Add one or more tags to a campaign (set semantics).
+Add one or more tags to a camp (set semantics).
 
-Re-adding a tag the campaign already carries is a no-op for that tag. Each tag
+Re-adding a tag the camp already carries is a no-op for that tag. Each tag
 name must be lowercase letters, digits, and hyphens with no leading digit.
 
 ```
-camp tag add <campaign> <tag>... [flags]
+camp tag add <camp> <tag>... [flags]
 ```
 
 ### Examples
@@ -40,4 +40,4 @@ camp tag add <campaign> <tag>... [flags]
 
 ### SEE ALSO
 
-* [camp tag](../camp_tag/)	 - Label campaigns with tags
+* [camp tag](../camp_tag/)	 - Label camps with tags

--- a/docs/cli-reference/camp/camp_tag_list.md
+++ b/docs/cli-reference/camp/camp_tag_list.md
@@ -1,12 +1,12 @@
 ---
 title: "camp tag list"
 linkTitle: "camp tag list"
-description: "List all tags in use with campaign counts"
+description: "List all tags in use with camp counts"
 ---
 
 ## camp tag list
 
-List all tags in use with campaign counts
+List all tags in use with camp counts
 
 ```
 camp tag list [flags]
@@ -33,4 +33,4 @@ camp tag list [flags]
 
 ### SEE ALSO
 
-* [camp tag](../camp_tag/)	 - Label campaigns with tags
+* [camp tag](../camp_tag/)	 - Label camps with tags

--- a/docs/cli-reference/camp/camp_tag_rm.md
+++ b/docs/cli-reference/camp/camp_tag_rm.md
@@ -1,21 +1,21 @@
 ---
 title: "camp tag rm"
 linkTitle: "camp tag rm"
-description: "Remove tags from a campaign"
+description: "Remove tags from a camp"
 ---
 
 ## camp tag rm
 
-Remove tags from a campaign
+Remove tags from a camp
 
 ### Synopsis
 
-Remove one or more tags from a campaign.
+Remove one or more tags from a camp.
 
-Removing a tag the campaign does not carry is a no-op for that tag.
+Removing a tag the camp does not carry is a no-op for that tag.
 
 ```
-camp tag rm <campaign> <tag>... [flags]
+camp tag rm <camp> <tag>... [flags]
 ```
 
 ### Examples
@@ -39,4 +39,4 @@ camp tag rm <campaign> <tag>... [flags]
 
 ### SEE ALSO
 
-* [camp tag](../camp_tag/)	 - Label campaigns with tags
+* [camp tag](../camp_tag/)	 - Label camps with tags

--- a/docs/cli-reference/camp/camp_transfer.md
+++ b/docs/cli-reference/camp/camp_transfer.md
@@ -1,25 +1,25 @@
 ---
 title: "camp transfer"
 linkTitle: "camp transfer"
-description: "Copy files between campaigns (and machines)"
+description: "Copy files between camps (and machines)"
 ---
 
 ## camp transfer
 
-Copy files between campaigns (and machines)
+Copy files between camps (and machines)
 
 ### Synopsis
 
-Copy files between campaigns, and between this machine and a registered
+Copy files between camps, and between this machine and a registered
 fleet machine.
 
 Transfer always copies; it never moves or deletes the source.
 
 Local forms:
-  campaign:path     another registered campaign on this machine
-  path              relative to the current campaign root
+  campaign:path     another registered camp on this machine
+  path              relative to the current camp root
   local:campaign:path
-                    force the campaign reading when campaign name collides
+                    force the camp reading when camp name collides
                     with a registered machine id
 
 Machine forms (one side only; both-remote is refused):
@@ -28,8 +28,8 @@ Machine forms (one side only; both-remote is refused):
 
 See docs/transfer.md for the full grammar, transport, and skew guidance.
 
-At least one side must reference a different campaign or machine. For copies
-within the same campaign on this machine, use 'camp copy' instead.
+At least one side must reference a different camp or machine. For copies
+within the same camp on this machine, use 'camp copy' instead.
 
 ```
 camp transfer <src> <dest> [flags]
@@ -61,4 +61,4 @@ camp transfer <src> <dest> [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_triage.md
+++ b/docs/cli-reference/camp/camp_triage.md
@@ -1,18 +1,18 @@
 ---
 title: "camp triage"
 linkTitle: "camp triage"
-description: "Review the campaign's workitems in a recorded session"
+description: "Review the camp's workitems in a recorded session"
 ---
 
 ## camp triage
 
-Review the campaign's workitems in a recorded session
+Review the camp's workitems in a recorded session
 
 ### Synopsis
 
-Review the campaign's workitems in a recorded, resumable session.
+Review the camp's workitems in a recorded, resumable session.
 
-A triage run freezes what the campaign contains, collects evidence about each
+A triage run freezes what the camp contains, collects evidence about each
 item, records your verdicts, and applies them through camp's normal workitem
 machinery. Every step is written to .campaign/triage/runs/<run-id>/, so a run
 survives being interrupted and the decisions stay auditable afterwards.
@@ -21,7 +21,7 @@ Camp never calls a model. Agents read the queue and submit evidence and
 proposals; you approve them; camp applies what you approved.
 
 Session:
-  start     Snapshot the campaign and open a run
+  start     Snapshot the camp and open a run
   status    Show where the active run stands
   abandon   Close the active run without applying it
 
@@ -65,7 +65,7 @@ camp triage [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp triage abandon](../camp_triage_abandon/)	 - Close the active triage run without applying it
 * [camp triage apply](../camp_triage_apply/)	 - Execute the approved verdicts of the active run
 * [camp triage approve](../camp_triage_approve/)	 - Record verdicts on proposed dispositions
@@ -77,6 +77,6 @@ camp triage [flags]
 * [camp triage queue](../camp_triage_queue/)	 - List rows awaiting judgment
 * [camp triage refresh](../camp_triage_refresh/)	 - Re-check the active run against the world
 * [camp triage review](../camp_triage_review/)	 - Render the review documents for the active run
-* [camp triage start](../camp_triage_start/)	 - Snapshot the campaign and open a triage run
+* [camp triage start](../camp_triage_start/)	 - Snapshot the camp and open a triage run
 * [camp triage status](../camp_triage_status/)	 - Show where the active triage run stands
-* [camp triage verify](../camp_triage_verify/)	 - Prove the campaign matches the approved decisions
+* [camp triage verify](../camp_triage_verify/)	 - Prove the camp matches the approved decisions

--- a/docs/cli-reference/camp/camp_triage_abandon.md
+++ b/docs/cli-reference/camp/camp_triage_abandon.md
@@ -41,4 +41,4 @@ camp triage abandon [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_apply.md
+++ b/docs/cli-reference/camp/camp_triage_apply.md
@@ -27,7 +27,7 @@ the commit it made, and the command that reverses it. The undo is derived from
 where the workitem actually landed, not from where the plan expected it to.
 
 A failure stops the pass. Rows after it stay pending rather than being applied
-against a campaign that is no longer in the state the plan was compiled for.
+against a camp that is no longer in the state the plan was compiled for.
 Re-running continues from the first row without an applied receipt, so an
 interrupted apply is resumed rather than restarted.
 
@@ -56,4 +56,4 @@ camp triage apply [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_approve.md
+++ b/docs/cli-reference/camp/camp_triage_approve.md
@@ -60,4 +60,4 @@ camp triage approve [stable-id...] [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_evidence.md
+++ b/docs/cli-reference/camp/camp_triage_evidence.md
@@ -38,6 +38,6 @@ camp triage evidence [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session
 * [camp triage evidence set](../camp_triage_evidence_set/)	 - Store an evidence record for a row
 * [camp triage evidence template](../camp_triage_evidence_template/)	 - Print an evidence record with the known facts filled in

--- a/docs/cli-reference/camp/camp_triage_init.md
+++ b/docs/cli-reference/camp/camp_triage_init.md
@@ -42,4 +42,4 @@ camp triage init [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_priorities.md
+++ b/docs/cli-reference/camp/camp_triage_priorities.md
@@ -42,4 +42,4 @@ camp triage priorities [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_profile.md
+++ b/docs/cli-reference/camp/camp_triage_profile.md
@@ -12,7 +12,7 @@ Show the resolved triage profile
 
 Print the profile a run would use, fully merged.
 
-Resolution is: the campaign's .campaign/triage/profile.yaml when it exists,
+Resolution is: the camp's .campaign/triage/profile.yaml when it exists,
 otherwise the named built-in. Keys the file omits inherit the built-in default.
 A type's policy is types/<type>.yaml, else types/_default.yaml, else camp's
 built-in, and a type policy that declares dispositions replaces the inherited
@@ -31,7 +31,7 @@ camp triage profile [flags]
 ```
   -h, --help             help for profile
       --json             Output result as a single JSON object
-      --profile string   Resolve a named built-in instead of the campaign's: default, sweep, or deep
+      --profile string   Resolve a named built-in instead of the camp's: default, sweep, or deep
       --resolved         Print the fully merged profile (the default and only mode today)
 ```
 
@@ -43,4 +43,4 @@ camp triage profile [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_propose.md
+++ b/docs/cli-reference/camp/camp_triage_propose.md
@@ -14,7 +14,7 @@ Propose what should happen to one row.
 
 The disposition is a label from the row's type vocabulary; camp resolves it to
 the action it will actually perform and records both. That indirection is what
-lets a campaign rename its labels without triage learning a new mutation.
+lets a camp rename its labels without triage learning a new mutation.
 
 A proposal is not a decision. Terminal actions - dungeon moves and splits -
 always require a human to approve them, and the result says so.
@@ -51,4 +51,4 @@ camp triage propose <stable-id> [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_queue.md
+++ b/docs/cli-reference/camp/camp_triage_queue.md
@@ -50,4 +50,4 @@ camp triage queue [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_refresh.md
+++ b/docs/cli-reference/camp/camp_triage_refresh.md
@@ -56,4 +56,4 @@ camp triage refresh [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_review.md
+++ b/docs/cli-reference/camp/camp_triage_review.md
@@ -49,4 +49,4 @@ camp triage review [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_start.md
+++ b/docs/cli-reference/camp/camp_triage_start.md
@@ -1,20 +1,20 @@
 ---
 title: "camp triage start"
 linkTitle: "camp triage start"
-description: "Snapshot the campaign and open a triage run"
+description: "Snapshot the camp and open a triage run"
 ---
 
 ## camp triage start
 
-Snapshot the campaign and open a triage run
+Snapshot the camp and open a triage run
 
 ### Synopsis
 
-Snapshot the campaign's workitems and open a triage run.
+Snapshot the camp's workitems and open a triage run.
 
-The snapshot is frozen: the run records what the campaign contained when it
+The snapshot is frozen: the run records what the camp contained when it
 started, along with the resolved profile it will be judged under, so a verdict
-stays explainable even after the campaign and the profile move on.
+stays explainable even after the camp and the profile move on.
 
 Scope expressions use the same filters as camp workitem, one per --scope flag:
 
@@ -40,7 +40,7 @@ camp triage start [flags]
       --identity string     Override the profile's identity policy: repair (adopt and report) or strict (refuse and list)
       --json                Output result as a single JSON object
       --no-workflow-doc     Skip the companion WORKFLOW.md scaffold
-      --profile string      Use a named built-in profile instead of the campaign's: default, sweep, or deep
+      --profile string      Use a named built-in profile instead of the camp's: default, sweep, or deep
       --scope stringArray   Limit the run with a key:value filter (repeat for more)
 ```
 
@@ -52,4 +52,4 @@ camp triage start [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_status.md
+++ b/docs/cli-reference/camp/camp_triage_status.md
@@ -12,17 +12,17 @@ Show where the active triage run stands
 
 Show where the active triage run stands.
 
-Status reports the session, not the campaign. It reads the run's own recorded
+Status reports the session, not the camp. It reads the run's own recorded
 data and never walks the filesystem, so it is instant and keeps meaning even
-after the campaign moves underneath the run. Comparing a run against the
-current state of the campaign is what camp triage refresh does.
+after the camp moves underneath the run. Comparing a run against the
+current state of the camp is what camp triage refresh does.
 
-When the last refresh is older than the campaign's runs.stale_after_days
+When the last refresh is older than the camp's runs.stale_after_days
 threshold, or workitems have changed since, it also prints the same one-line
 notice high-traffic commands share (from the cached verdict, not a discovery
 walk).
 
-Exits 0 when there is no run: a campaign that has not triaged yet is a state,
+Exits 0 when there is no run: a camp that has not triaged yet is a state,
 not an error.
 
 ```
@@ -45,4 +45,4 @@ camp triage status [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_triage_verify.md
+++ b/docs/cli-reference/camp/camp_triage_verify.md
@@ -1,18 +1,18 @@
 ---
 title: "camp triage verify"
 linkTitle: "camp triage verify"
-description: "Prove the campaign matches the approved decisions"
+description: "Prove the camp matches the approved decisions"
 ---
 
 ## camp triage verify
 
-Prove the campaign matches the approved decisions
+Prove the camp matches the approved decisions
 
 ### Synopsis
 
 Check every applied row against a fresh discovery pass.
 
-Apply without proof is just hope. Verify re-walks the campaign and compares
+Apply without proof is just hope. Verify re-walks the camp and compares
 what it finds against what each receipt says happened: a parked workitem should
 carry that stage, a retired one should no longer be discoverable outside the
 dungeon, a split's successors should all exist.
@@ -20,7 +20,7 @@ dungeon, a split's successors should all exist.
 It reads receipts, not the plan. The plan is what was intended; the receipts
 are what actually ran, and only the second one can be checked against reality.
 
-An unexplained mismatch exits 1. That is the whole signal: the campaign is not
+An unexplained mismatch exits 1. That is the whole signal: the camp is not
 in the state the approved decisions said it would be. A mismatch someone has
 already accounted for carries an explanation and does not fail the run.
 
@@ -47,4 +47,4 @@ camp triage verify [flags]
 
 ### SEE ALSO
 
-* [camp triage](../camp_triage/)	 - Review the campaign's workitems in a recorded session
+* [camp triage](../camp_triage/)	 - Review the camp's workitems in a recorded session

--- a/docs/cli-reference/camp/camp_unbundle.md
+++ b/docs/cli-reference/camp/camp_unbundle.md
@@ -35,4 +35,4 @@ camp unbundle [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_unpin.md
+++ b/docs/cli-reference/camp/camp_unpin.md
@@ -32,4 +32,4 @@ camp unpin [name] [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_unregister.md
+++ b/docs/cli-reference/camp/camp_unregister.md
@@ -1,26 +1,26 @@
 ---
 title: "camp unregister"
 linkTitle: "camp unregister"
-description: "Remove campaign from registry"
+description: "Remove a camp from the registry"
 ---
 
 ## camp unregister
 
-Remove campaign from registry
+Remove a camp from the registry
 
 ### Synopsis
 
-Remove a campaign from the global registry.
+Remove a camp from the global registry.
 
-This does NOT delete any files - it only removes the campaign from
+This does NOT delete any files - it only removes the camp from
 tracking in the global registry. Use this when:
-  - A campaign directory was deleted manually
-  - A campaign was moved to a different location
-  - You no longer want to track a campaign
+  - A camp directory was deleted manually
+  - A camp was moved to a different location
+  - You no longer want to track a camp
 
-The campaign files remain untouched on disk.
+The camp files remain untouched on disk.
 
-You can specify the campaign by name or ID (or ID prefix).
+You can specify the camp by name or ID (or ID prefix).
 
 Examples:
   camp unregister old-project            # Remove by name
@@ -46,4 +46,4 @@ camp unregister <name-or-id> [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_version.md
+++ b/docs/cli-reference/camp/camp_version.md
@@ -39,4 +39,4 @@ camp version [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them

--- a/docs/cli-reference/camp/camp_workflow.md
+++ b/docs/cli-reference/camp/camp_workflow.md
@@ -12,7 +12,7 @@ Manage workflow collections
 
 Manage workflow collections.
 
-A workflow collection is a campaign directory under workflow/<type>/ with
+A workflow collection is a camp directory under workflow/<type>/ with
 navigation config and workitem type support.
 
 ### Options
@@ -29,7 +29,7 @@ navigation config and workitem type support.
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp workflow create](../camp_workflow_create/)	 - Create a custom workflow collection
 * [camp workflow doctor](../camp_workflow_doctor/)	 - Report workflow surface inconsistencies
 * [camp workflow list](../camp_workflow_list/)	 - List user-created workflow collections

--- a/docs/cli-reference/camp/camp_workflow_create.md
+++ b/docs/cli-reference/camp/camp_workflow_create.md
@@ -14,7 +14,7 @@ Create a custom workflow collection under workflow/<type>/.
 
 The command creates the workflow directory, terminal dungeon directories,
 .gitkeep files, and an OBEY.md guide, then registers the collection in
-campaign configuration through a concept and navigation shortcut. A shortcut is
+camp configuration through a concept and navigation shortcut. A shortcut is
 required. Use --dry-run to inspect planned writes and --json for
 machine-readable planning or apply results.
 

--- a/docs/cli-reference/camp/camp_workflow_doctor.md
+++ b/docs/cli-reference/camp/camp_workflow_doctor.md
@@ -10,7 +10,7 @@ Report workflow surface inconsistencies
 
 ### Synopsis
 
-Report inconsistencies between workflow directories and campaign configuration.
+Report inconsistencies between workflow directories and camp configuration.
 
 The command reads campaign.yaml, .campaign/settings/jumps.yaml, workflow/
 directories, and the navigation cache to find missing concepts, stale

--- a/docs/cli-reference/camp/camp_workflow_list.md
+++ b/docs/cli-reference/camp/camp_workflow_list.md
@@ -10,9 +10,9 @@ List user-created workflow collections
 
 ### Synopsis
 
-List user-created workflow collections registered in the campaign.
+List user-created workflow collections registered in the camp.
 
-The command reads campaign configuration and workflow/ directories, then shows
+The command reads camp configuration and workflow/ directories, then shows
 each collection's shortcut, item count, and latest workitem update. Built-in
 workflow types are omitted so the output focuses on custom collections. Use
 --json for machine-readable workflow inventory output.

--- a/docs/cli-reference/camp/camp_workflow_shortcut.md
+++ b/docs/cli-reference/camp/camp_workflow_shortcut.md
@@ -12,7 +12,7 @@ Manage navigation shortcuts for workflow collections
 
 Manage navigation shortcuts for custom workflow collections.
 
-Workflow shortcuts are stored in campaign configuration and point to
+Workflow shortcuts are stored in camp configuration and point to
 workflow/<type>/ directories. Use subcommands to attach or repair shortcut
 entries after creating or moving workflow collections.
 

--- a/docs/cli-reference/camp/camp_workflow_show.md
+++ b/docs/cli-reference/camp/camp_workflow_show.md
@@ -12,7 +12,7 @@ Show a workflow collection's config and recent workitems
 
 Show configuration and recent workitems for a workflow collection.
 
-The command reads campaign configuration plus the workflow/<type>/ directory,
+The command reads camp configuration plus the workflow/<type>/ directory,
 then prints the collection path, shortcut state, concept state, and recent
 .workitem-backed items. Use --json for machine-readable collection details and
 recent workitem data.

--- a/docs/cli-reference/camp/camp_workitem.md
+++ b/docs/cli-reference/camp/camp_workitem.md
@@ -1,16 +1,16 @@
 ---
 title: "camp workitem"
 linkTitle: "camp workitem"
-description: "View active campaign work items"
+description: "View active camp work items"
 ---
 
 ## camp workitem
 
-View active campaign work items
+View active camp work items
 
 ### Synopsis
 
-View active campaign work items.
+View active camp work items.
 
 Launches an interactive dashboard on a TTY. Non-interactive callers must pass
 --json, --list, or --print.
@@ -54,7 +54,7 @@ camp workitem [flags]
 
 ### SEE ALSO
 
-* [camp](../camp/)	 - Campaign management CLI for multi-project AI workspaces
+* [camp](../camp/)	 - Manage your camps and the projects and festivals inside them
 * [camp workitem adopt](../camp_workitem_adopt/)	 - Adopt an existing directory or file as a workitem
 * [camp workitem commit](../camp_workitem_commit/)	 - Commit changes scoped to a workitem
 * [camp workitem commits](../camp_workitem_commits/)	 - List commits referencing a workitem

--- a/docs/cli-reference/camp/camp_workitem_adopt.md
+++ b/docs/cli-reference/camp/camp_workitem_adopt.md
@@ -10,7 +10,7 @@ Adopt an existing directory or file as a workitem
 
 ### Synopsis
 
-Attach workitem metadata to an existing campaign directory or markdown file.
+Attach workitem metadata to an existing camp directory or markdown file.
 
 With a directory argument, writes a .workitem marker (the directory must exist
 and must not already contain a .workitem). With --file <path.md>, stamps a
@@ -47,4 +47,4 @@ camp workitem adopt [dir] [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_commit.md
+++ b/docs/cli-reference/camp/camp_workitem_commit.md
@@ -15,7 +15,7 @@ Stage and commit changes belonging to a resolved workitem.
 The staging plan is computed from the resolver context (cwd-aware, with
 explicit positional <selector> or --project overrides) and printed to stderr
 before the commit runs. The plan never silently widens to "git add ." at the
-campaign root.
+camp root.
 
 See docs/workitem-commit-reference.md for the staging matrix and flag
 precedence.
@@ -48,4 +48,4 @@ camp workitem commit [selector] [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_commits.md
+++ b/docs/cli-reference/camp/camp_workitem_commits.md
@@ -12,10 +12,10 @@ List commits referencing a workitem
 
 List commits referencing this workitem, newest first.
 
-When the campaign event ledger already holds the workitem's commit evidence,
+When the camp event ledger already holds the workitem's commit evidence,
 the answer comes from a single merged ledger read (fast path). Otherwise it
-falls back to scanning the campaign root and every linked
-project/repo/worktree/festival repo for commits whose campaign tag references
+falls back to scanning the camp root and every linked
+project/repo/worktree/festival repo for commits whose camp tag references
 the workitem's ref (pre-ledger history).
 
 Use --json for structured output; the "source" field reports which path
@@ -47,4 +47,4 @@ camp workitem commits [selector] [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_completion.md
+++ b/docs/cli-reference/camp/camp_workitem_completion.md
@@ -37,4 +37,4 @@ camp workitem completion <selector> <review|acknowledge|recurring> [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_convert.md
+++ b/docs/cli-reference/camp/camp_workitem_convert.md
@@ -58,4 +58,4 @@ camp workitem convert <selector> [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_create.md
+++ b/docs/cli-reference/camp/camp_workitem_create.md
@@ -25,7 +25,7 @@ types, the recommended structured-workflow scaffold is:
   cd workflow/<type>/<slug> && fest create workflow <slug>
 
 For other types (feature, bug, chore, …), no festival scaffold is implied;
-populate campaign-governed content under the new directory as needed.
+populate camp-governed content under the new directory as needed.
 
 Use "camp workitem adopt" to attach a marker to an existing directory.
 Use --json for machine-readable identity. next.command is set only for
@@ -58,4 +58,4 @@ camp workitem create <slug> [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_demote.md
+++ b/docs/cli-reference/camp/camp_workitem_demote.md
@@ -42,4 +42,4 @@ camp workitem demote [id] [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_doctor.md
+++ b/docs/cli-reference/camp/camp_workitem_doctor.md
@@ -10,7 +10,7 @@ Report link-registry health issues
 
 ### Synopsis
 
-Report health issues in the campaign workitem link registry.
+Report health issues in the camp workitem link registry.
 
 The command reads .campaign/workitems/links.yaml, scans .workitem metadata on
 disk, and checks current-workitem and priority stores for stale or inconsistent
@@ -38,4 +38,4 @@ camp workitem doctor [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_group.md
+++ b/docs/cli-reference/camp/camp_workitem_group.md
@@ -27,4 +27,4 @@ camp workitem group <selector> <group|clear> [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_id.md
+++ b/docs/cli-reference/camp/camp_workitem_id.md
@@ -16,9 +16,9 @@ With no argument, the workitem is detected from the current context using the
 same tiered resolution as `camp workitem resolve` (explicit selector, cwd
 ancestor, linked scope, festival, current-workitem pointer). With an argument,
 the workitem is resolved through the shared selector family: workitem ref,
-stable id, key, campaign-relative path, directory slug, festival id, or intent
+stable id, key, camp-relative path, directory slug, festival id, or intent
 frontmatter id. A filesystem path (absolute or relative to the current directory)
-is accepted and translated to the campaign-relative form the selector expects.
+is accepted and translated to the camp-relative form the selector expects.
 
 Stdout is the bare durable id for shell scripting: stable .workitem id when
 present, otherwise a source-declared id (festival fest.yaml id or intent
@@ -54,4 +54,4 @@ camp workitem id [selector-or-path] [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_link.md
+++ b/docs/cli-reference/camp/camp_workitem_link.md
@@ -10,7 +10,7 @@ Create a workitem link
 
 ### Synopsis
 
-Attach a workitem to a project, festival, worktree, or campaign path.
+Attach a workitem to a project, festival, worktree, or camp path.
 
 Links are stored in .campaign/workitems/links.yaml and connect a .workitem
 identity to an explicit scope for planning, execution, and lookup. Pass a
@@ -59,4 +59,4 @@ camp workitem link <selector> [path] [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_links.md
+++ b/docs/cli-reference/camp/camp_workitem_links.md
@@ -10,7 +10,7 @@ List workitem links
 
 ### Synopsis
 
-List workitem links recorded in the campaign link registry.
+List workitem links recorded in the camp link registry.
 
 The command reads .campaign/workitems/links.yaml and prints every link, or only
 links for the supplied workitem selector. Use this to audit which projects,
@@ -36,4 +36,4 @@ camp workitem links [selector] [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_list.md
+++ b/docs/cli-reference/camp/camp_workitem_list.md
@@ -10,7 +10,7 @@ List or browse filtered workitems
 
 ### Synopsis
 
-List campaign workitems with the same filters used by the dashboard.
+List camp workitems with the same filters used by the dashboard.
 
 In a terminal, this opens the TUI with visible, editable prefilters. When
 stdout is not a terminal, it prints a compact grouped list. Use --json for the
@@ -60,4 +60,4 @@ camp workitem list [type|status|category] [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_priority.md
+++ b/docs/cli-reference/camp/camp_workitem_priority.md
@@ -41,4 +41,4 @@ camp workitem priority <selector> <high|medium|low|clear> [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_promote.md
+++ b/docs/cli-reference/camp/camp_workitem_promote.md
@@ -56,4 +56,4 @@ camp workitem promote [id] --target <target> [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_rename.md
+++ b/docs/cli-reference/camp/camp_workitem_rename.md
@@ -46,4 +46,4 @@ camp workitem rename <selector> <new-name> [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_repair.md
+++ b/docs/cli-reference/camp/camp_workitem_repair.md
@@ -42,4 +42,4 @@ camp workitem repair <path> [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_resolve.md
+++ b/docs/cli-reference/camp/camp_workitem_resolve.md
@@ -10,7 +10,7 @@ Print the workitem for the current context
 
 ### Synopsis
 
-Resolve the active workitem from the current campaign context.
+Resolve the active workitem from the current camp context.
 
 Resolution checks explicit selectors, cwd, festival context, linked scopes,
 and the current-workitem file without mutating any files. Use --explain to show
@@ -39,4 +39,4 @@ camp workitem resolve [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_split.md
+++ b/docs/cli-reference/camp/camp_workitem_split.md
@@ -58,4 +58,4 @@ camp workitem split <selector> [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_stage.md
+++ b/docs/cli-reference/camp/camp_workitem_stage.md
@@ -27,4 +27,4 @@ camp workitem stage <selector> <current|next|active|parked|clear> [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_sweep.md
+++ b/docs/cli-reference/camp/camp_workitem_sweep.md
@@ -64,4 +64,4 @@ camp workitem sweep [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_unlink.md
+++ b/docs/cli-reference/camp/camp_workitem_unlink.md
@@ -10,7 +10,7 @@ Remove workitem links
 
 ### Synopsis
 
-Remove workitem links from the campaign link registry.
+Remove workitem links from the camp link registry.
 
 The command updates .campaign/workitems/links.yaml by link id, workitem
 selector, explicit path, or scope filter. Use --all when a selector matches
@@ -41,4 +41,4 @@ camp workitem unlink [selector] [path] [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_validate.md
+++ b/docs/cli-reference/camp/camp_workitem_validate.md
@@ -41,4 +41,4 @@ camp workitem validate [path] [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/camp/camp_workitem_worktree.md
+++ b/docs/cli-reference/camp/camp_workitem_worktree.md
@@ -61,4 +61,4 @@ camp workitem worktree <selector> [flags]
 
 ### SEE ALSO
 
-* [camp workitem](../camp_workitem/)	 - View active campaign work items
+* [camp workitem](../camp_workitem/)	 - View active camp work items

--- a/docs/cli-reference/fest/fest_commit.md
+++ b/docs/cli-reference/fest/fest_commit.md
@@ -17,19 +17,19 @@ a linked project directory (see 'fest link'), or use --festival to specify one.
 
 The fest commit command wraps git commit and automatically:
   1. Stages changes and prepends the festival reference to the commit message
-  2. Creates a campaign root commit for festival-scoped files (task docs, progress, state)
+  2. Creates a camp root commit for festival-scoped files (task docs, progress, state)
 
 When a festival or sequence has a linked project, up to two commits are created
 even when this command is run from inside the festival:
   - Project commit: stages all project changes (skipped when the project is clean)
-  - Campaign root commit: stages only festival directory, .campaign/fest/,
+  - Camp root commit: stages only festival directory, .campaign/fest/,
     festivals/.festival/.state/, and the submodule pointer
 
 The sequence's fest_working_dir is preferred over the festival navigation link
 and legacy fest.yaml project_path. A festival with no linked project creates one
-campaign-root commit containing only festival-scoped files (not git add -A).
+camp root commit containing only festival-scoped files (not git add -A).
 
-Use --no-root to skip the campaign root commit.
+Use --no-root to skip the camp root commit.
 
 Reference format: [FE-{id}]
   - FE: Festival component identifier
@@ -70,7 +70,7 @@ Examples:
   # Skip auto-staging, commit only what's already staged
 
   fest commit --auto-write
-  # Run the configured campaign commit-message hook from the target repo
+  # Run the configured camp commit-message hook from the target repo
 ```
 
 ```
@@ -87,7 +87,7 @@ fest commit [flags]
   -h, --help              help for commit
       --json              output result as JSON
   -m, --message string    commit message (required unless --auto-write)
-      --no-root           skip campaign root commit (project commit only)
+      --no-root           skip camp root commit (project commit only)
       --no-tag            don't prepend task reference
       --stage             auto-stage all changes before commit (default true)
       --task string       task reference ID to use (e.g., FEST-123456)

--- a/docs/cli-reference/fest/fest_promote.md
+++ b/docs/cli-reference/fest/fest_promote.md
@@ -18,7 +18,7 @@ Each transition validates readiness:
   active → completed:  All tasks must be completed
 
 By default, promotes the festival you are currently inside. From elsewhere in a
-campaign, pass a festival name or run promote interactively to pick one:
+camp, pass a festival name or run promote interactively to pick one:
 ```bash
   fest promote my-feature       Promote a festival by name (tab completion)
   fest promote                  Pick a festival from a fuzzy picker (in a terminal)

--- a/docs/cli-reference/fest/fest_show.md
+++ b/docs/cli-reference/fest/fest_show.md
@@ -13,13 +13,13 @@ Display festival information
 Display festival information for a single festival.
 
 When run inside a festival directory, shows the current festival's details.
-When run outside a festival in an interactive campaign workspace, opens a
+When run outside a festival in an interactive camp, opens a
 cyclable view; use ←/→ to move between festivals and q/Ctrl+C to exit.
 
 ```bash
   fest show                        Show current festival, or cycle festivals in a workspace
   fest show <name>                 Show details of a specific festival by name
-  fest show --festival <selector>  Show a festival by explicit selector (campaign workspace)
+  fest show --festival <selector>  Show a festival by explicit selector (from a camp)
 ```
 
 To list festivals by status, use 'fest list' (e.g. 'fest list active',
@@ -41,7 +41,7 @@ fest show [festival-name] [flags]
 
 ```
       --collapsed         show collapsed tree with counters only
-      --festival string   festival selector (name or ID) from within a campaign workspace
+      --festival string   festival selector (name or ID) from within a camp
       --goals             show goals for phases and sequences
   -h, --help              help for show
       --inprogress        expand only in-progress phases and sequences

--- a/docs/cli-reference/fest/fest_types_list.md
+++ b/docs/cli-reference/fest/fest_types_list.md
@@ -15,7 +15,7 @@ List types you can pass to fest create, grouped by level.
 Sources:
   - Festival workflow types from festival_types.yaml (create festival --type)
   - Phase/sequence/task scaffold packages under the methodology templates tree
-    (~/.obey/fest/festivals/.festival/templates or campaign festivals/.festival/templates)
+    (~/.obey/fest/festivals/.festival/templates or camp festivals/.festival/templates)
   - Custom overrides in a festival's .festival/templates/
 
 Examples:

--- a/docs/cli-reference/fest/fest_watch.md
+++ b/docs/cli-reference/fest/fest_watch.md
@@ -17,7 +17,7 @@ Without a selector, it watches the current festival when run from a festival
 directory, the linked festival when run from a linked project directory, or a
 standalone WORKFLOW.md from that workflow directory.
 
-From a campaign or festivals workspace in an interactive terminal, fest watch
+From a camp or festivals workspace in an interactive terminal, fest watch
 opens a festival picker. Watch mode refreshes in place until you press Ctrl+C.
 It does not change your shell directory.
 


### PR DESCRIPTION
## Summary
- Bump `camp` submodule pin to `435dd2b0` and `fest` submodule pin to `598f7a96` (current origin/main heads at the time of this PR) so festival tracks the mains produced by the CC0008 camp-rename merges.
- Regenerate CLI reference docs (`just docs camp` / `just docs fest`) so `docs/cli-reference/` reflects the renamed camp/camps vocabulary now emitted by both CLIs (e.g. `fest promote` help text now says "From elsewhere in a camp..." instead of "...a campaign,").

## Test gate results
`just test all` (unit + integration, verbatim tail):

```
│ Total Time: 159.14s                           │
│ ✓ ALL 5033 TESTS PASSED                       │
...
│ Total Time: 988.36s                                                          │
│ ✗ 69/1005 TESTS FAILED                                                       │
╰──────────────────────────────────────────────────────────────────────────────╯
```

All 5033 unit tests pass. The 69 integration failures are pre-existing on the `camp` submodule at the pinned commit `435dd2b0` itself, not caused by this bump or the docs regen: `camp`'s own integration test suite has not yet been updated for its own CC0008 rename. Example (verified by re-running in isolation):

```
Error: "error: not inside a camp directory\nhint: run 'camp init' ..." does not contain "campaign"
Test:  TestRoot_NotInCampaign
Messages: error should mention campaign detection
```

and

```
Error: "...Camp Leverage: 0.1x (1 author detected)..." does not contain "Campaign Leverage:"
Test:  TestLeverage_Autocommit/scoring_commits_only_the_leverage_data
```

All 69 failures share this one root cause: stale "campaign" wording assertions in `camp/tests/integration` against a CLI that now correctly emits "camp" vocabulary. This needs a follow-up fix in the `camp` repo itself (updating its own integration test assertions), tracked separately from this pin bump.

## Test plan
- [x] `just docs camp` and `just docs fest` regenerated cleanly
- [x] `just test all` run; unit suite green, integration failures triaged and confirmed pre-existing/out of scope for this PR
- [ ] Follow-up: fix stale "campaign" assertions in `camp`'s own integration test suite (separate PR in Obedience-Corp/camp)