### PR TITLE
release-operator: accept any checkout at origin/main instead of requiring a branch named main

### DIFF
--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -29,7 +29,7 @@ refresh-dev:
 require-stable-publish-credentials:
     go -C tools/release-operator run . require-stable-publish-credentials --repo-root ../..
 
-# Show operator-facing release readiness for current branch and latest tags
+# Show operator-facing release readiness for the current checkout and latest tags
 [no-cd]
 status:
     go -C tools/release-operator run . status --repo-root ../..
@@ -67,7 +67,7 @@ rc fest="latest" camp="latest" festival_installer="latest":
     go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" --festival-installer-tag "{{festival_installer}}" rc
 
 [no-cd]
-[confirm("This will create a stable festival release on main using the selected fest/camp/festival-installer tags (the pin commit ships through an auto-merged PR because main is PR-only). Run 'just release plan stable <fest> <camp> <festival_installer>' first if you want to see the exact tags (positional selectors: latest, keep, or vX.Y.Z). Continue?")]
+[confirm("This will create a stable festival release from this checkout, which must be at origin/main (any branch name, or a detached HEAD), using the selected fest/camp/festival-installer tags (the pin commit ships through an auto-merged PR because main is PR-only). Run 'just release plan stable <fest> <camp> <festival_installer>' first if you want to see the exact tags (positional selectors: latest, keep, or vX.Y.Z). Continue?")]
 stable fest="latest" camp="latest" festival_installer="latest":
     just test release-operator
     go -C tools/release-operator run . bundle --repo-root ../.. --fest-tag "{{fest}}" --camp-tag "{{camp}}" --festival-installer-tag "{{festival_installer}}" stable
@@ -101,7 +101,7 @@ npm-publish-dry-run version="latest" mode="stable":
 # First stable release bootstrap:
 # - create/push fest + camp stable tags at their current HEAD
 # - pin festival submodules to those tags
-# - commit the submodule pointer update (through an auto-merged PR when on main)
+# - commit the submodule pointer update (through an auto-merged PR against main)
 # - create/push festival stable tag
 [private]
 [no-cd]
@@ -114,7 +114,7 @@ draft-bootstrap version fest_version camp_version festival_installer_version:
 # - mode=rc: latest rc tags (vX.Y.Z-rc.N)
 # - mode=dev: latest dev tags (vX.Y.Z-dev.N)
 # - pin submodules, refresh docs, commit pointer update if needed
-#   (through an auto-merged PR when on main, direct push otherwise)
+#   (through an auto-merged PR for stable, direct push for dev/rc)
 # - create/push festival release tag for the selected channel
 [private]
 [no-cd]

--- a/tools/release-operator/checkout.go
+++ b/tools/release-operator/checkout.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// releaseBaseBranch is the branch on origin that every bundled stable
+// release ships from. It names a branch on the remote, not a requirement
+// about the local checkout.
+const releaseBaseBranch = "main"
+
+// originBaseRef is the remote-tracking ref for releaseBaseBranch.
+const originBaseRef = "refs/remotes/origin/" + releaseBaseBranch
+
+// checkoutState is where the festival repo's HEAD stands relative to
+// origin/main.
+//
+// The release flow used to require a local branch literally named main.
+// That made it unrunnable from a normal festival checkout: the repo is
+// worked through git worktrees, and git refuses to check out one branch in
+// two worktrees at once, so whichever worktree happened to hold main became
+// the only place a release could be cut. What a release actually needs is
+// the commit origin/main points at, so the flow checks the commit and lets
+// the branch be named anything, or be no branch at all.
+type checkoutState struct {
+	// Branch is the checked-out branch, or "" when HEAD is detached.
+	Branch string
+	// Head is the commit HEAD resolves to.
+	Head string
+	// OriginBase is the commit origin/main resolves to, or "" when that
+	// remote-tracking ref has never been fetched into this checkout.
+	OriginBase string
+	// Dirty reports uncommitted changes in the superproject worktree.
+	Dirty bool
+}
+
+// atReleaseBase reports whether HEAD is exactly the commit origin/main
+// points at.
+func (s checkoutState) atReleaseBase() bool {
+	return s.Head != "" && s.Head == s.OriginBase
+}
+
+// onBaseBranch reports whether the local branch is literally named main,
+// regardless of where it stands relative to origin.
+func (s checkoutState) onBaseBranch() bool {
+	return s.Branch == releaseBaseBranch
+}
+
+// String renders the checkout for release output: the branch name when HEAD
+// is on one, and where the detached HEAD stands otherwise.
+func (s checkoutState) String() string {
+	switch {
+	case s.Branch != "":
+		return s.Branch
+	case s.atReleaseBase():
+		return "detached at origin/" + releaseBaseBranch
+	default:
+		return "detached at " + shortCommit(s.Head)
+	}
+}
+
+func shortCommit(commit string) string {
+	if commit == "" {
+		return "an unknown commit"
+	}
+	if len(commit) > 12 {
+		return commit[:12]
+	}
+	return commit
+}
+
+// readCheckoutState reads the checkout's position from local refs only. A
+// missing origin/main leaves OriginBase empty rather than failing, so the
+// dev and rc paths, which never consult it, keep working in a checkout that
+// has not fetched it.
+func readCheckoutState(root string) (checkoutState, error) {
+	branch, err := gitOutput(root, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return checkoutState{}, err
+	}
+	if branch == "HEAD" {
+		branch = ""
+	}
+	head, err := gitOutput(root, "rev-parse", "HEAD")
+	if err != nil {
+		return checkoutState{}, err
+	}
+	base, err := gitOutput(root, "rev-parse", "-q", "--verify", originBaseRef)
+	if err != nil {
+		base = ""
+	}
+	dirty, err := worktreeDirty(root)
+	if err != nil {
+		return checkoutState{}, err
+	}
+	return checkoutState{Branch: branch, Head: head, OriginBase: base, Dirty: dirty}, nil
+}
+
+// resolveCheckoutState refreshes origin/main and then reads the position, so
+// callers compare against what the remote holds now rather than whatever
+// this checkout last saw.
+func resolveCheckoutState(root string) (checkoutState, error) {
+	if err := fetchReleaseBase(root); err != nil {
+		return checkoutState{}, err
+	}
+	return readCheckoutState(root)
+}
+
+// fetchReleaseBase updates refs/remotes/origin/main. The refspec is spelled
+// out so the update does not depend on the remote's configured fetch
+// refspec, which a purpose-built release checkout can be missing.
+func fetchReleaseBase(root string) error {
+	return runCmd(root, nil, "git", "fetch", "origin",
+		"+refs/heads/"+releaseBaseBranch+":"+originBaseRef)
+}
+
+// requireReleaseBase refuses to run a mutating release flow from a checkout
+// that is not exactly origin/main with a clean tree. The branch's name does
+// not matter; its commit does.
+func (r *repoContext) requireReleaseBase(state checkoutState) error {
+	if state.Dirty {
+		return errors.New("festival repo has uncommitted changes")
+	}
+	if state.OriginBase == "" {
+		return fmt.Errorf("origin/%s is not available in this checkout; run: git fetch origin %s",
+			releaseBaseBranch, releaseBaseBranch)
+	}
+	if state.atReleaseBase() {
+		return nil
+	}
+
+	relation, err := r.relationToReleaseBase(state)
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf(
+		"festival checkout %s is %s origin/%s (HEAD %s, origin/%s %s); a release must be cut from origin/%s, so run: git fetch origin %s && git checkout --detach origin/%s",
+		state, relation, releaseBaseBranch,
+		shortCommit(state.Head), releaseBaseBranch, shortCommit(state.OriginBase),
+		releaseBaseBranch, releaseBaseBranch, releaseBaseBranch)
+}
+
+// relationToReleaseBase describes how HEAD sits against origin/main for the
+// refusal message.
+func (r *repoContext) relationToReleaseBase(state checkoutState) (string, error) {
+	behind, err := isAncestor(r.Root, state.Head, state.OriginBase)
+	if err != nil {
+		return "", err
+	}
+	if behind {
+		return "behind", nil
+	}
+	ahead, err := isAncestor(r.Root, state.OriginBase, state.Head)
+	if err != nil {
+		return "", err
+	}
+	if ahead {
+		return "ahead of", nil
+	}
+	return "diverged from", nil
+}
+
+// returnToReleaseBase leaves whatever transient branch the release flow
+// created and lands the checkout back on the release base at origin/main.
+// prefer names the branch the run started on, or "" when it started
+// detached. A checkout that cannot hold that branch, which is every worktree
+// when another worktree already holds it, lands detached at origin/main
+// instead.
+func (r *repoContext) returnToReleaseBase(prefer string) error {
+	if err := fetchReleaseBase(r.Root); err != nil {
+		return err
+	}
+	if prefer != "" {
+		if err := r.runGit("switch", prefer); err == nil {
+			return r.runGit("merge", "--ff-only", originBaseRef)
+		}
+	}
+	return r.runGit("checkout", "--detach", originBaseRef)
+}

--- a/tools/release-operator/commands.go
+++ b/tools/release-operator/commands.go
@@ -328,23 +328,26 @@ func shipBranchName(releaseTag string) string {
 	return shipBranchPrefix + releaseTag
 }
 
-func shipsViaPullRequest(branch string) bool {
-	return branch == "main"
+// shipsViaPullRequest reports whether the pin commit has to travel through a
+// pull request. Stable releases land on main, which is branch-protected, so
+// their pin commit always does, whatever the local checkout is called and
+// whether or not it is on a branch at all. dev and rc releases push straight
+// to the branch they run from (develop, release/vX.Y.Z), which stays true
+// even when that branch happens to sit on the same commit as origin/main. A
+// checkout literally on main never direct-pushes, in any mode.
+func shipsViaPullRequest(modeName string, state checkoutState) bool {
+	return modeName == "stable" || state.onBaseBranch()
 }
 
 func releasePRBody(releaseTag, message string) string {
 	return fmt.Sprintf("%s.\n\nCreated by the release operator: main only accepts changes through pull requests, so the pin commit ships through this PR. After the squash merge, the operator tags %s on main to trigger release CI.", message, releaseTag)
 }
 
-func (r *repoContext) currentBranch() (string, error) {
-	return r.git("rev-parse", "--abbrev-ref", "HEAD")
-}
-
 // shipPinnedArtifacts commits and ships the currently-staged submodule
 // pointer and docs changes. current and selected are keyed by Component.Dir;
 // selected holds what each component is now pinned to, current holds what
 // each was pinned to before this run.
-func (r *repoContext) shipPinnedArtifacts(releaseTag string, current, selected map[string]string) error {
+func (r *repoContext) shipPinnedArtifacts(modeName, releaseTag string, current, selected map[string]string) error {
 	diffPaths := append(componentDirs(), "docs/cli-reference")
 	hasDiff, err := r.cachedDiffExists(diffPaths...)
 	if err != nil {
@@ -359,24 +362,31 @@ func (r *repoContext) shipPinnedArtifacts(releaseTag string, current, selected m
 		return nil
 	}
 
-	branch, err := r.currentBranch()
+	// Local refs are enough here: the bundle path already refreshed
+	// origin/main in prepareForBundle, and collectState refreshed it again
+	// before the plan that led to this commit.
+	state, err := readCheckoutState(r.Root)
 	if err != nil {
 		return err
 	}
 	message := releaseCommitMessage(current, selected)
-	if !shipsViaPullRequest(branch) {
+	if !shipsViaPullRequest(modeName, state) {
 		if err := r.runGit("commit", "-m", message); err != nil {
 			return err
 		}
 		return r.runGit("push", "origin", "HEAD")
 	}
-	return r.shipViaPullRequest(branch, releaseTag, message)
+	return r.shipViaPullRequest(state, releaseTag, message)
 }
 
-func (r *repoContext) shipViaPullRequest(baseBranch, releaseTag, message string) error {
+// shipViaPullRequest sends the staged pin commit through a transient
+// release-pin branch and an auto-merged PR against main, then returns the
+// checkout to base at the merged commit so the release tag lands there.
+// base is where the run started, which is what the return lands back on.
+func (r *repoContext) shipViaPullRequest(base checkoutState, releaseTag, message string) error {
 	gh := r.ghClient()
 	if !gh.authenticated() {
-		return fmt.Errorf("%s only accepts changes through pull requests and gh is not authenticated; run 'gh auth login' and retry", baseBranch)
+		return fmt.Errorf("%s only accepts changes through pull requests and gh is not authenticated; run 'gh auth login' and retry", releaseBaseBranch)
 	}
 	// Verify the merge is possible before mutating anything, so a permission
 	// gap fails fast instead of after the branch and PR already exist.
@@ -404,7 +414,7 @@ func (r *repoContext) shipViaPullRequest(baseBranch, releaseTag, message string)
 		return err
 	}
 	if open == "" {
-		if err := gh.createPullRequest(festivalRepoSlug, baseBranch, shipBranch, message, releasePRBody(releaseTag, message)); err != nil {
+		if err := gh.createPullRequest(festivalRepoSlug, releaseBaseBranch, shipBranch, message, releasePRBody(releaseTag, message)); err != nil {
 			return err
 		}
 	}
@@ -412,16 +422,15 @@ func (r *repoContext) shipViaPullRequest(baseBranch, releaseTag, message string)
 		return fmt.Errorf("merge release PR for %s: %w\nThe pin commit is pushed and the PR exists; check the PR for unmet merge requirements (required approvals or status checks), merge it on GitHub, then rerun the same release command to continue tagging", shipBranch, err)
 	}
 
-	if err := r.runGit("switch", baseBranch); err != nil {
+	// Land on the merged pin commit, which is what the release tag is
+	// created at moments later.
+	if err := r.returnToReleaseBase(base.Branch); err != nil {
 		return err
 	}
 	if _, err := r.git("rev-parse", "--verify", "refs/heads/"+shipBranch); err == nil {
 		if err := r.runGit("branch", "-D", shipBranch); err != nil {
 			return err
 		}
-	}
-	if err := r.runGit("pull", "--ff-only", "origin", baseBranch); err != nil {
-		return err
 	}
 	if err := r.runGit("submodule", "update", "--init"); err != nil {
 		return err
@@ -436,29 +445,70 @@ func (r *repoContext) shipViaPullRequest(baseBranch, releaseTag, message string)
 	return nil
 }
 
-func (r *repoContext) prepareMainForBundle() error {
-	branch, err := r.currentBranch()
+// prepareForBundle gets the festival checkout ready to ship a bundled
+// release. A stable release must be cut from the commit origin/main points
+// at; the local branch's name is not part of that requirement, because the
+// festival repo is worked through git worktrees and git will not check out
+// one branch in two worktrees at once.
+//
+// A named branch that is neither main nor at origin/main is a dev or rc
+// checkout (develop, release/vX.Y.Z) and is left exactly as it stands, as
+// this step has always done; planStable is what refuses a stable release
+// from there.
+func (r *repoContext) prepareForBundle() error {
+	state, err := resolveCheckoutState(r.Root)
 	if err != nil {
 		return err
 	}
-	if strings.HasPrefix(branch, shipBranchPrefix) {
-		if err := r.runGit("switch", "main"); err != nil {
+
+	// Resume path: an earlier run failed after creating the transient pin
+	// branch. Return to the release base, drop the leftover branch, then
+	// re-read where that landed.
+	if strings.HasPrefix(state.Branch, shipBranchPrefix) {
+		leftover := state.Branch
+		if err := r.returnToReleaseBase(releaseBaseBranch); err != nil {
 			return err
 		}
-		if err := r.runGit("branch", "-D", branch); err != nil {
+		if err := r.runGit("branch", "-D", leftover); err != nil {
 			return err
 		}
-		branch = "main"
+		if state, err = readCheckoutState(r.Root); err != nil {
+			return err
+		}
 	}
-	if branch != "main" {
+
+	// A named branch that is neither main nor standing on origin/main is a
+	// dev or rc checkout (develop, release/vX.Y.Z), and is left exactly as
+	// it stands, as this step always has. A detached HEAD is never one of
+	// those, so it is held to the release base here rather than left for
+	// planStable to refuse with less to say about it.
+	if state.Branch != "" && !state.onBaseBranch() && !state.atReleaseBase() {
 		return nil
 	}
-	if dirty, err := worktreeDirty(r.Root); err != nil {
-		return err
-	} else if dirty {
+	if state.Dirty {
 		return errors.New("festival repo has uncommitted changes")
 	}
-	if err := r.runGit("pull", "--ff-only", "origin", "main"); err != nil {
+
+	// A local branch named main is fast-forwarded onto origin/main, which is
+	// what this step's `git pull --ff-only origin main` always did. Every
+	// other checkout, a detached one included, has to already be there:
+	// moving a checkout the operator did not create is not its call.
+	if state.onBaseBranch() && !state.atReleaseBase() {
+		behind, err := isAncestor(r.Root, state.Head, state.OriginBase)
+		if err != nil {
+			return err
+		}
+		if behind {
+			if err := r.runGit("merge", "--ff-only", originBaseRef); err != nil {
+				return err
+			}
+			if state, err = readCheckoutState(r.Root); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := r.requireReleaseBase(state); err != nil {
 		return err
 	}
 	return r.runGit("submodule", "update", "--init")
@@ -831,12 +881,12 @@ func runRequireStablePublishCredentials(ctx *repoContext) error {
 func runStatus(ctx *repoContext) error {
 	_ = ctx.fetchReleaseRefs()
 
-	branch, err := ctx.git("rev-parse", "--abbrev-ref", "HEAD")
+	checkout, err := readCheckoutState(ctx.Root)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("festival branch: %s\n\n", branch)
+	fmt.Printf("festival branch: %s\n\n", checkout)
 	fmt.Println("Current submodule pins:")
 	for _, c := range components {
 		sha, err := ctx.gitSubmodule(c.Dir, "rev-parse", "--short", "HEAD")
@@ -1031,7 +1081,7 @@ func runDraftFromLatest(ctx *repoContext, version string, mode releaseMode, iter
 		}
 	}
 
-	if err := ctx.shipPinnedArtifacts(releaseTag, currentPinned, tags); err != nil {
+	if err := ctx.shipPinnedArtifacts(mode.Name, releaseTag, currentPinned, tags); err != nil {
 		return err
 	}
 	if err := runPreflight(ctx, mode); err != nil {
@@ -1134,7 +1184,7 @@ func runDraftBootstrap(ctx *repoContext, festivalVersion string, versions map[st
 	if err := ctx.stageReleaseArtifacts(); err != nil {
 		return err
 	}
-	if err := ctx.shipPinnedArtifacts(releaseTag, map[string]string{}, tags); err != nil {
+	if err := ctx.shipPinnedArtifacts(stable.Name, releaseTag, map[string]string{}, tags); err != nil {
 		return err
 	}
 
@@ -1199,7 +1249,7 @@ func runPlanWithRoot(opts planOptions) error {
 	fmt.Println()
 	fmt.Println("== Release Plan ==")
 	fmt.Printf("  channel: %s\n", opts.Channel)
-	fmt.Printf("  festival branch: %s\n", state.CurrentBranch)
+	fmt.Printf("  festival branch: %s\n", state.CheckoutState)
 	fmt.Printf("  planned release tag: %s\n", plan.ReleaseTag)
 	for _, c := range components {
 		fmt.Printf("  %s: %s -> %s (%s)\n", c.Dir, valueOrNone(state.CurrentPinned[c.Dir]), state.SelectedTags[c.Dir], opts.Selectors[c.Dir])
@@ -1219,7 +1269,7 @@ func runBundleWithRoot(opts bundleOptions) error {
 		return err
 	}
 
-	if err := ctx.prepareMainForBundle(); err != nil {
+	if err := ctx.prepareForBundle(); err != nil {
 		return err
 	}
 
@@ -1239,7 +1289,7 @@ func runBundleWithRoot(opts bundleOptions) error {
 
 	fmt.Println()
 	fmt.Println("== Current State ==")
-	fmt.Printf("  festival branch: %s\n", state.CurrentBranch)
+	fmt.Printf("  festival branch: %s\n", state.CheckoutState)
 	for _, c := range components {
 		fmt.Printf("  %s: %s -> %s (%s)\n", c.Dir, valueOrNone(state.CurrentPinned[c.Dir]), state.SelectedTags[c.Dir], opts.Selectors[c.Dir])
 	}

--- a/tools/release-operator/commands_test.go
+++ b/tools/release-operator/commands_test.go
@@ -222,6 +222,65 @@ func TestShipPinnedArtifactsShipsViaPullRequestOnMain(t *testing.T) {
 	}
 }
 
+// TestShipPinnedArtifactsShipsViaPullRequestFromDetachedCheckout is the
+// end-to-end shape of the change: a checkout that holds no branch at all
+// still ships the pin through a PR against main and lands back on the merged
+// commit, which is the commit runDraftFromLatest tags moments later.
+func TestShipPinnedArtifactsShipsViaPullRequestFromDetachedCheckout(t *testing.T) {
+	repo := initTestRepo(t)
+	bare := addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+	gh := &fakeGH{t: t, bare: bare, authed: true, canMerge: true}
+	ctx.gh = gh
+
+	runGit(t, repo, "checkout", "--detach", "origin/main")
+	stagePinnedDocChange(t, repo, "detached pin\n")
+
+	if err := ctx.shipPinnedArtifacts("stable", "v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17")); err != nil {
+		t.Fatalf("shipPinnedArtifacts returned error: %v", err)
+	}
+
+	if gh.created != 1 || gh.merged != 1 {
+		t.Fatalf("create=%d merge=%d, want 1 and 1", gh.created, gh.merged)
+	}
+	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "HEAD" {
+		t.Fatalf("current branch = %q; a detached run must not adopt a branch", branch)
+	}
+	if local, remote := gitRevParse(t, repo, "HEAD"), gitRevParse(t, bare, "main"); local != remote {
+		t.Fatalf("HEAD = %s, merged origin main = %s; the release tag would land on the wrong commit", local, remote)
+	}
+	if _, err := gitOutput(repo, "rev-parse", "--verify", "refs/heads/release-pin/v0.2.12"); err == nil {
+		t.Fatal("local ship branch release-pin/v0.2.12 was not deleted")
+	}
+}
+
+// A worktree branch that is not named main ships the same way and is
+// fast-forwarded onto the merged commit rather than left behind it.
+func TestShipPinnedArtifactsShipsViaPullRequestFromWorktreeBranch(t *testing.T) {
+	repo := initTestRepo(t)
+	bare := addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+	gh := &fakeGH{t: t, bare: bare, authed: true, canMerge: true}
+	ctx.gh = gh
+
+	runGit(t, repo, "switch", "-c", "release-cut")
+	stagePinnedDocChange(t, repo, "worktree pin\n")
+
+	if err := ctx.shipPinnedArtifacts("stable", "v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17")); err != nil {
+		t.Fatalf("shipPinnedArtifacts returned error: %v", err)
+	}
+
+	if gh.created != 1 || gh.merged != 1 {
+		t.Fatalf("create=%d merge=%d, want 1 and 1", gh.created, gh.merged)
+	}
+	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "release-cut" {
+		t.Fatalf("current branch = %q, want release-cut", branch)
+	}
+	if local, remote := gitRevParse(t, repo, "HEAD"), gitRevParse(t, bare, "main"); local != remote {
+		t.Fatalf("HEAD = %s, merged origin main = %s; the release tag would land on the wrong commit", local, remote)
+	}
+}
+
 func TestShipViaPullRequestSkipsCreateWhenPROpen(t *testing.T) {
 	repo := initTestRepo(t)
 	bare := addBareOrigin(t, repo)

--- a/tools/release-operator/commands_test.go
+++ b/tools/release-operator/commands_test.go
@@ -49,19 +49,55 @@ func TestShipBranchName(t *testing.T) {
 
 func TestShipsViaPullRequest(t *testing.T) {
 	tests := []struct {
-		branch string
-		want   bool
+		name  string
+		mode  string
+		state checkoutState
+		want  bool
 	}{
-		{branch: "main", want: true},
-		{branch: "develop", want: false},
-		{branch: "release/v0.3.0", want: false},
-		{branch: "release-pin/v0.2.12", want: false},
+		{
+			name:  "stable on the main branch",
+			mode:  "stable",
+			state: checkoutState{Branch: "main", Head: "abc", OriginBase: "abc"},
+			want:  true,
+		},
+		{
+			name:  "stable detached at origin/main",
+			mode:  "stable",
+			state: checkoutState{Head: "abc", OriginBase: "abc"},
+			want:  true,
+		},
+		{
+			name:  "stable on a worktree branch at origin/main",
+			mode:  "stable",
+			state: checkoutState{Branch: "release-cut", Head: "abc", OriginBase: "abc"},
+			want:  true,
+		},
+		{
+			name:  "dev on develop",
+			mode:  "dev",
+			state: checkoutState{Branch: "develop", Head: "def", OriginBase: "abc"},
+			want:  false,
+		},
+		{
+			// develop can sit on the same commit as origin/main without the
+			// dev release becoming a main release: it still pushes to develop.
+			name:  "dev on develop that happens to be at origin/main",
+			mode:  "dev",
+			state: checkoutState{Branch: "develop", Head: "abc", OriginBase: "abc"},
+			want:  false,
+		},
+		{
+			name:  "rc on a release branch",
+			mode:  "rc",
+			state: checkoutState{Branch: "release/v0.3.0", Head: "def", OriginBase: "abc"},
+			want:  false,
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.branch, func(t *testing.T) {
-			if got := shipsViaPullRequest(tt.branch); got != tt.want {
-				t.Fatalf("shipsViaPullRequest(%q) = %v, want %v", tt.branch, got, tt.want)
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shipsViaPullRequest(tt.mode, tt.state); got != tt.want {
+				t.Fatalf("shipsViaPullRequest(%q, %v) = %v, want %v", tt.mode, tt.state, got, tt.want)
 			}
 		})
 	}
@@ -101,7 +137,7 @@ func TestShipPinnedArtifactsNoDiffIsNoop(t *testing.T) {
 	ctx := testRepoContext(t, repo)
 
 	before := gitRevParse(t, repo, "HEAD")
-	if err := ctx.shipPinnedArtifacts("v0.2.0", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.8", "v0.2.17")); err != nil {
+	if err := ctx.shipPinnedArtifacts("stable", "v0.2.0", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.8", "v0.2.17")); err != nil {
 		t.Fatalf("shipPinnedArtifacts returned error: %v", err)
 	}
 	if after := gitRevParse(t, repo, "HEAD"); after != before {
@@ -165,7 +201,7 @@ func TestShipPinnedArtifactsShipsViaPullRequestOnMain(t *testing.T) {
 
 	stagePinnedDocChange(t, repo, "stable pin\n")
 
-	if err := ctx.shipPinnedArtifacts("v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17")); err != nil {
+	if err := ctx.shipPinnedArtifacts("stable", "v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17")); err != nil {
 		t.Fatalf("shipPinnedArtifacts returned error: %v", err)
 	}
 
@@ -195,7 +231,7 @@ func TestShipViaPullRequestSkipsCreateWhenPROpen(t *testing.T) {
 
 	stagePinnedDocChange(t, repo, "resumed pin\n")
 
-	if err := ctx.shipPinnedArtifacts("v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17")); err != nil {
+	if err := ctx.shipPinnedArtifacts("stable", "v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17")); err != nil {
 		t.Fatalf("shipPinnedArtifacts returned error: %v", err)
 	}
 	if gh.created != 0 {
@@ -215,7 +251,7 @@ func TestShipViaPullRequestPropagatesOpenPRQueryError(t *testing.T) {
 
 	stagePinnedDocChange(t, repo, "pin\n")
 
-	err := ctx.shipPinnedArtifacts("v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17"))
+	err := ctx.shipPinnedArtifacts("stable", "v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17"))
 	if err == nil {
 		t.Fatal("expected a transient open-PR query error to propagate, got nil")
 	}
@@ -236,7 +272,7 @@ func TestShipViaPullRequestFailsFastWhenCannotMerge(t *testing.T) {
 
 	stagePinnedDocChange(t, repo, "pin\n")
 
-	err := ctx.shipPinnedArtifacts("v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17"))
+	err := ctx.shipPinnedArtifacts("stable", "v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17"))
 	if err == nil {
 		t.Fatal("expected an error when the account cannot merge")
 	}
@@ -256,7 +292,7 @@ func TestShipViaPullRequestFailsWhenUnauthenticated(t *testing.T) {
 
 	stagePinnedDocChange(t, repo, "pin\n")
 
-	if err := ctx.shipPinnedArtifacts("v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17")); err == nil {
+	if err := ctx.shipPinnedArtifacts("stable", "v0.2.12", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9", "v0.2.17")); err == nil {
 		t.Fatal("expected an error when gh is not authenticated")
 	}
 }
@@ -269,7 +305,7 @@ func TestShipPinnedArtifactsDirectPushOffMain(t *testing.T) {
 	runGit(t, repo, "switch", "-c", "develop")
 	stagePinnedDocChange(t, repo, "dev pin\n")
 
-	if err := ctx.shipPinnedArtifacts("v0.2.0-dev.1", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9-dev.1", "v0.2.17")); err != nil {
+	if err := ctx.shipPinnedArtifacts("dev", "v0.2.0-dev.1", tagMap("v0.4.8", "v0.2.17"), tagMap("v0.4.9-dev.1", "v0.2.17")); err != nil {
 		t.Fatalf("shipPinnedArtifacts returned error: %v", err)
 	}
 
@@ -290,7 +326,7 @@ func TestShipPinnedArtifactsDirectPushOffMain(t *testing.T) {
 	}
 }
 
-func TestPrepareMainForBundleFastForwardsStaleMain(t *testing.T) {
+func TestPrepareForBundleFastForwardsStaleMain(t *testing.T) {
 	repo := initTestRepo(t)
 	addBareOrigin(t, repo)
 	ctx := testRepoContext(t, repo)
@@ -302,24 +338,30 @@ func TestPrepareMainForBundleFastForwardsStaleMain(t *testing.T) {
 	ahead := gitRevParse(t, repo, "HEAD")
 	runGit(t, repo, "reset", "--hard", "HEAD~1")
 
-	if err := ctx.prepareMainForBundle(); err != nil {
-		t.Fatalf("prepareMainForBundle returned error: %v", err)
+	if err := ctx.prepareForBundle(); err != nil {
+		t.Fatalf("prepareForBundle returned error: %v", err)
 	}
 	if head := gitRevParse(t, repo, "HEAD"); head != ahead {
 		t.Fatalf("HEAD = %s, want origin/main %s", head, ahead)
 	}
 }
 
-func TestPrepareMainForBundleLeavesOtherBranchesAlone(t *testing.T) {
+func TestPrepareForBundleLeavesOtherBranchesAlone(t *testing.T) {
 	repo := initTestRepo(t)
 	addBareOrigin(t, repo)
 	ctx := testRepoContext(t, repo)
 
+	// develop carries its own commit, so it is neither named main nor
+	// standing on origin/main: the dev and rc release channels run from
+	// exactly this shape and prepare must not touch it.
 	runGit(t, repo, "switch", "-c", "develop")
+	writeFile(t, filepath.Join(repo, "develop.txt"), "develop\n")
+	runGit(t, repo, "add", "develop.txt")
+	runGit(t, repo, "commit", "-m", "develop work")
 	before := gitRevParse(t, repo, "HEAD")
 
-	if err := ctx.prepareMainForBundle(); err != nil {
-		t.Fatalf("prepareMainForBundle returned error: %v", err)
+	if err := ctx.prepareForBundle(); err != nil {
+		t.Fatalf("prepareForBundle returned error: %v", err)
 	}
 	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "develop" {
 		t.Fatalf("current branch = %q, want develop", branch)
@@ -329,7 +371,7 @@ func TestPrepareMainForBundleLeavesOtherBranchesAlone(t *testing.T) {
 	}
 }
 
-func TestPrepareMainForBundleRecoversFromStaleShipBranch(t *testing.T) {
+func TestPrepareForBundleRecoversFromStaleShipBranch(t *testing.T) {
 	repo := initTestRepo(t)
 	addBareOrigin(t, repo)
 	ctx := testRepoContext(t, repo)
@@ -338,8 +380,8 @@ func TestPrepareMainForBundleRecoversFromStaleShipBranch(t *testing.T) {
 	stagePinnedDocChange(t, repo, "abandoned pin\n")
 	runGit(t, repo, "commit", "-m", "Release: pin fest v0.4.9")
 
-	if err := ctx.prepareMainForBundle(); err != nil {
-		t.Fatalf("prepareMainForBundle returned error: %v", err)
+	if err := ctx.prepareForBundle(); err != nil {
+		t.Fatalf("prepareForBundle returned error: %v", err)
 	}
 	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "main" {
 		t.Fatalf("current branch = %q, want main", branch)
@@ -349,15 +391,15 @@ func TestPrepareMainForBundleRecoversFromStaleShipBranch(t *testing.T) {
 	}
 }
 
-func TestPrepareMainForBundleRejectsDirtyMain(t *testing.T) {
+func TestPrepareForBundleRejectsDirtyMain(t *testing.T) {
 	repo := initTestRepo(t)
 	addBareOrigin(t, repo)
 	ctx := testRepoContext(t, repo)
 
 	writeFile(t, filepath.Join(repo, "README.md"), "dirty\n")
 
-	if err := ctx.prepareMainForBundle(); err == nil {
-		t.Fatal("expected prepareMainForBundle to fail on a dirty main worktree")
+	if err := ctx.prepareForBundle(); err == nil {
+		t.Fatal("expected prepareForBundle to fail on a dirty main worktree")
 	}
 }
 
@@ -369,6 +411,204 @@ func TestReleasePRBodyMentionsTag(t *testing.T) {
 	if !strings.Contains(body, "Release: pin fest v0.4.9") {
 		t.Fatalf("PR body does not include the release message: %q", body)
 	}
+}
+
+// TestPrepareForBundleAcceptsDetachedAtOriginMain is the case that made this
+// change necessary: the festival repo is worked through git worktrees, git
+// refuses to check out main in two worktrees at once, and a release had to
+// be cut from whichever stale worktree happened to be holding the branch.
+func TestPrepareForBundleAcceptsDetachedAtOriginMain(t *testing.T) {
+	repo := initTestRepo(t)
+	addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+
+	runGit(t, repo, "checkout", "--detach", "origin/main")
+	before := gitRevParse(t, repo, "HEAD")
+
+	if err := ctx.prepareForBundle(); err != nil {
+		t.Fatalf("prepareForBundle returned error: %v", err)
+	}
+	if head := gitRevParse(t, repo, "HEAD"); head != before {
+		t.Fatalf("HEAD moved from %s to %s; a checkout already at origin/main must be left alone", before, head)
+	}
+	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "HEAD" {
+		t.Fatalf("current branch = %q, want a still-detached HEAD", branch)
+	}
+}
+
+func TestPrepareForBundleAcceptsAnyBranchNameAtOriginMain(t *testing.T) {
+	repo := initTestRepo(t)
+	addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+
+	runGit(t, repo, "switch", "-c", "release-cut")
+	before := gitRevParse(t, repo, "HEAD")
+
+	if err := ctx.prepareForBundle(); err != nil {
+		t.Fatalf("prepareForBundle returned error: %v", err)
+	}
+	if head := gitRevParse(t, repo, "HEAD"); head != before {
+		t.Fatalf("HEAD moved from %s to %s", before, head)
+	}
+	if branch := gitRevParse(t, repo, "--abbrev-ref", "HEAD"); branch != "release-cut" {
+		t.Fatalf("current branch = %q, want release-cut", branch)
+	}
+}
+
+func TestPrepareForBundleRefusesDetachedOffOriginMain(t *testing.T) {
+	repo := initTestRepo(t)
+	addBareOrigin(t, repo)
+	ctx := testRepoContext(t, repo)
+
+	advanceOrigin(t, repo)
+	runGit(t, repo, "checkout", "--detach", "HEAD")
+	before := gitRevParse(t, repo, "HEAD")
+
+	err := ctx.prepareForBundle()
+	if err == nil {
+		t.Fatal("expected prepareForBundle to refuse a detached HEAD that is not origin/main")
+	}
+	if !strings.Contains(err.Error(), "origin/main") {
+		t.Fatalf("error = %q, want it to name origin/main", err)
+	}
+	if head := gitRevParse(t, repo, "HEAD"); head != before {
+		t.Fatalf("HEAD moved from %s to %s; a refusal must not move a detached checkout", before, head)
+	}
+}
+
+// TestRequireReleaseBase covers the state check that replaced the old
+// "the branch must be named main" rule. What a release needs is the commit
+// origin/main points at; the branch's name, and whether there is one, is not
+// part of it.
+func TestRequireReleaseBase(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, repo string)
+		wantErr string
+	}{
+		{
+			name:  "on main at origin/main",
+			setup: func(t *testing.T, repo string) {},
+		},
+		{
+			name: "detached at origin/main",
+			setup: func(t *testing.T, repo string) {
+				runGit(t, repo, "checkout", "--detach", "origin/main")
+			},
+		},
+		{
+			name: "on another branch at origin/main",
+			setup: func(t *testing.T, repo string) {
+				runGit(t, repo, "switch", "-c", "release-cut")
+			},
+		},
+		{
+			name: "on main behind origin/main",
+			setup: func(t *testing.T, repo string) {
+				advanceOrigin(t, repo)
+			},
+			wantErr: "is behind origin/main",
+		},
+		{
+			name: "detached at a commit that is not on origin/main",
+			setup: func(t *testing.T, repo string) {
+				advanceOrigin(t, repo)
+				runGit(t, repo, "checkout", "--detach", "HEAD")
+				writeFile(t, filepath.Join(repo, "local.txt"), "local\n")
+				runGit(t, repo, "add", "local.txt")
+				runGit(t, repo, "commit", "-m", "local work")
+			},
+			wantErr: "diverged from origin/main",
+		},
+		{
+			name: "ahead of origin/main",
+			setup: func(t *testing.T, repo string) {
+				writeFile(t, filepath.Join(repo, "ahead.txt"), "ahead\n")
+				runGit(t, repo, "add", "ahead.txt")
+				runGit(t, repo, "commit", "-m", "unpushed work")
+			},
+			wantErr: "is ahead of origin/main",
+		},
+		{
+			name: "dirty tree",
+			setup: func(t *testing.T, repo string) {
+				writeFile(t, filepath.Join(repo, "README.md"), "dirty\n")
+			},
+			wantErr: "uncommitted changes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := initTestRepo(t)
+			addBareOrigin(t, repo)
+			ctx := testRepoContext(t, repo)
+			tt.setup(t, repo)
+
+			state, err := resolveCheckoutState(repo)
+			if err != nil {
+				t.Fatalf("resolveCheckoutState: %v", err)
+			}
+			err = ctx.requireReleaseBase(state)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("requireReleaseBase returned error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected a refusal mentioning %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckoutStateStringNamesTheResolvedPosition(t *testing.T) {
+	tests := []struct {
+		name  string
+		state checkoutState
+		want  string
+	}{
+		{
+			name:  "on a branch",
+			state: checkoutState{Branch: "main", Head: "abc", OriginBase: "abc"},
+			want:  "main",
+		},
+		{
+			name:  "detached at origin/main",
+			state: checkoutState{Head: "abc", OriginBase: "abc"},
+			want:  "detached at origin/main",
+		},
+		{
+			name:  "detached elsewhere",
+			state: checkoutState{Head: "0123456789abcdef", OriginBase: "abc"},
+			want:  "detached at 0123456789ab",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.state.String(); got != tt.want {
+				t.Fatalf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// advanceOrigin adds a commit, pushes it to the bare origin, and leaves the
+// local checkout on the commit it started at, so the checkout is one commit
+// behind origin/main.
+func advanceOrigin(t *testing.T, repo string) {
+	t.Helper()
+	start := gitRevParse(t, repo, "HEAD")
+	writeFile(t, filepath.Join(repo, "advance.txt"), "advance\n")
+	runGit(t, repo, "add", "advance.txt")
+	runGit(t, repo, "commit", "-m", "origin advance")
+	runGit(t, repo, "push", "origin", "main")
+	runGit(t, repo, "reset", "--hard", start)
 }
 
 func testRepoContext(t *testing.T, repo string) *repoContext {

--- a/tools/release-operator/internal/operator/plan.go
+++ b/tools/release-operator/internal/operator/plan.go
@@ -55,8 +55,20 @@ type ParsedPrerelease struct {
 }
 
 type BundleInput struct {
-	Channel                         string
-	CurrentBranch                   string
+	Channel string
+	// CurrentBranch is the checked-out branch, or "" when HEAD is detached.
+	// dev and rc releases key off it because they genuinely ship from named
+	// branches (develop, release/vX.Y.Z).
+	CurrentBranch string
+	// CheckoutState renders where the checkout stands for release output:
+	// the branch name, or "detached at origin/main".
+	CheckoutState string
+	// AtReleaseBase reports whether HEAD is exactly the commit origin/main
+	// points at. Stable releases require it, and require nothing about the
+	// branch's name: the festival repo is worked through git worktrees, and
+	// git refuses to check out one branch in two worktrees at once, so
+	// demanding a branch named main left only one worktree able to release.
+	AtReleaseBase                   bool
 	SelectedTags                    map[string]string // keyed by component dir
 	CurrentPinned                   map[string]string // keyed by component dir
 	LatestFestivalDev               string
@@ -66,8 +78,9 @@ type BundleInput struct {
 	CurrentCommitTaggedLatestDev    bool
 	CurrentCommitTaggedLatestStable bool
 	CurrentCommitTaggedVersionRC    bool
-	// ReadOnly skips the stable-on-main guard so `just release plan` can
-	// preview a patch bump from a worktree. Mutating bundle still requires main.
+	// ReadOnly skips the release-base guard so `just release plan` can
+	// preview a patch bump from any checkout. A mutating bundle still
+	// requires HEAD to be at origin/main.
 	ReadOnly bool
 }
 
@@ -185,8 +198,8 @@ func planRC(in BundleInput) (BundlePlan, error) {
 }
 
 func planStable(in BundleInput) (BundlePlan, error) {
-	if !in.ReadOnly && in.CurrentBranch != "main" {
-		return BundlePlan{}, fmt.Errorf("stable releases must be created from the main branch")
+	if !in.ReadOnly && !in.AtReleaseBase {
+		return BundlePlan{}, fmt.Errorf("stable releases must be created from a checkout at origin/main (this checkout: %s)", checkoutLabel(in))
 	}
 	if in.LatestFestivalStable == "" {
 		return BundlePlan{}, fmt.Errorf("main does not contain a prior festival stable release; use draft-bootstrap or draft --version")
@@ -209,6 +222,19 @@ func planStable(in BundleInput) (BundlePlan, error) {
 		DraftArgs:   []string{version},
 		Description: fmt.Sprintf("Festival version line: v%s (patch bump from %s on main)", version, in.LatestFestivalStable),
 	}, nil
+}
+
+// checkoutLabel names the checkout for the release-base refusal, falling
+// back to the branch when the caller did not render a state.
+func checkoutLabel(in BundleInput) string {
+	switch {
+	case in.CheckoutState != "":
+		return in.CheckoutState
+	case in.CurrentBranch != "":
+		return in.CurrentBranch
+	default:
+		return "unknown"
+	}
 }
 
 func ParseStableTag(tag string) (Version, error) {

--- a/tools/release-operator/internal/operator/plan_test.go
+++ b/tools/release-operator/internal/operator/plan_test.go
@@ -53,6 +53,7 @@ func TestDeriveBundlePlanStableBumpsLatestStablePatch(t *testing.T) {
 	plan, err := DeriveBundlePlan(BundleInput{
 		Channel:              "stable",
 		CurrentBranch:        "main",
+		AtReleaseBase:        true,
 		SelectedTags:         map[string]string{"fest": "v0.2.0", "camp": "v0.2.1"},
 		CurrentPinned:        map[string]string{"fest": "v0.1.9", "camp": "v0.2.1"},
 		LatestFestivalStable: "v0.1.1",
@@ -66,18 +67,62 @@ func TestDeriveBundlePlanStableBumpsLatestStablePatch(t *testing.T) {
 	}
 }
 
-func TestDeriveBundlePlanStableRejectsWrongBranch(t *testing.T) {
+func TestDeriveBundlePlanStableRejectsCheckoutOffOriginMain(t *testing.T) {
 	_, err := DeriveBundlePlan(BundleInput{
 		Channel:              "stable",
 		CurrentBranch:        "feature/hub",
+		CheckoutState:        "feature/hub",
 		SelectedTags:         map[string]string{"fest": "v0.2.0", "camp": "v0.2.1"},
 		LatestFestivalStable: "v0.1.1",
 	})
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "main branch") {
-		t.Fatalf("error = %q, want main-branch guard", err)
+	if !strings.Contains(err.Error(), "origin/main") {
+		t.Fatalf("error = %q, want the release-base guard", err)
+	}
+	if !strings.Contains(err.Error(), "feature/hub") {
+		t.Fatalf("error = %q, want it to name the checkout it refused", err)
+	}
+}
+
+// TestDeriveBundlePlanStableAcceptsDetachedCheckoutAtOriginMain is the
+// behavior this guard was changed for: a release cut from a worktree that
+// cannot hold the main branch, because another worktree already does.
+func TestDeriveBundlePlanStableAcceptsDetachedCheckoutAtOriginMain(t *testing.T) {
+	plan, err := DeriveBundlePlan(BundleInput{
+		Channel:              "stable",
+		CurrentBranch:        "",
+		CheckoutState:        "detached at origin/main",
+		AtReleaseBase:        true,
+		SelectedTags:         map[string]string{"fest": "v0.2.0", "camp": "v0.2.1"},
+		CurrentPinned:        map[string]string{"fest": "v0.1.9", "camp": "v0.2.1"},
+		LatestFestivalStable: "v0.1.1",
+	})
+	if err != nil {
+		t.Fatalf("DeriveBundlePlan returned error: %v", err)
+	}
+	if got, want := plan.ReleaseTag, "v0.1.2"; got != want {
+		t.Fatalf("ReleaseTag = %q, want %q", got, want)
+	}
+}
+
+// A branch named main that has fallen off origin/main is refused for the
+// same reason any other stale checkout is: the release would not ship the
+// commit main actually holds.
+func TestDeriveBundlePlanStableRejectsMainBranchOffOriginMain(t *testing.T) {
+	_, err := DeriveBundlePlan(BundleInput{
+		Channel:              "stable",
+		CurrentBranch:        "main",
+		CheckoutState:        "main",
+		SelectedTags:         map[string]string{"fest": "v0.2.0", "camp": "v0.2.1"},
+		LatestFestivalStable: "v0.1.1",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "origin/main") {
+		t.Fatalf("error = %q, want the release-base guard", err)
 	}
 }
 
@@ -103,6 +148,7 @@ func TestDeriveBundlePlanStableRejectsWhenMainHasNoStableHistory(t *testing.T) {
 	_, err := DeriveBundlePlan(BundleInput{
 		Channel:       "stable",
 		CurrentBranch: "main",
+		AtReleaseBase: true,
 		SelectedTags:  map[string]string{"fest": "v0.2.0", "camp": "v0.2.1"},
 	})
 	if err == nil {
@@ -114,6 +160,7 @@ func TestDeriveBundlePlanStableRejectsWhenCurrentCommitAlreadyBundlesSelectedTag
 	_, err := DeriveBundlePlan(BundleInput{
 		Channel:                         "stable",
 		CurrentBranch:                   "main",
+		AtReleaseBase:                   true,
 		SelectedTags:                    map[string]string{"fest": "v0.2.0", "camp": "v0.2.1"},
 		CurrentPinned:                   map[string]string{"fest": "v0.2.0", "camp": "v0.2.1"},
 		LatestFestivalStable:            "v0.2.0",

--- a/tools/release-operator/main.go
+++ b/tools/release-operator/main.go
@@ -444,6 +444,11 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, "  just release cleanup <tag>")
 	fmt.Fprintln(out)
 	fmt.Fprintln(out, "Stable releases on main:")
+	fmt.Fprintln(out, "  A stable release runs from any checkout whose HEAD is the commit")
+	fmt.Fprintln(out, "  origin/main points at, with a clean tree. The local branch may be")
+	fmt.Fprintln(out, "  named main, named anything else, or be a detached HEAD, so a worktree")
+	fmt.Fprintln(out, "  can cut a release while another worktree holds the main branch.")
+	fmt.Fprintln(out, "  Get there with: git fetch origin main && git checkout --detach origin/main")
 	fmt.Fprintln(out, "  main is PR-only, so the stable pin commit ships through a transient")
 	fmt.Fprintln(out, "  release-pin/<tag> branch that is auto-created and squash-merged.")
 	fmt.Fprintln(out, "  The active gh account needs push access to Obedience-Corp/festival.")
@@ -488,7 +493,11 @@ func collectState(repoRoot, channel string, selectors map[string]string) (operat
 		}
 	}
 
-	branch, err := gitOutput(repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	// Resolve the checkout against origin/main rather than against a branch
+	// name: a release ships from the commit origin/main points at, and the
+	// festival repo is normally worked through git worktrees, where the
+	// branch named main is usually held by some other worktree.
+	checkout, err := resolveCheckoutState(repoRoot)
 	if err != nil {
 		return operator.BundleInput{}, err
 	}
@@ -508,7 +517,9 @@ func collectState(repoRoot, channel string, selectors map[string]string) (operat
 
 	state := operator.BundleInput{
 		Channel:       channel,
-		CurrentBranch: branch,
+		CurrentBranch: checkout.Branch,
+		CheckoutState: checkout.String(),
+		AtReleaseBase: checkout.atReleaseBase(),
 		SelectedTags:  selectedTags,
 		CurrentPinned: currentPinned,
 	}
@@ -653,7 +664,14 @@ func tagAncestorOfHead(dir, tag string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	cmd := exec.Command("git", "merge-base", "--is-ancestor", tagCommit, "HEAD")
+	return isAncestor(dir, tagCommit, "HEAD")
+}
+
+// isAncestor reports whether ancestor is reachable from descendant. Exit
+// code 1 is git's answer for "no", not a failure, so only other exit codes
+// become errors.
+func isAncestor(dir, ancestor, descendant string) (bool, error) {
+	cmd := exec.Command("git", "merge-base", "--is-ancestor", ancestor, descendant)
 	cmd.Dir = dir
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {


### PR DESCRIPTION
## Why

The bundle path refused to run unless the local branch was literally named `main` (`shipsViaPullRequest` and `planStable` both compared the branch name), and it returned to `main` with `git switch main` plus `git pull --ff-only`. In this camp the festival checkout is normally a worktree, and git will not let two worktrees hold the same branch, so today's v0.3.7 cut had to run from a stale worktree named `release-v0-4-0` that happened to hold `main` while the real checkout sat on an old branch.

## What

The name check becomes a state check. A new `checkout.go` resolves `checkoutState` (fetch `origin main` with an explicit refspec, then HEAD, origin/main, dirty). `requireReleaseBase` accepts a branch named `main`, a detached HEAD, or any other branch, as long as HEAD equals origin/main and the tree is clean; it refuses behind, ahead, off-main, and dirty with a message naming the resolved position. After the pin PR merges, `returnToReleaseBase` fast-forwards the starting branch or re-detaches at origin/main, so the tag still lands on the merged pin commit exactly as before (v0.3.7 tagged 89c3957 this way).

Two judgment calls: a branch named `main` that is behind is still fast-forwarded, as the old `git pull --ff-only` did, so releasing from `main` is unchanged; and the PR-versus-direct-push decision now keys off the release mode rather than the branch name, because `develop` can sit on the same commit as origin/main and a dev release must still push to `develop`.

`plan` reports the resolved position on its `festival branch:` line.

## Tests

`TestRequireReleaseBase` (seven cases: on main at origin/main, detached at origin/main, another branch at origin/main, main behind, detached off origin/main, ahead, dirty), `prepareForBundle` accept and refuse cases, `shipPinnedArtifacts` via pull request from a detached checkout and from a worktree branch, `deriveBundlePlan` stable accept and refuse. `go vet` clean; `go test ./tools/release-operator/...` green. `just release plan stable keep keep keep` runs from a worktree that is not on `main`.