### PR TITLE
docs: simplify Quick Start with a video-led first handoff

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,167 +1,124 @@
 ---
 title: "Quick Start"
+description: "Create a camp, hand a goal to your agent, and review the work as it progresses. A video-led first run with Festival."
 weight: 12
 ---
 
 # Quick Start
 
-**Your files. Any agent.**
+**Hand off a goal. Keep working on what matters to you.**
 
-Festival is the planning and verification layer for long-running agent work. The camp is files you own. The harness is whatever you already run. The next session starts from `fest next`, not from a vendor brief.
+Festival gives your agent a plan to follow and a lasting record of the work. You set the goal and review the important decisions. Your agent plans, executes, and checks the work while you focus elsewhere.
 
-Create your first camp and festival in under 5 minutes.
+This guide takes you from a fresh install to your first handoff. The recordings show what to look for along the way.
 
-## Common Questions
+1. [Install the tools](#install)
+2. [Create a camp](#create-a-camp)
+3. [Hand off a goal](#hand-off-a-goal)
+4. [Run, review, and resume](#run-review-and-resume)
 
-**Is this a coding agent?**
+## 1. Install the tools {#install}
 
-No. Keep Claude Code, Codex, Grok, or whatever you use. Festival is the work system those agents read and write.
+Choose one method. Both install `camp`, `fest`, and the `festival` suite manager.
 
-**Where does the memory live?**
-
-In your camp: phases, sequences, tasks, intents, and git history, as plain files on your disk. You can copy it, diff it, and leave with it.
-
-**What happens when a session ends?**
-
-The next actionable task is still on disk. `fest next` is the resume, in the same agent or a different one.
-
-**How do you know the work is done?**
-
-Each task carries completion criteria, `fest validate` checks the plan against the methodology, quality gates run at the end of an implementation sequence, and `fest commit` ties the change back to the task it came from. That trail is the proof of work.
-
-**Why not a hosted agent workspace?**
-
-A hosted workspace keeps your continuity in someone else's account and usually replaces the coding agent you already run. Festival sits beside the harness you already pay for and keeps the record on your disk.
-
-{{< terminal-demo src="/images/demos/proof-loop.gif" title="fest next" alt="One sentence of intent scaffolds a festival, an agent runs the next task, the session is interrupted, fest next resumes it, then fest validate and fest commit close it out" max="700" >}}
-
-*One sentence of intent. A scaffolded festival. The agent runs the next task, the session is interrupted, and `fest next` picks it back up. Validate, commit, done.*
-
-## Prerequisites
-
-`fest` and `camp` should already be installed. If not, see the [Installation]({{< ref "/getting-started/installation" >}}) guide.
-
-## 1. Set Up Shell Integration
+**Homebrew on macOS**
 
 ```bash
-# Linux packages (AUR festival-bin, deb/rpm/apk obedience-festival)
-source /usr/share/festival/shell/festival.zsh
-
-# Add to ~/.zshrc when installed with install.sh
-source ~/.local/share/festival/shell/festival.zsh
-
-# Homebrew
-source "$(brew --prefix)/share/festival/shell/festival.zsh"
-
-# Or, if no helper file is installed:
-eval "$(camp shell-init zsh)"
-eval "$(fest shell-init zsh)"
-
-# Restart your shell or source the file
-source ~/.zshrc
+brew install --cask Obedience-Corp/tap/festival
 ```
 
-This gives you `cgo` for camp navigation and `fgo` for festival shortcuts.
-
-## 2. Create a Camp
+**npm with Node.js installed**
 
 ```bash
-camp init my-project
-cd my-project
+npm install -g @obedience-corp/festival
 ```
 
-This creates the camp directory structure with `projects/`, `festivals/`, `docs/`, and the `.campaign/` workspace config.
+For Linux packages, other install methods, or troubleshooting, see [Installation]({{< ref "/getting-started/installation" >}}).
 
-## 3. Navigate the Camp
+Check that the tools are available:
 
 ```bash
-cgo              # Jump to camp root
-cgo p            # Jump to projects/
-cgo f            # Jump to festivals/
-csw              # Interactive camp picker -- switch between camps
-csw my-project   # Switch directly by name
+festival doctor
 ```
 
-Single-letter shortcuts make navigation instant. `cgo p api` fuzzy-matches project names so you never type full paths. `csw` switches between camps -- use it when you're managing more than one.
+Then choose an [agent setup guide]({{< ref "/getting-started/agents" >}}) for your existing coding agent. Claude Code, Codex, Cursor, Grok Build, and other agents that can read files and run commands can use Festival. Agent-specific skills are optional; the CLI includes guidance your agent can read.
 
-## 4. Add a Project (Optional)
+**Ready when:** the tools are installed and your agent can run `camp` and `fest` in its terminal.
+
+## 2. Create a camp {#create-a-camp}
+
+A **camp** holds the context for one part of your life: your job, a side project, or a hobby. Each camp can contain several projects, with shared plans, research, and decisions. Start with one.
+
+From a directory where you keep your work:
 
 ```bash
-camp project add https://github.com/you/your-repo
+camp init my-camp
+cd my-camp
 ```
 
-Projects are added as git submodules under `projects/`.
+This creates `projects/`, `festivals/`, `docs/`, and instructions for your agent in `AGENTS.md`.
 
-## 5. Create Your First Festival
+Bring in a repository you already work on. Replace the example path with its full local path:
 
 ```bash
-fest create festival --name "my-first-feature" --type standard
+camp project link /path/to/your-existing-repo
 ```
 
-Use `standard` for the beginner path. It scaffolds the ingest and planning phases you need before implementation. Use `implementation` only when requirements are already defined and you want to skip that planning structure.
+This links the project into the camp without moving it, and adds a `.camp` attachment file to the project. To clone a repository into the camp instead, use [`camp project add`]({{< ref "/cli-reference/camp/camp_project_add" >}}).
 
-If you are not sure whether this work should start as an intent, a design doc, or a festival, read [Intent vs Design vs Festival]({{< ref "/guides/intent-design-festival" >}}) before creating more planning artifacts.
+{{< terminal-demo src="/images/demos/tui-setup.gif" poster="/images/demos/tui-setup-poster.png" title="Camp setup" alt="A terminal session initializes a camp, adds a local project, and scaffolds a standard festival." width="860" height="500" max="760" caption="Watch a sample camp take shape. The recording uses camp project add --local; the command above links an existing repository. Your agent will create your own festival in the next step." >}}
 
-## 6. Fill Required Markers
+**Ready when:** your project is accessible under `projects/`. Open your agent at the camp root, `my-camp/`, so it can read both the camp instructions and the project.
 
-Open the generated festival files and replace the required `REPLACE` markers with real content. Do not skip this step.
+## 3. Hand off a goal {#hand-off-a-goal}
 
-## 7. Validate the Festival
+A **festival** is the structured plan and work record for a goal. Choose a real outcome you can review, such as adding a feature with tests or investigating a problem and delivering a recommendation.
+
+Tell your agent what you want, which project to use, and what a good result looks like. Replace the bracketed text in this starter prompt:
+
+{{< agent-prompt >}}
+Read AGENTS.md and run fest intro to learn this camp's workflow.
+
+In [project name], I want [specific outcome].
+Success means [what I should be able to verify].
+Constraints: [scope, compatibility, or other requirements].
+
+Use the fest CLI to create and plan a standard festival for this goal. Ask me about missing requirements, follow the planning workflow, and stop at approval gates. Fill required markers, validate the plan, and link the festival to the project or worktree where you will implement it.
+
+Show me the plan and its location before starting implementation.
+{{< /agent-prompt >}}
+
+{{< terminal-demo src="/images/demos/tui-delegate.gif" poster="/images/demos/tui-delegate-poster.png" title="Planning with Grok Build" alt="Grok Build receives a goal, reads Festival guidance, and creates a design work item and an eight-phase festival plan." width="860" height="556" max="760" caption="A real Grok Build session planning a sample app feature. Your agent's interface and the size of your plan will vary with the goal." >}}
+
+**Review before execution:** does the plan describe the outcome you want, stay within scope, and include checks that will demonstrate it works? Ask for changes here, then approve the plan when you are ready.
+
+## 4. Run, review, and resume {#run-review-and-resume}
+
+After reviewing the plan, give your agent the go-ahead:
+
+{{< agent-prompt >}}
+The plan is approved. Work on this festival from its linked project or worktree. Run fest next, follow the instructions it returns, record progress, and repeat. Run the planned checks and review the results before marking work complete.
+
+Continue until the goal is complete or you reach an approval gate, a blocker, or a decision that needs me. Ask me at those points. Finish with a summary of what changed, the verification results, and anything I should review.
+{{< /agent-prompt >}}
+
+`fest next` supplies the next step and its context. Your agent runs the loop; you can work on something else and return at a review point. Keep the agent's own permission settings appropriate for the work you have authorized.
+
+To check progress yourself, open another terminal in the festival directory your agent showed you:
 
 ```bash
-fest validate
+fest watch
 ```
 
-Validation catches unfinished markers and structure issues before execution. Keep running it until the new festival passes cleanly.
+{{< terminal-demo src="/images/demos/tui-fest-watch.gif" poster="/images/demos/tui-fest-watch-poster.png" title="Progress with fest watch" alt="The fest watch terminal interface updates a festival tree as sample task progress advances." width="860" height="513" max="760" caption="The progress view you can open alongside your agent. This recording demonstrates fest watch with scripted progress updates in a sample festival." >}}
 
-## 8. Write a Task
+**If the session ends:** open your agent in the same camp and point it to the saved festival. Ask it to read the current state and continue the `fest next` loop from the linked project. The plan, recorded progress, and decisions stay in files between sessions.
 
-When `standard` scaffolding is valid, your first useful work starts in `001_INGEST/`. Implementation tasks later live directly inside the sequence directory, not under a `tasks/` subdirectory:
+**Your first handoff is complete when:** you have reviewed the result against your success criteria, checked the verification evidence, and can find the plan and work record in the camp. That gives the next session a starting point for whatever comes next.
 
-```
-01_setup-database/
-  01_create-schema.md
-  02_write-migrations.md
-  03_seed-test-data.md
-```
+## Keep going
 
-If you later create implementation sequences manually, add the standard quality gates explicitly:
-
-```bash
-fest gates apply --approve
-```
-
-## 9. Start Working
-
-```bash
-fest next                              # Get the next task with full context
-```
-
-On a first-run `standard` festival, `fest next` should take you into the ingest workflow after marker fill and validation. Once you reach implementation tasks later, do the work described and then:
-
-```bash
-fest task completed                     # Mark the current task done
-fest commit -m "implement user model"  # Commit with festival tracking
-```
-
-`fest commit` wraps git commit with metadata that ties changes back to the active task. Always prefer it over raw `git commit` when working inside a festival.
-
-## 10. Track Progress
-
-```bash
-fest status        # View overall festival progress
-fest progress      # Detailed execution progress with phase/sequence breakdown
-```
-
-`fest status` gives a high-level view. `fest progress` shows exactly where you are in the phase-sequence-task hierarchy.
-
-To see every festival in the camp at once, grouped by status, use `fest list`:
-
-{{< terminal-demo src="/images/demos/tui-fest-list.gif" title="fest list" alt="fest list showing festivals grouped by status: active, ready, and planning" max="600" >}}
-
-## What's Next?
-
-- [Methodology Overview]({{< ref "/methodology/overview" >}}) -- Understand the full phase-sequence-task system
-- [First Festival Tutorial]({{< ref "/tutorials/first-festival" >}}) -- Detailed end-to-end tutorial with real examples
-- [Agent Workflows]({{< ref "/guides/agent-workflows" >}}) -- Using Festival with AI coding tools
-- [Best Practices]({{< ref "/guides/best-practices" >}}) -- Patterns for effective planning and execution
+- [Shell integration]({{< ref "/getting-started/shell-setup" >}}): add `cgo` and `fgo` navigation shortcuts.
+- [First Festival tutorial]({{< ref "/tutorials/first-festival" >}}): walk through the scaffolding and task structure yourself.
+- [Loops & Orchestration]({{< ref "/guides/loops-and-orchestration" >}}): build repeatable loops and coordinate work across projects.
+- [Work items]({{< ref "/cli-reference/camp/camp_workitem" >}}): find your intents, designs, and festivals as the camp grows.

--- a/scripts/test_docs_onboarding.mjs
+++ b/scripts/test_docs_onboarding.mjs
@@ -1,0 +1,151 @@
+// Run after Hugo and Pagefind: DOCS_SITE_DIR=/path/to/build node --test scripts/test_docs_onboarding.mjs
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const site = resolve(process.env.DOCS_SITE_DIR || 'public');
+const guide = readFileSync(resolve(site, 'getting-started/quickstart/index.html'), 'utf8');
+const home = readFileSync(resolve(site, 'index.html'), 'utf8');
+const script = readFileSync(new URL('../themes/festival/assets/js/terminal-recordings.js', import.meta.url), 'utf8');
+
+test('Quick Start has four ordered stages, two prompts, and three captioned recordings', () => {
+  const stages = ['install', 'create-a-camp', 'hand-off-a-goal', 'run-review-and-resume'];
+  let previous = -1;
+  for (const stage of stages) {
+    const position = guide.indexOf(`id="${stage}"`);
+    assert.ok(position > previous, `missing or out-of-order stage: ${stage}`);
+    previous = position;
+  }
+  assert.equal((guide.match(/data-lang="agent-prompt"/g) || []).length, 2);
+  assert.equal((guide.match(/data-demo-src=/g) || []).length, 3);
+  assert.equal((guide.match(/<figcaption>/g) || []).length, 3);
+  assert.match(guide, /content-area--with-toc/);
+  assert.doesNotMatch(guide, /proof-loop\.gif|under 5 minutes/);
+  for (const name of ['tui-setup', 'tui-delegate', 'tui-fest-watch']) {
+    assert.match(guide, new RegExp(`src="/images/demos/${name}-poster\\.png"`));
+    assert.ok(existsSync(resolve(site, `images/demos/${name}.gif`)));
+    assert.ok(existsSync(resolve(site, `images/demos/${name}-poster.png`)));
+  }
+});
+
+test('all local Quick Start links and fragments resolve in the built site', () => {
+  for (const [, href] of guide.matchAll(/href="([^"]+)"/g)) {
+    if (!href.startsWith('/') && !href.startsWith('#')) continue;
+    const url = new URL(href.replaceAll('&amp;', '&'), 'https://docs.fest.build/getting-started/quickstart/');
+    let target = resolve(site, `.${decodeURIComponent(url.pathname)}`);
+    assert.ok(existsSync(target), `missing link: ${href}`);
+    if (statSync(target).isDirectory()) target = resolve(target, 'index.html');
+    assert.ok(existsSync(target), `missing page: ${href}`);
+    if (url.hash) {
+      const html = readFileSync(target, 'utf8');
+      assert.ok(html.includes(`id="${decodeURIComponent(url.hash.slice(1))}"`), `missing anchor: ${href}`);
+    }
+  }
+});
+
+test('landing page keeps its video overview and points into the guide', () => {
+  assert.match(home, /id="how-it-works"/);
+  for (const name of ['tui-setup', 'tui-delegate', 'tui-fest-watch', 'tui-workitems']) {
+    assert.ok(home.includes(`/images/demos/${name}.gif`));
+  }
+  for (const anchor of ['create-a-camp', 'hand-off-a-goal', 'run-review-and-resume']) {
+    assert.ok(home.includes(`/getting-started/quickstart/#${anchor}`));
+  }
+  assert.match(home, /Start with the guide/);
+});
+
+function events(properties = {}) {
+  const listeners = new Map();
+  return Object.assign(properties, {
+    addEventListener(name, callback) {
+      if (!listeners.has(name)) listeners.set(name, []);
+      listeners.get(name).push(callback);
+    },
+    emit(name) { for (const callback of listeners.get(name) || []) callback(); },
+  });
+}
+
+function player({ reduced = false, observer = true } = {}) {
+  const attrs = { src: '/poster.png' };
+  const img = events({
+    getAttribute: (key) => attrs[key],
+    setAttribute: (key, value) => { attrs[key] = value; },
+  });
+  const button = events({ hidden: true, setAttribute(key, value) { this[key] = value; } });
+  const recording = {
+    dataset: { demoSrc: '/demo.gif', demoPoster: '/poster.png', demoTitle: 'Camp setup' },
+    querySelector: (selector) => selector === 'img' ? img : button,
+  };
+  const motion = events({ matches: reduced });
+  const document = events({ hidden: false, querySelectorAll: () => [recording] });
+  let visibility;
+  const IntersectionObserver = class {
+    constructor(callback) { visibility = callback; }
+    observe(target) { assert.equal(target, recording); }
+  };
+  const window = { matchMedia: () => motion };
+  if (observer) window.IntersectionObserver = IntersectionObserver;
+  vm.runInNewContext(script, { window, document, IntersectionObserver });
+  return {
+    img, button, motion, document,
+    src: () => attrs.src,
+    view: (visible) => visibility([{ isIntersecting: visible }]),
+  };
+}
+
+test('recordings autoplay in view, pause to a poster, and retain a manual pause across scrolling', () => {
+  const p = player();
+  assert.equal(p.src(), '/poster.png');
+  assert.equal(p.button.hidden, false);
+  p.view(true);
+  assert.equal(p.src(), '/demo.gif');
+  assert.equal(p.button['aria-label'], 'Pause animation: Camp setup');
+  p.button.emit('click');
+  assert.equal(p.src(), '/poster.png');
+  p.view(false);
+  p.view(true);
+  assert.equal(p.src(), '/poster.png');
+  p.button.emit('click');
+  assert.equal(p.src(), '/demo.gif');
+  p.view(false);
+  assert.equal(p.src(), '/poster.png');
+  p.view(true);
+  assert.equal(p.src(), '/demo.gif');
+});
+
+test('reduced motion uses posters, allows explicit play, and follows preference changes', () => {
+  const p = player({ reduced: true });
+  p.view(true);
+  assert.equal(p.src(), '/poster.png');
+  p.button.emit('click');
+  assert.equal(p.src(), '/demo.gif');
+  p.motion.emit('change');
+  assert.equal(p.src(), '/poster.png');
+  p.motion.matches = false;
+  p.motion.emit('change');
+  assert.equal(p.src(), '/demo.gif');
+});
+
+test('hidden tabs stop animation and media failures leave a usable static preview', () => {
+  const p = player();
+  p.view(true);
+  p.document.hidden = true;
+  p.document.emit('visibilitychange');
+  assert.equal(p.src(), '/poster.png');
+  p.document.hidden = false;
+  p.document.emit('visibilitychange');
+  assert.equal(p.src(), '/demo.gif');
+  p.img.emit('error');
+  assert.equal(p.src(), '/poster.png');
+  assert.equal(p.button.disabled, true);
+  assert.equal(p.button.textContent, 'Animation unavailable');
+});
+
+test('browsers without IntersectionObserver retain working play and pause', () => {
+  const p = player({ observer: false });
+  assert.equal(p.src(), '/demo.gif');
+  p.button.emit('click');
+  assert.equal(p.src(), '/poster.png');
+});

--- a/themes/festival/assets/css/main.css
+++ b/themes/festival/assets/css/main.css
@@ -344,6 +344,12 @@ a:hover {
   margin-left: 0;
 }
 
+@media (min-width: 1281px) {
+  .content-area--with-toc {
+    margin-right: calc(var(--toc-width) + 4rem);
+  }
+}
+
 .content {
   max-width: var(--content-max-width);
   width: 100%;
@@ -353,6 +359,10 @@ a:hover {
 .content-area--home .content {
   max-width: 100%;
   padding: 0;
+}
+
+.site-body--docs .content :is(h2, h3, h4)[id] {
+  scroll-margin-top: calc(var(--header-height) + 1.5rem);
 }
 
 .doc-index__featured {
@@ -586,7 +596,7 @@ pre code {
   margin-left: auto;
   font-family: 'Berkeley Mono', 'SF Mono', monospace;
   font-size: 0.65rem;
-  color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.7);
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
@@ -597,7 +607,7 @@ pre code {
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 5px;
-  color: rgba(255, 255, 255, 0.35);
+  color: rgba(255, 255, 255, 0.75);
   padding: 0.2rem 0.5rem;
   font-family: 'Berkeley Mono', 'SF Mono', monospace;
   font-size: 0.65rem;
@@ -615,6 +625,17 @@ pre code {
 .copy-btn.copied {
   color: #50fa7b;
   border-color: rgba(80, 250, 123, 0.3);
+}
+
+.content code[data-lang="agent-prompt"] {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.copy-btn:focus-visible,
+.terminal-recording__toggle:focus-visible {
+  outline: 2px solid #ffb77c;
+  outline-offset: 3px;
 }
 
 /* Tables */
@@ -1395,6 +1416,43 @@ summary {
   height: auto;
 }
 
+.terminal-recording .terminal-demo {
+  border-radius: 12px;
+}
+
+.site-body--docs .content .terminal-recording img {
+  border-radius: 0;
+}
+
+.terminal-recording .terminal-demo__bar {
+  padding: 0.65rem 1rem;
+}
+
+.terminal-recording .terminal-demo__title {
+  color: #b9b9c2;
+}
+
+.terminal-recording__toggle {
+  flex-shrink: 0;
+  margin-left: auto;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid #55555e;
+  border-radius: 5px;
+  background: transparent;
+  color: #e4e4e7;
+  font: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.terminal-recording__toggle:hover {
+  background: #303036;
+}
+
+.terminal-recording__toggle:disabled {
+  cursor: default;
+}
+
 /* Gallery of terminal-native command demos on the landing page. */
 .demo-gallery {
   display: grid;
@@ -1792,6 +1850,10 @@ summary {
 }
 
 @media (max-width: 768px) {
+  .terminal-recording .terminal-demo__dots {
+    display: none;
+  }
+
   .sidebar {
     position: fixed;
     transform: translateX(-100%);

--- a/themes/festival/assets/js/terminal-recordings.js
+++ b/themes/festival/assets/js/terminal-recordings.js
@@ -1,0 +1,46 @@
+// GIFs autoplay in view. Pausing shows the poster; playing restarts the recording.
+// Starting from the poster also keeps the no-JS and reduced-motion paths still.
+(() => {
+  const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+  document.querySelectorAll('[data-demo-src]').forEach((recording) => {
+    const img = recording.querySelector('img');
+    const button = recording.querySelector('[data-demo-toggle]');
+    let wantsPlayback = !motion.matches;
+    let inView = !('IntersectionObserver' in window);
+    let failed = false;
+
+    function render() {
+      const playing = wantsPlayback && inView && !document.hidden && !failed;
+      const src = playing ? recording.dataset.demoSrc : recording.dataset.demoPoster;
+      if (img.getAttribute('src') !== src) img.setAttribute('src', src);
+      button.textContent = failed ? 'Animation unavailable' : playing ? 'Pause animation' : 'Play animation';
+      button.setAttribute('aria-label', `${button.textContent}: ${recording.dataset.demoTitle}`);
+      button.disabled = failed;
+    }
+
+    button.hidden = false;
+    button.addEventListener('click', () => {
+      wantsPlayback = !wantsPlayback;
+      render();
+    });
+    img.addEventListener('error', () => {
+      failed = true;
+      render();
+    });
+    motion.addEventListener('change', () => {
+      wantsPlayback = !motion.matches;
+      render();
+    });
+    document.addEventListener('visibilitychange', render);
+
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver((entries) => {
+        inView = entries[0].isIntersecting;
+        render();
+      });
+      observer.observe(recording);
+    }
+    render();
+  });
+})();

--- a/themes/festival/layouts/_default/baseof.html
+++ b/themes/festival/layouts/_default/baseof.html
@@ -20,7 +20,7 @@
       {{ partial "sidebar.html" . }}
     {{ end }}
 
-    <main class="content-area{{ if .IsHome }} content-area--home{{ end }}">
+    <main class="content-area{{ if .IsHome }} content-area--home{{ else if .TableOfContents }} content-area--with-toc{{ end }}">
       <div class="content">
         {{ block "main" . }}{{ end }}
       </div>
@@ -55,6 +55,10 @@
   </footer>
 
   <script src="{{ "pagefind/pagefind-ui.js" | relURL }}"></script>
+  {{ if .HasShortcode "terminal-demo" }}
+    {{ $recordings := resources.Get "js/terminal-recordings.js" | minify | fingerprint }}
+    <script src="{{ $recordings.RelPermalink }}" defer></script>
+  {{ end }}
   <script>
   // Theme toggle
   (function() {
@@ -223,24 +227,43 @@
       if (lang) {
         var langLabel = document.createElement('span');
         langLabel.className = 'code-block__lang';
-        langLabel.textContent = lang;
+        langLabel.textContent = lang === 'agent-prompt' ? 'Agent prompt' : lang;
+        if (lang === 'agent-prompt') wrapper.classList.add('code-block--prompt');
         header.appendChild(langLabel);
       }
 
       // Copy button
       var btn = document.createElement('button');
+      btn.type = 'button';
       btn.className = 'copy-btn';
       btn.textContent = 'Copy';
+      btn.setAttribute('aria-live', 'polite');
       btn.addEventListener('click', function() {
         var code = pre.querySelector('code') || pre;
-        navigator.clipboard.writeText(code.textContent).then(function() {
-          btn.textContent = 'Copied!';
-          btn.classList.add('copied');
+        function resetLabel() {
           setTimeout(function() {
             btn.textContent = 'Copy';
             btn.classList.remove('copied');
           }, 2000);
-        });
+        }
+        function selectForCopy() {
+          var selection = window.getSelection();
+          var range = document.createRange();
+          range.selectNodeContents(code);
+          selection.removeAllRanges();
+          selection.addRange(range);
+          btn.textContent = 'Selected: copy manually';
+          resetLabel();
+        }
+        if (!navigator.clipboard || !navigator.clipboard.writeText) {
+          selectForCopy();
+          return;
+        }
+        navigator.clipboard.writeText(code.textContent).then(function() {
+          btn.textContent = 'Copied!';
+          btn.classList.add('copied');
+          resetLabel();
+        }).catch(selectForCopy);
       });
       header.appendChild(btn);
 

--- a/themes/festival/layouts/index.html
+++ b/themes/festival/layouts/index.html
@@ -9,8 +9,8 @@
       </p>
 
       <div class="home-hero__actions">
-        {{ with site.GetPage "/getting-started/installation" }}
-          <a href="{{ .RelPermalink }}" class="btn btn--primary">Install Festival</a>
+        {{ with site.GetPage "/getting-started/quickstart" }}
+          <a href="{{ .RelPermalink }}" class="btn btn--primary">Start with the guide</a>
         {{ end }}
         <a href="#how-it-works" class="btn btn--secondary">See how it works</a>
         {{ with site.Params.repo }}
@@ -42,11 +42,11 @@
             <span class="terminal-demo__dot terminal-demo__dot--yellow"></span>
             <span class="terminal-demo__dot terminal-demo__dot--green"></span>
           </div>
-          <span class="terminal-demo__title">fest show</span>
+          <span class="terminal-demo__title">Camp Hardening: progress replay</span>
         </div>
-        <img src="/images/fest-show.gif" alt="fest show on a finished festival: four phases at 100 percent, then the task tree with every sequence and quality gate checked off" style="display:block;width:100%;height:auto;" loading="lazy">
+        <img src="/images/fest-show.gif" alt="A historical replay of recorded progress from the Camp Hardening festival, showing phases, tasks, and quality gates reaching completion" style="display:block;width:100%;height:auto;" loading="lazy">
       </div>
-      <p class="home-hero__visual-caption"><code>fest show</code> on a real festival, finished end to end. fest is the planning system that breaks a long-running, complex, or highly specific goal into structured work and drives it to completion.</p>
+      <p class="home-hero__visual-caption">A historical replay of the Camp Hardening festival's recorded progress. Festival turns a long-running goal into structured work, with a record you can return to and review.</p>
     </div>
   </section>
 
@@ -62,8 +62,8 @@
           <div class="howto__meta"><span class="howto__num">01</span><span class="howto__label">Set up</span></div>
           <h3>Create your workspace</h3>
           <p>One command scaffolds a campaign that holds every project, plan, and doc in one place. Add your repositories, create your first festival, and the workspace is ready. That is the whole setup.</p>
-          {{ with site.GetPage "/tutorials/campaign-setup" }}
-            <a href="{{ .RelPermalink }}" class="howto__link">Campaign setup &rarr;</a>
+          {{ with site.GetPage "/getting-started/quickstart" }}
+            <a href="{{ .RelPermalink }}#create-a-camp" class="howto__link">Create your camp &rarr;</a>
           {{ end }}
         </div>
         <div class="howto__visual">
@@ -72,7 +72,7 @@
               <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
               <span class="terminal-demo__title">camp init</span>
             </div>
-            <img src="/images/demos/tui-setup.gif" class="terminal-demo__gif" alt="camp init scaffolds a campaign, camp project add brings a repository in as a submodule, and fest create festival writes the first plan" data-poster="/images/demos/tui-setup-poster.png" loading="lazy">
+            <img src="/images/demos/tui-setup.gif" class="terminal-demo__gif" alt="camp init scaffolds a campaign, camp project add --local adds a local project, and fest create festival scaffolds the first festival" data-poster="/images/demos/tui-setup-poster.png" loading="lazy">
           </div>
         </div>
       </div>
@@ -82,8 +82,8 @@
           <div class="howto__meta"><span class="howto__num">02</span><span class="howto__label">Delegate</span></div>
           <h3>Describe the work to your agent</h3>
           <p>Open your agent of choice, Claude Code, Codex, or Grok, and describe what you want in a sentence. It creates the design, scaffolds a festival, and plans the whole thing out into phases, sequences, and tasks. You do not touch the <code>fest</code> CLI.</p>
-          {{ with site.GetPage "/guides/intent-design-festival" }}
-            <a href="{{ .RelPermalink }}" class="howto__link">Intent, design, festival &rarr;</a>
+          {{ with site.GetPage "/getting-started/quickstart" }}
+            <a href="{{ .RelPermalink }}#hand-off-a-goal" class="howto__link">Try your first handoff &rarr;</a>
           {{ end }}
         </div>
         <div class="howto__visual">
@@ -101,9 +101,9 @@
         <div class="howto__copy">
           <div class="howto__meta"><span class="howto__num">03</span><span class="howto__label">Watch</span></div>
           <h3>Watch the plan get built</h3>
-          <p>Your agent works the <code>fest next</code> loop on its own, and you watch progress climb in real time as tasks complete and commit with tracking. Any session picks up exactly where the last one stopped.</p>
-          {{ with site.GetPage "/guides/agent-workflows" }}
-            <a href="{{ .RelPermalink }}" class="howto__link">Agent workflows &rarr;</a>
+          <p>Your agent follows the <code>fest next</code> loop while you focus on other work. Check progress when you need to, review the results, and continue from the saved work record in your next session.</p>
+          {{ with site.GetPage "/getting-started/quickstart" }}
+            <a href="{{ .RelPermalink }}#run-review-and-resume" class="howto__link">Run and review the work &rarr;</a>
           {{ end }}
         </div>
         <div class="howto__visual">
@@ -112,7 +112,7 @@
               <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
               <span class="terminal-demo__title">fest watch</span>
             </div>
-            <img src="/images/demos/tui-fest-watch.gif" class="terminal-demo__gif" alt="fest watch: a festival's progress bar and task icons climbing live as the agent works" data-poster="/images/demos/tui-fest-watch-poster.png" loading="lazy">
+            <img src="/images/demos/tui-fest-watch.gif" class="terminal-demo__gif" alt="fest watch: a festival's progress bar and task icons updating with scripted sample task progress" data-poster="/images/demos/tui-fest-watch-poster.png" loading="lazy">
           </div>
         </div>
       </div>
@@ -132,7 +132,7 @@
               <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
               <span class="terminal-demo__title">camp wi</span>
             </div>
-            <img src="/images/demos/tui-workitems.gif" class="terminal-demo__gif" alt="camp wi dashboard: every festival, intent, design, and project in one unified list" data-poster="/images/demos/tui-workitems-poster.png" loading="lazy">
+            <img src="/images/demos/tui-workitems.gif" class="terminal-demo__gif" alt="camp wi dashboard: browse and preview sample intents, designs, explores, and festivals, then narrow the list with search" data-poster="/images/demos/tui-workitems-poster.png" loading="lazy">
           </div>
         </div>
       </div>

--- a/themes/festival/layouts/shortcodes/agent-prompt.html
+++ b/themes/festival/layouts/shortcodes/agent-prompt.html
@@ -1,0 +1,1 @@
+<pre><code data-lang="agent-prompt">{{ .Inner | strings.TrimSpace }}</code></pre>

--- a/themes/festival/layouts/shortcodes/terminal-demo.html
+++ b/themes/festival/layouts/shortcodes/terminal-demo.html
@@ -2,10 +2,21 @@
 {{- $title := .Get "title" -}}
 {{- $alt := .Get "alt" -}}
 {{- $max := .Get "max" | default "600" -}}
+{{- $poster := .Get "poster" -}}
+{{- $id := printf "terminal-recording-%d" .Ordinal -}}
+{{ if $poster }}
+<figure class="terminal-recording" style="max-width:{{ $max }}px;" data-demo-src="{{ $src }}" data-demo-poster="{{ $poster }}" data-demo-title="{{ $title }}">
+{{ end }}
 <div class="terminal-demo terminal-demo--embed" style="max-width:{{ $max }}px;">
   <div class="terminal-demo__bar">
-    <div class="terminal-demo__dots"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
+    <div class="terminal-demo__dots" aria-hidden="true"><span class="terminal-demo__dot terminal-demo__dot--red"></span><span class="terminal-demo__dot terminal-demo__dot--yellow"></span><span class="terminal-demo__dot terminal-demo__dot--green"></span></div>
     <span class="terminal-demo__title">{{ $title }}</span>
+    {{ if $poster }}<button type="button" class="terminal-recording__toggle" data-demo-toggle aria-controls="{{ $id }}" hidden>Play animation</button>{{ end }}
   </div>
-  <img src="{{ $src }}" alt="{{ $alt }}" class="terminal-demo__gif" style="display:block;width:100%;height:auto;" loading="lazy">
+  <img {{ if $poster }}id="{{ $id }}"{{ end }} src="{{ if $poster }}{{ $poster }}{{ else }}{{ $src }}{{ end }}" alt="{{ $alt }}" class="terminal-demo__gif" {{ with .Get "width" }}width="{{ . }}"{{ end }} {{ with .Get "height" }}height="{{ . }}"{{ end }} loading="lazy" decoding="async">
 </div>
+{{ if $poster }}
+  {{ with .Get "caption" }}<figcaption>{{ . }}</figcaption>{{ end }}
+  <noscript><p><a href="{{ $src }}">Open the animated recording: {{ $title }}</a></p></noscript>
+</figure>
+{{ end }}


### PR DESCRIPTION
## Summary

Preserve the docs landing page and its video-led overview while making Quick Start a practical path to the first agent handoff.

- Replace the FAQ-first, ten-step manual walkthrough with four stages: install, create a camp, hand off a goal, then run/review/resume.
- Add copyable planning and execution prompts with explicit approval and blocker checkpoints.
- Reuse the existing setup, Grok Build, and progress recordings with accurate captions, autoplay in view, keyboard pause/play, reduced-motion posters, and a no-JavaScript fallback.
- Connect the landing page's primary action and setup links to the relevant Quick Start stages. Keep its layout, branding, gradient, and recordings.
- Fix the desktop article/TOC overlap, improve copy-button contrast and clipboard-error recovery, and wrap agent prompts on narrow screens.
- Add seven regression tests for the guide, local links, retained landing media, and playback behavior.

## Verification

- [x] Fresh Hugo production build (local Hugo 0.163.3).
- [x] Pagefind build: 497 HTML pages indexed.
- [x] Seven tests pass with `DOCS_SITE_DIR=<build-dir> node --test scripts/test_docs_onboarding.mjs`.
- [x] JavaScript syntax check and `git diff --check`.
- [x] PinchTab checks at 1440px desktop and 390px mobile: layout, light/dark themes, playback controls, reduced motion, keyboard focus, clipboard success/fallback, sidebar, anchors, and search.
- [x] Independent read-only review; clarified the sample setup caption after feedback.

No global install or fresh agent goal was executed as part of these checks. Existing documentation and installed CLI help were used to verify the instructions. No CLI changes, new media, or tracking changes are included.

## Deployment

This PR does not publish the docs. The existing Pages workflow runs on release tags or a manual dispatch.