### PR TITLE
docs: improve use cases, developer onboarding, and discovery

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,5 +1,6 @@
 ---
-title: "Documentation"
+title: "Festival Documentation"
+description: "Hand goals to your agents and keep the work coherent. Learn Festival through real recordings, practical use cases, developer workflows, and CLI guides."
 ---
 
-Welcome to the Festival documentation. Use the sidebar to navigate.
+Learn how to plan, execute, review, and resume agent work with Festival.

--- a/docs/compare/festival-vs-issue-trackers.md
+++ b/docs/compare/festival-vs-issue-trackers.md
@@ -1,78 +1,51 @@
 ---
-title: "Festival vs Issue Trackers"
-description: "Compare Festival with GitHub Issues, Linear, Jira, and task lists for AI-assisted software work."
+title: "Using Festival with Your Issue Tracker"
+linkTitle: "Festival & Issue Trackers"
+description: "Keep GitHub Issues, Linear, or Jira for team coordination. Use Festival for agent execution plans, review gates, and context, connected through scripts or justfiles."
 weight: 39
 ---
 
-# Festival vs Issue Trackers
+# Using Festival with Your Issue Tracker
 
-Issue trackers are good at recording what a team intends to do. Festival is built for turning a goal into executable work that an AI agent can pick up, verify, commit, and resume.
+Keep the issue where your team already discusses it. Use Festival to organize the work your agent needs to do to resolve it.
 
-You may still use GitHub Issues, Linear, Jira, or a task list. Festival fills a different gap.
+An issue might request a new permission model. Delivering it may require decisions, changes to several repositories, migration checks, documentation, and review. A festival connects those steps to the outcome. The issue remains the place to agree on priority and communicate the result.
 
-## Short Version
+## Connect the request to the work
 
-Use an issue tracker for prioritization, discussion, assignment, and team visibility.
+A useful handoff keeps both records linked:
 
-Use Festival when the work needs structured execution:
+| Record | What to keep there |
+| --- | --- |
+| Issue or ticket | Request, discussion, priority, owner, and links to the result |
+| Camp intent or research | Source URL, initial questions, evidence, and constraints |
+| Festival | Approved plan, task criteria, dependencies, review gates, and progress |
+| Pull request | Implementation diff, verification summary, and links back to the issue and festival |
 
-- project-local context
-- phase and task hierarchy
-- agent-readable next steps
-- acceptance criteria
-- quality gates
-- handoff notes
-- commit traceability
+For a small fix, you may need only the issue and a branch. A festival becomes useful when the work needs decomposition, a lasting decision record, or coordination across projects.
 
-## Comparison
+## Bring an issue into a camp
 
-| Need | Issue tracker | Festival |
-|---|---|---|
-| Team backlog | Strong | Not the primary job |
-| Project discussion | Strong | Supported through docs, but not a comment system |
-| AI agent next task | Usually ambiguous | `fest next` returns the next executable task |
-| Context across sessions | Often scattered | Stored in the workspace |
-| Multi-step execution | Manual coordination | Phases, sequences, and tasks |
-| Verification | Usually checklist text | Task criteria plus gates and commands |
-| Commit traceability | Manual conventions | `fest commit` ties work to the plan |
-| Works without a hosted service | Usually no | Yes, filesystem plus git |
+Ask your agent to read the issue through the tracker CLI or API you already use. It can capture the source URL and relevant requirements in an intent, research work item, or festival plan.
 
-## Where Issue Trackers Break Down For Agents
+For repeated use, put that step in a script or justfile. Decide what to copy, where it belongs, and how to recognize an issue that has already been imported. Keep credentials in your existing credential system and include only the data the work needs.
 
-An issue often describes a desired outcome, but an agent still needs to infer:
+Festival stores work in files, so the integration can use your preferred language and tooling. The tracker adapter is a script or integration you supply; Festival does not include native synchronization with every tracker.
 
-- which files matter
-- what order to do the work in
-- what prior decisions constrain the implementation
-- how to verify each step
-- what to do after the first subtask is complete
+## Give the agent a bounded goal
 
-That inference burns context and creates risk. Festival makes the execution plan explicit.
+{{< agent-prompt >}}
+Read [issue URL] using the configured tracker tool. Capture its source link, requirements, and open questions in this camp.
 
-## How They Work Together
+Plan the work in [project] with Festival, including acceptance criteria and verification. Ask me about missing requirements and show the plan before implementation.
 
-A practical setup is:
+Keep the issue's discussion and priority in the tracker. When the work is ready, prepare a summary with the pull request and verification results for me to review before posting it.
+{{< /agent-prompt >}}
 
-1. Use GitHub Issues, Linear, or Jira for product backlog and team discussion.
-2. Promote selected work into a Festival when it becomes AI-executable.
-3. Use Festival to plan phases, sequences, tasks, gates, and verification.
-4. Link commits and PRs back to the issue if needed.
+If your team wants automated updates, define the allowed fields and posting rules in the script. A local task completing does not necessarily mean an issue should close: there may still be a deployment, review, or customer confirmation to do.
 
-The issue remains the team-level artifact. The festival becomes the execution artifact.
+## Return a useful result
 
-## When Festival Is Overkill
+At review time, ask for the implementation, checks run, unresolved concerns, and links back to the work record. Your agent can prepare those from the festival and repository.
 
-Do not create a festival for every tiny task. A one-line typo fix or a small isolated edit does not need the full structure.
-
-Festival pays for itself when the work is large enough that losing context would cost more than writing the plan.
-
-## Try It
-
-```bash
-camp init my-workspace
-cd my-workspace
-fest create festival --name issue-123-auth-refactor --type standard
-fest next
-```
-
-Next: read [AI Agent Project Management]({{< ref "/use-cases/ai-agent-project-management" >}}) or start with the [Quick Start]({{< ref "/getting-started/quickstart" >}}).
+That leaves the team with its familiar issue workflow and gives the next agent session a specific place to continue. Follow the [Quick Start]({{< ref "/getting-started/quickstart" >}}) to try one issue, or read [Loops & Orchestration]({{< ref "/guides/loops-and-orchestration" >}}) for recurring intake.

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -1,8 +1,31 @@
 ---
 title: "Getting Started"
+description: "Choose your first Festival path: hand a goal to an agent, organize your development projects, or learn the suite installer and plugin manager."
 weight: 10
+hideChildList: true
 ---
 
-**Your files. Any agent.**
+Start with the job you want to do. You can use Festival with an existing agent and an existing repository.
 
-Festival is the planning and verification layer for long-running agent work. The camp is files you own. The harness is whatever you already run. The next session starts from `fest next`, not from a vendor brief.
+<div class="doc-index__list">
+  <a class="doc-index__item" href="{{< ref "/getting-started/quickstart" >}}">
+    <strong>Hand off your first goal</strong>
+    <span>Install, create a camp, and ask your agent to plan and execute work you can review.</span>
+  </a>
+  <a class="doc-index__item" href="{{< ref "/guides/everyday-development" >}}">
+    <strong>Organize your daily development</strong>
+    <span>Navigate projects with cgo, work in parallel, and prepare the next branch after a merge.</span>
+  </a>
+  <a class="doc-index__item" href="{{< ref "/getting-started/festival-manager" >}}">
+    <strong>Understand the installer and plugins</strong>
+    <span>Learn what festival, camp, and fest do, and how to manage the tools you run.</span>
+  </a>
+  <a class="doc-index__item" href="{{< ref "/use-cases" >}}">
+    <strong>Find the fit for your work</strong>
+    <span>Explore development, research, incident, support, and infrastructure workflows.</span>
+  </a>
+</div>
+
+## Setup reference
+
+Use the [installation guide]({{< ref "/getting-started/installation" >}}) for package-manager choices and troubleshooting, [agent setup]({{< ref "/getting-started/agents" >}}) for your coding tool, and [shell setup]({{< ref "/getting-started/shell-setup" >}}) for navigation shortcuts.

--- a/docs/getting-started/agents/_index.md
+++ b/docs/getting-started/agents/_index.md
@@ -1,5 +1,7 @@
 ---
 title: "Set up with your agent"
+description: "Choose your agent's Festival setup guide, install the relevant skills, and connect the agent to a camp and an approved work plan."
+hideChildList: true
 weight: 14
 ---
 

--- a/docs/getting-started/festival-manager.md
+++ b/docs/getting-started/festival-manager.md
@@ -1,0 +1,103 @@
+---
+title: "Festival Installer and Plugin Manager"
+linkTitle: "Installer & Plugins"
+description: "Use the festival binary to install and update the suite, check installation health, and discover executable camp and fest plugins."
+---
+
+# Festival Installer and Plugin Manager
+
+The `festival` binary is the suite's installer, launchpad, and CLI plugin manager. It helps you get the right tools on your PATH and find extensions when you need them.
+
+If you have not installed the suite yet, choose your platform in the [installation guide]({{< ref "/getting-started/installation" >}}), then return here to manage it.
+
+The suite has three commands with different jobs:
+
+- `festival` installs and updates the `camp` and `fest` suite, checks it,
+  locates binaries, and browses registered marketplaces.
+- `fest` plans work with phases, sequences, tasks, and approval gates.
+- `camp` holds projects, worktrees, planning files, and navigation shortcuts.
+
+Run `festival` with no arguments in a terminal to open its interactive
+launchpad. Starting `camp` or `fest` there runs the real CLI process; quitting
+it returns to the launchpad.
+
+## Check the suite you are running
+
+Start with read-only checks when a command is missing, a shell wrapper seems to
+point to the wrong program, or a recent update did not take effect:
+
+```bash
+festival doctor
+festival which camp
+festival which fest --show-all
+```
+
+`festival doctor` reports PATH, package sources, and receipts. `festival which`
+resolves the executable behind a suite tool and can show both the active and
+installer-managed locations. Shell integration may define `camp` and `fest` as
+functions, so a plain `which camp` may show a function instead of a binary.
+
+For a suite installed by the Festival manager, an update is:
+
+```bash
+festival update festival
+```
+
+The suite moves together: `festival update camp` and `festival update fest` are
+accepted aliases, not independent component updates. The manager does not
+replace a Homebrew, npm, or AUR installation; it preserves package-manager
+ownership. The [installation guide]({{< ref "/getting-started/installation" >}})
+lists direct upgrade commands. Check the
+[doctor reference]({{< ref "/cli-reference/festival/festival_doctor" >}}),
+[which reference]({{< ref "/cli-reference/festival/festival_which" >}}), and
+[update reference]({{< ref "/cli-reference/festival/festival_update" >}}) before
+changing an installation.
+
+## Browse and install CLI plugins
+
+The manager can register a Git marketplace and display packages from the
+marketplaces already registered on this machine:
+
+```bash
+festival marketplace list
+festival browse
+festival browse --kind plugin --product fest
+festival browse --kind plugin --product camp
+```
+
+`--kind` filters package classes. `--product` filters by the host product in
+package metadata: `fest`, `camp`, or `obey`. To add a marketplace, use
+`festival marketplace add <git-url>`; refresh its cached data with
+`festival marketplace refresh [name]`. Both change local state.
+
+In the interactive manager, open **Browse**, select a compatible `camp-*` or
+`fest-*` plugin, and press Enter to install it. These executable extensions are
+not agent plugins. The manager resolves the selected package, checks its
+compatibility, verifies its artifact, activates it, and records a receipt.
+Review the package source and compatibility information before installing an
+executable extension.
+
+`festival update` updates the `camp` and `fest` suite together, not plugins. In Browse, `r`
+refreshes marketplace data; it does not update an installed plugin. The
+[browse reference]({{< ref "/cli-reference/festival/festival_browse" >}}) and
+[marketplace reference]({{< ref "/cli-reference/festival/festival_marketplace" >}})
+cover the non-interactive discovery commands.
+
+## Keep CLI plugins separate from agent integrations
+
+A **CLI plugin** is an executable extension named for its host, such as a
+`camp-*` or `fest-*` package. Festival discovers and installs these from its
+own marketplaces. `camp plugins` and `fest plugins` show what their CLIs find.
+
+An **agent integration package** belongs to an AI coding product, not Festival.
+It may contain skills, hooks, commands, or agent definitions, and its product
+controls installation and updates. A **skill** is an instruction unit an agent
+loads for a kind of work. Neither is a `camp-*` or `fest-*` executable plugin.
+
+Use the [agent setup guides]({{< ref "/getting-started/agents" >}}) for an
+agent integration's installation path. Use `festival browse` and the Browser
+for marketplace CLI plugins. `obey` metadata is a catalog filter, not a signal
+that Festival can install it as a `camp` or `fest` plugin.
+
+For planning help, start in a camp with `fest intro` or `fest understand methodology`. For project and navigation work, use `camp`. For suite health,
+updates, and package discovery, return to `festival`.

--- a/docs/guides/agent-workflows.md
+++ b/docs/guides/agent-workflows.md
@@ -1,5 +1,6 @@
 ---
 title: "Agent Workflows"
+description: "Give an agent a goal, run the fest next loop, verify its work, and preserve decisions for the next session or tool."
 weight: 31
 ---
 
@@ -11,16 +12,16 @@ How to use Festival Methodology with AI agents for autonomous development sessio
 
 ## Why Festival for AI Agents
 
-AI coding agents are powerful but stateless. Every session starts from zero - the agent doesn't know what was planned, what's already done, or what comes next. Without structure, you get duplicated work, missed steps, and sessions that spend half their context window figuring out where they are.
+Hand off an approved goal, let the agent work, and return to a result you can inspect. Festival keeps the plan, decisions, progress, and checks alongside the work, so that handoff can extend across sessions and tools.
 
-Festival solves this by putting all project state in the filesystem. Plans, progress, and context are markdown files that any agent can read. There is no external database, no API, and no proprietary format. An agent that can run bash commands and read files can use Festival immediately.
+Plans and context are Markdown files; the CLI records progress in the workspace. An agent with shell and file access can use that record without a Festival API integration. For a first handoff, follow the [Quick Start]({{< ref "/getting-started/quickstart" >}}).
 
 The key properties that make this work:
 
-- **Context management** - Work is broken into tasks sized to fit within agent context windows. No task requires loading the entire project state.
-- **Resumable sessions** - `fest next` tells any new agent exactly what to do next, with full context included inline.
+- **Context management** - Break work into scoped tasks with relevant instructions and references.
+- **Resumable sessions** - `fest next` supplies the next recorded step and its planning context.
 - **Just-in-time context** - Agents load only what they need for the current task. Phase goals, sequence context, and task documents are served on demand.
-- **Progress tracking** - `fest status` shows what's done, what's in flight, and what remains. No guessing.
+- **Progress tracking** - `fest status` shows recorded completion and remaining work. Keep it aligned with the actual results.
 - **Methodology on demand** - `fest intro` and `fest understand` teach agents the system without upfront context dumps. The agent learns what it needs, when it needs it.
 
 ---
@@ -29,20 +30,19 @@ The key properties that make this work:
 
 The typical agent workflow is a tight loop:
 
+```text
+fest next → agent reads and executes → checks and review → record progress → repeat
 ```
-fest intro   → Agent learns the methodology (first session only)
-fest next    → Gets next task with full context, executes it (repeat)
-```
 
-`fest next` is the entire loop. It returns the next task with full inline context, and the task document itself tells the agent what commands to run when done -- `fest task completed`, `fest commit`, quality gates, whatever the task requires. The agent reads the task, does the work, follows the completion steps, and runs `fest next` again.
+Run this loop from the active festival directory or a project linked to it. `fest next` supplies guidance; your agent and its tools execute the work. The task document describes the deliverable and checks. The agent reads the relevant files, completes the work, follows the completion instructions, records progress, and requests the next step.
 
-On first contact, run `fest intro` once. After that, an agent can run `fest next` indefinitely across multiple sessions without losing state.
+On first contact, run `fest intro`. Review the plan and permissions before execution, and stop at approval gates or when scope changes. Agent runtime limits, credentials, and background execution belong to the agent tool, not `fest next`.
 
-Watch the work advance in real time with `fest watch` -- the progress bar and task icons update live as each step completes:
+Use `fest watch` to see recorded task progress. This CLI recording demonstrates the display with scripted sample progress:
 
-{{< terminal-demo src="/images/demos/tui-fest-watch.gif" title="fest watch" alt="fest watch showing a festival's progress bar and task icons updating live as work completes" max="640" >}}
+{{< terminal-demo src="/images/demos/tui-fest-watch.gif" poster="/images/demos/tui-fest-watch-poster.png" title="fest watch" alt="The fest watch TUI updating as scripted sample tasks are marked complete" max="640" >}}
 
-That is one festival. The same loop runs independently per festival, so you can leave several going in the background (different agents, different tools, different worktrees) and watch them with `fest show`. See [Loops & Orchestration]({{< ref "/guides/loops-and-orchestration" >}}).
+Separate agent sessions can work on different festivals and worktrees in parallel. Use `fest show` to inspect the work graph. See [Loops & Orchestration]({{< ref "/guides/loops-and-orchestration" >}}) for the agent's outer loop, recurring workflows, and review gates.
 
 ---
 
@@ -61,23 +61,23 @@ These are the commands agents use most. They are designed to return agent-readab
 | `fest task completed` | Mark the current task as done. |
 | `fest commit -m "msg"` | Git commit with festival metadata for traceability. |
 
-`fest next` is the most important command. Its output includes everything an agent needs to start working - the task document content, the phase it belongs to, and the overall festival goal. No additional file reads required.
+`fest next` brings the task and surrounding goals into the agent's context. The agent still reads referenced code, project instructions, evidence, and other files needed to do the task correctly.
 
 ---
 
 ## Working with Claude Code
 
-Claude Code is the primary development environment for Festival workflows. These patterns have been tested extensively.
+The [Claude Code setup guide]({{< ref "/getting-started/agents/claude-code" >}}) covers integration. Once configured:
 
-**Add festival instructions to CLAUDE.md.** Include a line telling the agent to run `fest intro` at the start of sessions and use `fest next` for task assignment. This eliminates the "what should I work on?" problem.
+**Add festival instructions to CLAUDE.md.** Tell the agent where the festival is, to run `fest intro` on first contact, and to use `fest next` for task guidance. Include the review and permission boundaries.
 
 **Use `fest next` output directly.** The output is structured markdown designed for agent consumption. It includes the task document, acceptance criteria, and surrounding context. Paste it into the conversation or let the agent run the command itself.
 
-**Use `fest commit` instead of raw `git commit`.** Festival commits include metadata that traces changes back to specific tasks and sequences. This makes progress tracking and review significantly easier. `fest commit -m "message"` handles staging and syncing automatically.
+**Use `fest commit` for festival work.** Its metadata ties the change to the plan. Inspect the diff and stage only the intended files; use the [commit options]({{< ref "/cli-reference/fest/fest_commit" >}}) to control staging and synchronization in a shared working tree.
 
-**Use `fest understand` instead of reading source docs.** Agents don't need to load methodology documentation files. `fest understand workflow` or `fest understand tasks` delivers exactly what the agent needs, formatted for consumption, without burning context on full documents.
+**Use `fest understand` for focused guidance.** Commands such as `fest understand workflow` or `fest understand tasks` explain the relevant methodology without requiring the whole manual.
 
-**Capture session state in CONTEXT.md.** When ending a session, write decisions, open questions, and partial progress into the festival's CONTEXT.md file. The next session picks this up and continues without re-deriving context.
+**Capture session state in CONTEXT.md.** Before ending a session, record decisions, open questions, failed checks, and partial progress. Tell the next session where to find those notes.
 
 ---
 
@@ -93,7 +93,7 @@ There is no API integration required. Everything is bash commands and markdown f
 
 The filesystem IS the state. Task documents are markdown files. Progress is tracked by file location and status markers. An agent reads task documents, writes code, and records completion - all through standard file operations and CLI commands.
 
-This means Festival works the same way regardless of which AI tool is driving the session. Switch tools mid-festival and nothing breaks. The state is in the files, not in any tool's memory.
+The shared work record stays available when you switch tools. The receiving agent still needs compatible file access, project instructions, and permission to run the required checks. See [agent setup]({{< ref "/getting-started/agents" >}}) for the supported integration paths.
 
 ---
 
@@ -101,15 +101,15 @@ This means Festival works the same way regardless of which AI tool is driving th
 
 The hardest problem in agent workflows is handoff - when one session ends and another begins. Festival makes this explicit rather than hoping context survives.
 
-**`fest status`** shows exactly where work stands. Which phases are complete, which sequences are in progress, which tasks remain. A new agent reads this and knows the full picture in seconds.
+**`fest status`** reports phase, sequence, and task progress. Check that the recorded status matches the working tree and latest verification results.
 
-**`fest next`** picks up the next incomplete task automatically. No manual searching through directories or reading status files. The agent gets a task with full context and starts working immediately.
+**`fest next`** identifies the next incomplete step and supplies its planning context. Read the task and referenced files before continuing.
 
 **`fest context`** provides full context for the current location. If an agent needs to understand where it is in the festival hierarchy - what phase, what sequence, what the goals are - this command delivers it.
 
 **CONTEXT.md files** capture decisions and rationale across sessions. Why was this approach chosen? What alternatives were considered? What gotchas were discovered? This is the institutional memory that prevents the next session from re-learning hard-won lessons.
 
-Nothing is lost between sessions. The plan is in the filesystem. The progress is in the filesystem. The context is in the filesystem. A new agent session with `fest next` is fully operational in under 30 seconds.
+Festival preserves what you record. Leave incomplete work marked incomplete, capture blockers, and note the next action before stopping. The [handoff checklist]({{< ref "/use-cases/ai-agent-handoff" >}}) is a useful final check for both the outgoing agent and the reviewer.
 
 ---
 

--- a/docs/guides/everyday-development.md
+++ b/docs/guides/everyday-development.md
@@ -1,0 +1,120 @@
+---
+title: "Everyday Development in a Camp"
+linkTitle: "Everyday Development"
+description: "Move between camp work, isolate changes in worktrees, and reset projects safely after a merge."
+---
+
+# Everyday Development in a Camp
+
+A camp gives planning files and one or more codebases a shared home. Day to day,
+that means less path hunting, separate directories for concurrent changes, and a
+repeatable post-merge reset. The commands below keep those jobs separate: `camp`
+manages the workspace and `fest` manages a festival plan.
+
+## Move where the work is
+
+Shell integration adds `cgo`, a function that can change the directory of the
+shell you are using. Use the packaged helper when it is available, or the
+dynamic setup shown in [Shell Setup]({{< ref "/getting-started/shell-setup" >}}).
+For a zsh session without the packaged helper:
+
+```bash
+eval "$(camp shell-init zsh)"
+```
+
+Then move by category or project name instead of spelling out long paths:
+
+```bash
+cgo              # camp root, or toggle back to the last location
+cgo p            # projects/
+cgo p api        # fuzzy-match a project under projects/
+cgo f            # festivals/
+cgo w            # workflow/
+cgo i            # .campaign/intents/
+```
+
+Run `camp shortcuts` to see the shortcuts defined for this camp. `camp go`
+resolves the same targets but does not change your current shell, which makes it
+useful in scripts:
+
+```bash
+cd "$(camp go p --print)"
+```
+
+When you need another registered camp, `csw` is the shell shortcut for `camp
+switch`. It opens a picker without an argument or accepts a camp name, ID prefix,
+or an `org/camp` selector:
+
+```bash
+csw client-work
+csw obey/platform
+```
+
+`csw` changes the shell's directory. Plain `camp switch` can resolve a target,
+but needs `--print` and `cd` when you are not using the shell wrapper. See the
+[shell-init reference]({{< ref "/cli-reference/camp/camp_shell-init" >}}) and
+[switch reference]({{< ref "/cli-reference/camp/camp_switch" >}}) for the full
+set of shell and remote-camp options.
+
+## Give each change its own directory
+
+Use a Git worktree when two changes in the same repository need to stay checked
+out at once. Camp creates its managed worktrees under
+`projects/worktrees/<project>/<worktree-name>/`, so they remain visible beside
+the rest of the camp.
+
+```bash
+# From anywhere in the camp, create a branch and working directory.
+camp project worktree add feature-search --project api --start-point main
+
+# Check the directories Git knows about for this project.
+camp project worktree list --project api
+```
+
+The first command creates a new branch named `feature-search` unless you choose
+an existing branch with `--branch` or a remote branch with `--track`. Give an
+agent the resulting worktree path when it should work independently from your
+main checkout. Remove a worktree only after its changes are merged or otherwise
+safe to discard. The [worktree reference]({{< ref "/cli-reference/camp/camp_project_worktree" >}})
+covers those choices and the removal command.
+
+## Start clean after a merge
+
+After a pull request lands, preview the reset before changing anything:
+
+```bash
+camp fresh api --dry-run
+```
+
+The normal cycle checks out the project's default branch, fetches `origin`,
+synchronizes to the remote default while retaining local-only commits, and
+prunes merged branches. When the preview looks right, run it without `--dry-run`:
+
+```bash
+camp fresh api
+```
+
+By default, `camp fresh` synchronizes and prunes. A camp can also configure a
+new working branch and follow-up commands such as bootstrap or build steps in
+`.campaign/settings/fresh.yaml`. Inspect that resolved sequence before relying
+on it:
+
+```bash
+camp fresh show-workflow api
+```
+
+Use `--no-follow-up` to skip configured commands. If a working branch is
+configured or supplied with `--branch`, fresh pushes that new branch unless you
+pass `--no-push`. `--no-prune` leaves merged branches alone.
+
+For a camp-wide preview, use:
+
+```bash
+camp fresh all --dry-run
+```
+
+`all` cycles every project submodule in the camp. It does not include linked
+external projects, so run `camp fresh <project-name> --dry-run` for those.
+Read the [fresh reference]({{< ref "/cli-reference/camp/camp_fresh" >}}) and
+[fresh-all reference]({{< ref "/cli-reference/camp/camp_fresh_all" >}}) before
+using pruning, branch creation, or configured follow-ups on unfamiliar work.

--- a/docs/methodology/overview.md
+++ b/docs/methodology/overview.md
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+description: "Understand Festival's goal-based planning: phases, tasks, dependencies, review gates, and durable context for human-agent collaboration."
 weight: 21
 ---
 
@@ -12,12 +13,10 @@ model that thinks in **steps to goals**. Every unit of work is defined by what
 must be accomplished and what completion looks like, not by how long someone
 guesses it will take.
 
-AI-human collaboration operates at a fundamentally different speed than
-traditional teams. When an AI agent executes implementation steps at 30x-100x
-the pace of manual development, duration-based planning becomes noise. Festival
-Methodology strips that noise out. What remains is a clean focus on logical
-steps, dependencies between those steps, opportunities for parallel execution,
-and unambiguous completion criteria.
+Festival focuses the execution plan on logical steps, dependencies,
+opportunities for parallel work, and verifiable completion criteria. Your
+team can still keep deadlines, ownership, and prioritization in its existing
+planning tools. See [using Festival with your issue tracker]({{< ref "/compare/festival-vs-issue-trackers" >}}).
 
 The result is a planning system that works for a solo developer driving an AI
 agent through a complex build, a team coordinating multi-phase projects, or an
@@ -31,7 +30,7 @@ AI agent operating autonomously across long-running sessions.
 2. **Human-AI Collaborative Planning** -- Humans provide goals, requirements, architectural decisions, and validation. AI agents identify steps, structure them, create task specifications, and execute autonomously.
 3. **Requirements-Driven Implementation** -- Implementation sequences can only be created after requirements are defined. No guessing. No premature coding.
 4. **Just-in-Time Sequence Creation** -- Sequences are designed when a phase is ready for execution, not months in advance. Plans stay grounded in current understanding.
-5. **Hyper-Efficient AI Execution** -- The methodology feeds work to AI agents in structured, unambiguous units that maximize autonomous execution at unprecedented speed.
+5. **Scoped Autonomous Execution** -- Agents receive defined tasks with relevant context and checks, so they can work independently within the approved scope.
 6. **Step-Based Progression** -- Progress is measured by completed steps with verified outcomes, not by hours logged or percentage-of-time-elapsed.
 7. **Context Preservation** -- Documentation is read just-in-time. Festival structure preserves context across sessions so agents resume work without re-reading the entire project history.
 8. **Quality Gates** -- Every implementation sequence ends with mandatory quality verification steps (testing, review, iteration). Quality is structural, not optional.
@@ -167,9 +166,9 @@ Festival Methodology is the right fit when:
 
 ## Key Advantages
 
-**No process overhead.** No mandatory ceremonies. No standups, no sprint
-planning, no retrospectives -- unless you decide they add value and create a
-ritual festival for them.
+**Choose your ceremonies.** Festival does not require standups, sprint planning,
+or retrospectives. If a recurring review is useful, you can capture it as a
+ritual festival.
 
 **Clear dependencies.** Sequential directory numbering makes dependencies obvious.
 `001_PLAN` completes before `002_IMPLEMENT`. `01_foundation` completes before

--- a/docs/methodology/why-festival.md
+++ b/docs/methodology/why-festival.md
@@ -1,83 +1,57 @@
 ---
 title: "Why Festival"
+description: "Hand goals to agents while you focus on other work. Festival keeps the plan, decisions, verification, and next steps available across sessions and projects."
 weight: 20
 ---
 
 # Why Festival
 
-## The Organization Problem
+**AI can generate the pieces. Festival keeps the work coherent.**
 
-If you work on more than a few things at once, staying organized becomes a job of
-its own.
+The useful moment is when you can hand off a goal and turn to something else. Your agent has enough direction to keep working, knows when to ask you, and leaves a result you can review.
 
-Work ends up spread across repositories, documents, chats, notes, bookmarks, TODO
-lists, and AI conversations. Finding where something belongs becomes work.
-Remembering what you were doing becomes work. Switching contexts becomes work. The
-effort you spend keeping track of work starts to rival the effort of doing it.
+Festival gives that work an operating environment: a place for its projects, plans, research, decisions, and progress. It stays with the work as the goal changes, through new sessions and new tools, over months or years.
 
-## AI Makes It Worse
+## Hand off the outcome, then review the result
 
-AI coding tools are genuinely fast. They write code, run research, draft plans, and
-break down tasks faster than most people can keep up with. That speed is real, and it
-is not the problem.
+You might ask for a feature across three repositories, an investigation into a recurring failure, or a recommendation backed by research. Your agent uses Festival to break the goal into steps, record completion criteria, and work through the plan.
 
-The problem is what happens to all of that output. AI generates plans, code,
-research, and tasks faster than you can file them. The bottleneck moves from
-producing work to organizing it. Every new session starts from nothing: no memory of
-the larger goal, no structure for multi-step work, no thread to pick back up. You
-spend your time re-explaining context that an organized workspace would make obvious.
+You review the scope and important decisions. After approval, the agent follows the `fest next` loop and performs the work with its own tools. While it runs, you can work on a different goal. At a gate or blocker, it brings the decision back to you.
 
-## Camps: A Workspace for a Mission
+A review has something concrete to inspect: what changed, which checks ran, what passed, what remains uncertain, and how those results relate to the goal.
 
-Festival is a workspace system built for that reality. It organizes work into
-camps.
+[Walk through your first handoff]({{< ref "/getting-started/quickstart" >}}).
 
-A camp, previously called a campaign, is a workspace for a mission: a high-level purpose like your startup, your
-job, or a hobby you keep coming back to. A mission is not a single task. It is a
-durable area of focus that grows over time, accumulating many projects, plans,
-documents, research, and decisions. A camp keeps all of that in one place, however
-large it gets and however long it runs.
+## Give each part of your work its own camp
 
-Instead of asking:
+You have different camps in life: your job, your side project, your hobbies. Each has its own context, and each may contain several projects.
 
-> "Where should this go?"
+A camp keeps the related repositories, notes, plans, and decisions together. That lets you move between areas of work without mixing their context. Within a camp, a festival records the plan for a particular goal.
 
-You put it in the camp it belongs to.
+You can use a camp before you need a large plan. Link your repositories, use `cgo` to move between them, and use worktrees when changes need separate working directories. After a merge, `camp fresh` handles the next branch cycle.
 
-Instead of asking:
+[See the everyday development workflow]({{< ref "/guides/everyday-development" >}}).
 
-> "What was I working on?"
+## Keep the reasoning with the work
 
-You resume the camp.
+A commit tells you what changed. The plan and task record explain what the change was intended to accomplish and how it was checked.
 
-Both humans and AI agents can enter a camp and immediately understand its
-structure, because every camp uses the same predictable layout. See
-[Camps]({{< ref "/methodology/campaigns" >}}) for the full directory model.
+Festival keeps those records in files you can read, diff, and version with Git. A later agent or human reviewer can inspect the decisions and continue from recorded progress. The quality of that handoff depends on recording what happened, including partial work and failed checks.
 
-## From Organization to Outcomes
+The files belong to the work. You can switch between Claude Code, Codex, Grok Build, Cursor, or another agent that can read them and run the CLI.
 
-Organization is the foundation, not the finish line. Once your work has a home,
-Festival gives every mission three things that turn structure into results:
+## Use the amount of structure the goal needs
 
-1. **Context** - a camp that holds all projects, docs, and research.
-2. **Direction** - structured plans that AI agents can execute, pause, and resume.
-3. **Verification** - work captured in reviewable files you can trace and audit.
+For a known sequence of steps, a standalone workflow can guide an agent through a recurring process. A festival adds a goal, phases, dependencies, and review gates when the work needs a fuller plan.
 
-The planning model that supplies direction and verification is the Festival
-Methodology. Read the [Methodology Overview]({{< ref "/methodology/overview" >}}) to
-see how phases, sequences, and tasks turn a goal into work an agent can keep moving
-through.
+The hierarchy forms a graph of work. `fest next` reads its state and supplies the next actionable step; the agent executes that step and records the result. For work across several projects, the agent can coordinate multiple loops and worktrees.
 
-## Built to Scale
+[Learn about loops and orchestration]({{< ref "/guides/loops-and-orchestration" >}}).
 
-This is not a system for one project. It is how the author of Festival manages 17
-camps and more than 150 projects without losing context between them.
+## Keep the tools you already use
 
-A camp can be a side project with two or three repos, or a mission spanning
-dozens of projects and hundreds of plans. The structure scales in both directions,
-and switching between missions is a single command.
+Your issue tracker can remain the place for team discussion and priorities. Your scripts and justfiles can bring external work into a camp and return a summary or link when it is ready for review.
 
-## Get Started
+Festival provides the local work structure. Your agent, services, and existing tools provide execution, access to external systems, and any scheduled triggers you choose to build.
 
-Create your first camp and run your first festival in about five minutes:
-[Quick Start]({{< ref "/getting-started/quickstart" >}}).
+[Find a use case]({{< ref "/use-cases" >}}), or [start with your own goal]({{< ref "/getting-started/quickstart" >}}).

--- a/docs/use-cases/_index.md
+++ b/docs/use-cases/_index.md
@@ -1,54 +1,53 @@
 ---
 title: "Use Cases"
-description: "Practical ways to use Festival for AI agent project management, long-running coding sessions, handoffs, and structured AI-assisted software work."
+description: "Use Festival for cross-repo development, long-running agent work, incident investigation, research, support escalation, and infrastructure changes."
 weight: 35
+hideChildList: true
 ---
 
-Festival is for AI-assisted software work that needs more structure than a chat thread, a task list, or a one-off prompt.
+Give your agent a goal you can review, then let it work while you focus elsewhere. Festival keeps the plan, decisions, checks, and progress together so the next session can continue the work.
 
-These pages describe the common situations where Festival helps: keeping agent sessions coherent, handing work between tools, tracking progress across repos, and turning broad goals into executable steps.
+Start with the kind of result you need.
 
 <div class="doc-index__list">
   <a class="doc-index__item" href="{{< ref "/use-cases/ai-agent-project-management" >}}">
-    <strong>AI Agent Project Management</strong>
-    <span>Plan, execute, and resume AI-assisted work without losing project state.</span>
+    <strong>Ship a change across repositories</strong>
+    <span>Coordinate implementation, tests, documentation, and review around one goal.</span>
   </a>
   <a class="doc-index__item" href="{{< ref "/use-cases/long-running-ai-coding-sessions" >}}">
-    <strong>Long-Running AI Coding Sessions</strong>
-    <span>Keep multi-day or multi-week coding work coherent across context windows.</span>
+    <strong>Keep long-running work moving</strong>
+    <span>Hand off execution and resume from the saved plan when a session ends.</span>
   </a>
-  <a class="doc-index__item" href="{{< ref "/use-cases/claude-code-project-management" >}}">
-    <strong>Claude Code Project Management</strong>
-    <span>Use Festival with Claude Code while keeping plans, tasks, and commits traceable.</span>
+  <a class="doc-index__item" href="{{< ref "/use-cases/incident-investigation" >}}">
+    <strong>Investigate an incident</strong>
+    <span>Build an evidence trail, test explanations, and turn findings into follow-up work.</span>
   </a>
-  <a class="doc-index__item" href="{{< ref "/use-cases/ai-agent-handoff" >}}">
-    <strong>AI Agent Handoff</strong>
-    <span>Let a new agent session pick up the next task without reconstructing the whole project.</span>
+  <a class="doc-index__item" href="{{< ref "/use-cases/research-and-analysis" >}}">
+    <strong>Research a decision or analyze data</strong>
+    <span>Keep sources, scripts, assumptions, and the recommendation in the same work record.</span>
+  </a>
+  <a class="doc-index__item" href="{{< ref "/use-cases/support-escalation" >}}">
+    <strong>Take a support case through to a fix</strong>
+    <span>Connect reproduction, investigation, implementation, and a reviewed response.</span>
+  </a>
+  <a class="doc-index__item" href="{{< ref "/use-cases/infrastructure-changes" >}}">
+    <strong>Plan infrastructure changes and recovery</strong>
+    <span>Keep the change plan, rehearsal, rollback criteria, and verification connected.</span>
   </a>
 </div>
 
-## When Festival Fits
+## Pick up work across sessions and tools
 
-Festival fits best when the work has more than one step and correctness depends on remembering decisions:
+[Agent handoff]({{< ref "/use-cases/ai-agent-handoff" >}}) covers what to save before a session ends and how the next agent resumes. For a Claude Code-specific path, see [Claude Code project management]({{< ref "/use-cases/claude-code-project-management" >}}).
 
-- a feature that touches multiple files or repos
-- a refactor that needs planning, staged execution, and verification
-- a launch checklist with docs, release, and follow-up tasks
-- a codebase cleanup that should not be rediscovered every session
-- a research or design effort that needs to become implementation work
+These are workflows you can build with Festival and your existing tools. The agent runs commands and calls external services through the access you provide. Festival records the plan and progress; monitoring, credentials, data access, and scheduling stay with your chosen tools.
 
-If the task is a single prompt or a quick edit, you may not need Festival. If the work will outlive one chat window, Festival gives it a durable home.
+## Get value from the camp every day
 
-## Start Here
+A camp is also useful for ordinary development: jump between repositories with `cgo`, give parallel changes separate worktrees, and prepare for the next branch after a merge with `camp fresh`.
 
-Install Festival, create a camp, then create your first festival:
+[Explore everyday development]({{< ref "/guides/everyday-development" >}}) and [the installer and plugin manager]({{< ref "/getting-started/festival-manager" >}}).
 
-```bash
-brew install --cask Obedience-Corp/tap/festival
-camp init my-project
-cd my-project
-fest create festival --name first-feature --type standard
-fest next
-```
+## Start with one outcome
 
-For the full path, read the [Quick Start]({{< ref "/getting-started/quickstart" >}}).
+Choose something whose result you can check. In the [Quick Start]({{< ref "/getting-started/quickstart" >}}), you create a camp, bring in a project, and give your agent a goal. It plans the work for your review before implementation starts.

--- a/docs/use-cases/ai-agent-handoff.md
+++ b/docs/use-cases/ai-agent-handoff.md
@@ -1,6 +1,6 @@
 ---
 title: "AI Agent Handoff"
-description: "Use Festival to hand off AI coding work between sessions, tools, and humans without losing plan context or next actions."
+description: "Hand off agent work with a recorded goal, decisions, checks, blockers, and next task so another session or reviewer can continue."
 weight: 38
 ---
 
@@ -33,14 +33,14 @@ Festival keeps handoff state in the workspace:
 - commits preserve traceability.
 - context notes capture decisions and open questions.
 
-The next agent can start with:
+From the active festival directory or a project linked to it, the next agent can start with:
 
 ```bash
 fest status
 fest next
 ```
 
-That is enough to understand where the work stands and what to do next.
+These commands provide the recorded status and next step. The agent still needs to read relevant project instructions, source files, and handoff notes before changing anything.
 
 ## What To Capture Before Ending A Session
 
@@ -54,7 +54,13 @@ Before stopping a long-running session, capture:
 - unresolved questions
 - the exact next task if it is not already represented
 
-Put that context in the festival files instead of only in chat. The next session can then resume without a verbal briefing.
+Put that context in the festival files, including failed checks and unfinished changes. A handoff is only as useful as the record left behind.
+
+{{< agent-prompt >}}
+Resume the festival at [path]. Read the goal, latest context notes, and project instructions, then run fest status and fest next from the festival directory.
+
+Check the working tree before making changes. Summarize the current step, completed checks, blockers, and any mismatch between the notes and the files. Continue only within the already-approved scope; ask before changing the plan or overwriting unfinished work.
+{{< /agent-prompt >}}
 
 ## Handoff Between Tools
 
@@ -86,4 +92,4 @@ Then make sure the task state matches reality:
 - record blockers in the task or context notes
 - commit finished work with `fest commit`
 
-Next: read [Agent Workflows]({{< ref "/guides/agent-workflows" >}}) and [Workflows & Gates]({{< ref "/methodology/workflows-and-gates" >}}).
+The reviewer should be able to connect each claimed result to a file, check, or commit. Read [Agent Workflows]({{< ref "/guides/agent-workflows" >}}) for the execution loop and [Workflows & Gates]({{< ref "/methodology/workflows-and-gates" >}}) for approval points.

--- a/docs/use-cases/ai-agent-project-management.md
+++ b/docs/use-cases/ai-agent-project-management.md
@@ -1,90 +1,72 @@
 ---
 title: "AI Agent Project Management"
-description: "Use Festival as a project management layer for AI agents: goals, phases, tasks, context, progress, and verification stored in your workspace."
+description: "Plan and review a cross-repository feature with an AI agent, a Festival work record, and clear human approval points."
 weight: 35
 ---
 
 # AI Agent Project Management
 
-AI agents can write code, investigate bugs, draft plans, and edit docs quickly. The hard part is keeping that work organized once it spans multiple sessions, repositories, decisions, and review steps.
+Use a festival when one outcome crosses more than one repository and needs a
+human-reviewed plan before implementation. An account-deletion flow, for
+example, can require an API change, a web interface, documentation, and a
+verification plan. Plan the repositories, their contract, the checks, and the
+decisions that need review before implementation.
 
-Festival is a project management layer for AI-assisted work. It does not replace your coding agent. It gives the agent a structured workspace it can read and update.
+Start with the [Quick Start]({{< ref "/getting-started/quickstart" >}}) to
+create a camp and bring the repositories into it. Keep each repository in its
+own project directory or worktree. The festival records the shared goal; it does
+not merge the repositories into one checkout.
 
-## The Problem
+## Give the agent an outcome it can plan
 
-Most AI coding work starts in a chat:
+State what should be true when the work is done, the repositories in scope, and
+the review boundary. This example asks for a plan first, rather than asking the
+agent to start changing code.
 
-1. Explain the goal.
-2. Add context about the repo.
-3. Ask for a plan.
-4. Execute part of the plan.
-5. Run out of context or stop for the day.
-6. Re-explain everything in the next session.
+{{< agent-prompt >}}
+In this camp, plan a cross-repository feature: [outcome]. The affected projects
+are [API project], [web project], and [other project or docs location]. Success
+means [observable behavior and verification evidence].
 
-That loop breaks down on real projects. The agent forgets prior decisions, duplicates work, misses verification steps, or implements an old version of the plan.
+Read the camp instructions and inspect the relevant code, tests, interfaces, and
+existing documentation. Create a Festival plan that identifies work by project,
+the API or data contract between projects, migration or compatibility concerns,
+test and documentation changes, and unresolved decisions. Link the festival to
+the primary implementation project or worktree, and identify the working
+directory for each remaining project.
 
-## The Festival Model
+Do not change source code, deploy, contact anyone, or create external tickets.
+Stop after presenting the plan, risks, and verification approach for my review.
+{{< /agent-prompt >}}
 
-Festival turns project work into a filesystem-backed plan:
+The agent can use `fest intro` and `fest understand` while planning. A standard
+festival gives the planning work a place to record findings, decisions, phases,
+and tasks. The plan should make dependency order visible. For instance, an API
+contract decision may need approval before a web task can safely start.
 
-- **Camps** hold related repos, docs, plans, and research.
-- **Festivals** define a goal and the work needed to reach it.
-- **Phases** group work by stage, such as ingest, plan, implement, review, or release.
-- **Sequences** group related tasks.
-- **Tasks** describe executable units of work with acceptance criteria and verification.
+## Review the plan before the changes
 
-The agent does not need a database or proprietary integration. It needs shell access and file access.
+Review the goal against the plan, then check three practical points:
 
-## The Agent Loop
+- Every repository has a named responsibility, rather than a vague "update
+  clients" task.
+- The plan names compatibility, migration, privacy, or rollout questions that
+  could change the implementation.
+- Each implementation task has evidence to produce: tests, a manual check,
+  documentation review, or another agreed check.
 
-The core loop is intentionally small:
+Ask for revisions while the work is still a plan. Once it is approved, tell the
+agent which project or worktree to use first. It should run `fest next` from the
+active festival or from its linked project or worktree. The task output supplies
+the next planned step; it is not a reason to scan every repository or invent a
+new order of work.
 
-```bash
-fest next
-# agent reads the task, edits files, runs checks
-fest task completed
-fest commit -m "implement feature step"
-fest next
-```
+As work reaches another repository, the agent changes to the directory named by
+the plan and performs the scoped task there. Keep review points for contract
+changes and live-system decisions. A festival can record the implementation and
+verification trail, while your repository hosting, deployment tooling, and
+access controls continue to govern code review, releases, and credentials.
 
-`fest next` gives the agent the next incomplete task with surrounding context. `fest status` and `fest progress` show what is done, what is in flight, and what remains.
-
-## Why This Is Different From a Task List
-
-A normal task list says what should happen. Festival also captures the structure around why it should happen and how to verify it:
-
-- the overall goal
-- phase context
-- task acceptance criteria
-- quality gates
-- command-line workflow
-- commit traceability
-- handoff notes and status
-
-That extra structure matters when a different AI session, a different model, or a human reviewer picks up the work later.
-
-## Good Fits
-
-Use Festival for:
-
-- multi-step coding tasks
-- cross-repository changes
-- refactors with staged verification
-- launch readiness work
-- documentation and release workflows
-- agent-led cleanup efforts
-- human-reviewed implementation plans
-
-Do not reach for Festival for every tiny edit. It is most useful when work has enough shape that losing context would be expensive.
-
-## Start With a Camp
-
-```bash
-camp init my-product
-cd my-product
-camp project add https://github.com/you/api
-fest create festival --name auth-system --type standard
-fest next
-```
-
-Next: follow the [Quick Start]({{< ref "/getting-started/quickstart" >}}) or read [Agent Workflows]({{< ref "/guides/agent-workflows" >}}).
+For task execution after approval, see [Agent Workflows]({{< ref
+"/guides/agent-workflows" >}}). For parallel changes in one repository, see
+[Everyday Development]({{< ref "/guides/everyday-development" >}}).

--- a/docs/use-cases/claude-code-project-management.md
+++ b/docs/use-cases/claude-code-project-management.md
@@ -19,17 +19,17 @@ Festival helps Claude Code sessions answer four questions quickly:
 - What is the next task?
 - How do we know this task is complete?
 
-Without that structure, each new session has to infer the plan from files, commits, and conversation history. That is slow and error-prone.
+Keep those answers in the work record so a later session can check them against the repository and continue the approved plan.
 
 ## Add Festival To The Session Instructions
 
-In a repo that uses Festival, tell Claude Code to start with the Festival loop:
+Follow the [Claude Code setup guide]({{< ref "/getting-started/agents/claude-code" >}}) first. In a repo with an approved festival, give the agent its location and operating boundaries:
 
-```text
-Run fest intro on first contact. Use fest next to get the next task.
-Follow the task acceptance criteria. When complete, run the requested checks,
-mark the task completed, and commit with fest commit.
-```
+{{< agent-prompt >}}
+Work on the approved festival at [path]. Run fest intro on first contact. From that festival or its linked project, use fest next to get the next task.
+
+Read the referenced files and follow the acceptance criteria. Run the requested checks, record their results, and mark only finished tasks complete. Use fest commit for scoped festival changes. Stop at approval gates or when continuing needs new access, spending, deployment, or a change in scope.
+{{< /agent-prompt >}}
 
 That instruction gives the agent a repeatable operating model.
 
@@ -55,17 +55,17 @@ Festival commits tie changes back to the plan, which makes review and status tra
 
 ## Recommended Claude Code Flow
 
-1. Start the session in the camp or project workspace.
+1. Start the session in the active festival directory or its linked project.
 2. Run `fest intro` if this is the first Festival session.
 3. Run `fest next`.
-4. Let Claude Code execute the task.
+4. Let Claude Code execute the approved task while you focus on other work.
 5. Run the task's validation commands.
 6. Mark the task complete.
 7. Commit with `fest commit`.
-8. Run `fest next` again.
+8. Run `fest next` again, stopping at approval gates and recording blockers when work cannot continue.
 
 ## Use Festival With Other Agents Too
 
-This pattern is not Claude-specific. Festival works with any agent that can run shell commands and read files. That makes it useful when you switch between Claude Code, Codex, OpenCode, Crush, Cursor Agents, or custom automation.
+This pattern is not Claude-specific. Festival works with agents that can run shell commands and read files, including Grok build, Codex, OpenCode, Crush, Cursor Agents, and custom automation. Each tool still has its own permissions, runtime, and session limits. Festival keeps the work record available across those sessions; it does not host the agent process.
 
 Next: read [Agent Workflows]({{< ref "/guides/agent-workflows" >}}) or start with the [Quick Start]({{< ref "/getting-started/quickstart" >}}).

--- a/docs/use-cases/incident-investigation.md
+++ b/docs/use-cases/incident-investigation.md
@@ -1,0 +1,38 @@
+---
+title: "Incident Investigation with Festival"
+linkTitle: "Incident Investigation"
+description: "Turn an incident record into a reviewed timeline, evidence-backed findings, and a postmortem with owned follow-up work."
+weight: 40
+---
+
+# Incident Investigation with Festival
+
+An incident investigation often begins with fragments: an alert summary, a few log exports, a support report, and several people remembering the same hour differently. The useful outcome is a reviewable record of what happened, what the evidence supports, what remains uncertain, and which follow-up work is approved.
+
+## From fragments to a postmortem
+
+Create a research festival when the investigation needs several passes. Put the incident brief, approved exports, relevant code or configuration, and the review criteria in the camp. The agent can then:
+
+1. build a dated timeline and identify gaps
+2. separate observations from hypotheses
+3. run a reproduction or a safe fixture test when one is available
+4. compare mitigation and remediation options
+5. draft a postmortem and turn accepted actions into follow-up work
+
+The camp gives the investigation a durable home. A new session can pick up the next documented step instead of reconstructing the case from chat.
+
+{{< agent-prompt >}}
+In [project or camp path], investigate [incident or failure] using only the approved evidence in [paths or exports].
+
+Produce a dated timeline, evidence table, competing cause hypotheses, reproduction or validation steps, and a postmortem draft. Mark every inference and unresolved question. Propose follow-up tasks with owners and verification criteria, but do not change production systems or contact anyone.
+
+Stop for human review before publishing the postmortem, accepting a root-cause claim, or creating work outside the approved scope.
+{{< /agent-prompt >}}
+
+## What the reviewer checks
+
+Review the timeline against source timestamps, the difference between cause and correlation, the quality of any reproduction, and whether the proposed actions address the failure rather than its symptoms. The postmortem should also state what the evidence cannot establish. Link accepted remediation to the team’s issue tracker if that is where ownership and discussion belong. Festival remains the execution record; see [using Festival with your issue tracker]({{< ref "/compare/festival-vs-issue-trackers" >}}).
+
+## Boundaries
+
+Alerting, logs, traces, paging, retention, redaction, and ticketing remain the responsibility of the systems that provide them. Festival does not monitor services, page responders, schedule investigations, or provide a secrets vault. The agent may inspect files and run approved local checks or scripts. A human controls access to sensitive evidence, production changes, severity decisions, external communications, and final approval. Start with the [Quick Start]({{< ref "/getting-started/quickstart" >}}) to set those permissions before the work begins.

--- a/docs/use-cases/infrastructure-changes.md
+++ b/docs/use-cases/infrastructure-changes.md
@@ -1,0 +1,30 @@
+---
+title: "Infrastructure Changes and Recovery Rehearsals"
+linkTitle: "Infrastructure Changes"
+description: "Plan infrastructure changes with explicit checks, rollback steps, and recovery rehearsal evidence before a human approves execution."
+weight: 43
+---
+
+# Infrastructure Changes and Recovery Rehearsals
+
+Infrastructure work is easier to review when the change, the checks, and the recovery path live together. Festival gives an agent a durable plan for a migration, configuration change, dependency update, or recovery rehearsal, while the operator keeps control of live systems.
+
+## Before, during, and after
+
+Start with a clear outcome and an inventory of the systems in scope. A festival can separate preparation, implementation, verification, and review into phases. A recurring rehearsal can use a ritual festival or a standalone workflow when its steps are known and linear.
+
+Before execution, capture the current state, dependencies, expected signals, approval point, and rollback trigger. During the work, the agent can update checklists, edit infrastructure files, run validation in an approved environment, and record evidence. Afterward, it can compare expected and observed results, document gaps, and prepare the next rehearsal.
+
+{{< agent-prompt >}}
+In [camp or project path], plan [infrastructure change or recovery rehearsal] for [approved environment].
+
+Produce a change plan, dependency and risk list, pre-change checks, verification checks, explicit rollback steps, and a recovery rehearsal record. Use only the configuration, fixtures, and access described in [approved paths]. Stop at the human approval gate before any live change. If a check fails, record the evidence and return to the rollback or remediation step.
+{{< /agent-prompt >}}
+
+## The review gate
+
+The operator reviews the blast radius, maintenance window, backup or restore evidence, rollback feasibility, and success criteria. A second reviewer can inspect the plan and rehearsal output before execution. Keep the final decision and observed results in the festival, then link any durable operational follow-up to the team’s issue tracker. The [Quick Start]({{< ref "/getting-started/quickstart" >}}) shows how to hand off a goal and stop at approval points. [Loops & Orchestration]({{< ref "/guides/loops-and-orchestration" >}}) explains when a festival phase workflow is preferable to a simpler workflow.
+
+## External systems remain external
+
+Cloud consoles, deployment systems, monitoring, alerting, backups, secrets, access control, and scheduling are provided and operated outside Festival. Festival does not watch infrastructure, run cron jobs, store credentials, or guarantee a safe change. The agent may work on approved files and non-production environments, or inspect operator-provided exports. A human controls production access, approval, rollback, incident communications, and the decision to continue. Keep the scope narrow enough that the checks and recovery path can be inspected before execution.

--- a/docs/use-cases/long-running-ai-coding-sessions.md
+++ b/docs/use-cases/long-running-ai-coding-sessions.md
@@ -1,95 +1,74 @@
 ---
 title: "Long-Running AI Coding Sessions"
-description: "Use Festival to keep long-running AI coding sessions coherent across context windows, interruptions, handoffs, and verification steps."
+description: "Hand off a multi-session goal to an AI agent, review durable progress, and resume work from the saved Festival record."
 weight: 36
 ---
 
 # Long-Running AI Coding Sessions
 
-AI coding agents are strongest when the next step is clear. They are weakest when every session starts by rediscovering the project, reconstructing the plan, and guessing what already happened.
+Some goals take several sessions: refactors, release preparation, or features
+that need review. Hand the agent a bounded
+piece of the goal, return to your other work, then review or resume from the
+written record. Festival keeps that record in the camp. It does not run agents,
+schedule work, or control permissions.
 
-Festival is designed for coding work that lasts longer than one prompt or one chat window.
+Begin with the [Quick Start]({{< ref "/getting-started/quickstart" >}}) to
+create the camp, set up the agent, and review a festival plan.
 
-## Why Long-Running Sessions Fail
+## Make a handoff that can survive a pause
 
-Long-running AI-assisted work usually fails for practical reasons:
+After you approve the plan, tell the agent to work from the festival's linked
+project or worktree, follow the next recorded task, and stop at a human decision
+or authority boundary.
 
-- the plan lives in chat history instead of the repo
-- the next task is ambiguous
-- acceptance criteria are missing
-- prior decisions are not written down
-- verification commands are forgotten
-- commits are not tied back to the plan
-- a new agent session has to rebuild context from scratch
+{{< agent-prompt >}}
+Work on the approved festival for [goal] from its linked project or worktree.
+Start by reading the current festival state and run `fest next` to get the next
+task. Complete only work covered by the task and its acceptance criteria. Run
+the planned checks, record results and blockers in the festival, and use the
+project's review and commit process.
 
-The result is friction. The agent spends too much time orienting and too little time executing.
+Stop and ask me before a scope change, a destructive action, an external
+message, a production change, or any approval gate. At the end of this session,
+leave the task state accurate so another session can continue.
+{{< /agent-prompt >}}
 
-## Festival Stores the Work Where Agents Can Read It
+You can leave the agent to work within that boundary, then review when it
+returns with a completed task, a failed check, or a question. The runtime that
+hosts the agent decides how long it runs and which commands, repositories,
+networks, or credentials it can access. Festival records the work and supplies
+the next task, but it does not grant access or keep work running after the agent
+session ends.
 
-Festival keeps work state in files:
+## Resume the goal, not the old conversation
 
-```text
-festivals/
-  active/
-    release-readiness-RR0001/
-      FESTIVAL_GOAL.md
-      FESTIVAL_OVERVIEW.md
-      TODO.md
-      001_INGEST/
-      002_PLAN/
-      003_IMPLEMENT/
-```
-
-That structure survives tool changes, session resets, model changes, and context limits.
-
-## Resume With One Command
-
-When a session starts, the agent can run:
+Open the active festival or its linked project or worktree and review the state:
 
 ```bash
+fest status
 fest next
 ```
 
-The response tells it what to do next and includes the context needed to start. The agent does not need to load the whole workspace or ask the human to summarize everything again.
+`fest next` is context-aware in an active festival and its linked working
+directory. It returns the next planned task after the earlier task state has
+been recorded. If the agent stopped partway through a task, inspect the task,
+the changed files, the check output, and any context notes before deciding
+whether to continue, revise the plan, or mark a blocker.
 
-## Keep Verification Attached To The Work
+The durable record includes the festival goal, phase and task files, decisions,
+verification evidence, and `FESTIVAL_TODO.md`. Keep open questions and failed
+checks there or in the relevant task instead of relying on chat history. A new
+agent session can then work from the same evidence without inheriting the old
+conversation.
 
-Long-running work needs more than a checklist. Each task can specify:
+## Review at meaningful boundaries
 
-- files to inspect or modify
-- acceptance criteria
-- commands to run
-- expected outputs
-- review notes
-- cleanup requirements
+Review after a planned phase, a risky change, or a result that changes the
+original decision. Compare the work against the approved outcome and acceptance
+criteria, inspect the verification evidence, and decide whether to approve the
+next phase. If the goal no longer makes sense, stop or revise the festival
+instead of asking the agent to continue on an obsolete plan.
 
-That makes the final work easier to review because the task and the commit history tell the same story.
-
-## Example Workflow
-
-```bash
-fest create festival --name docs-launch --type standard
-fest validate
-fest next
-
-# agent works the current task
-just docs build
-fest task completed
-fest commit -m "add launch docs"
-
-fest next
-```
-
-When you stop, the state is still in the festival. When you return, `fest next` resumes the loop.
-
-## When To Use This Pattern
-
-Use Festival when the work has:
-
-- more than one meaningful step
-- multiple files or repos
-- a plan that may change
-- verification requirements
-- a handoff between sessions, humans, or tools
-
-For the complete loop, read [Agent Workflows]({{< ref "/guides/agent-workflows" >}}).
+[Agent Workflows]({{< ref "/guides/agent-workflows" >}}) explains the task
+loop. [AI Agent Handoff]({{< ref "/use-cases/ai-agent-handoff" >}}) covers
+what to capture when a person or tool changes mid-goal.

--- a/docs/use-cases/research-and-analysis.md
+++ b/docs/use-cases/research-and-analysis.md
@@ -1,0 +1,36 @@
+---
+title: "Recurring Research and Analysis"
+linkTitle: "Research and Analysis"
+description: "Make recurring research reproducible with dated sources, scripts, review checkpoints, and a durable record of conclusions."
+weight: 41
+---
+
+# Recurring Research and Analysis
+
+Research becomes expensive when every run starts with a blank document. A useful analysis leaves behind the sources, extraction steps, scripts, assumptions, and limits that let someone else inspect the conclusion later.
+
+## A repeatable research desk
+
+Use a research festival for an investigation that needs framing, source collection, analysis, and synthesis. Use a standalone `WORKFLOW.md` when the process is known, fixed, and linear, such as a weekly source review or a release-readiness sweep. Each tracked run can keep its own progress history. The process still needs a person or an external scheduler to start it.
+
+Give the agent a question, a cutoff date, a source policy, and an output format. Ask it to save source URLs or file paths with access dates, preserve raw inputs where permitted, and keep analysis scripts next to the result. A strong deliverable includes:
+
+- the question and decision it informs
+- a dated source list with citations
+- a reproducible script or command sequence
+- tables or findings with assumptions shown
+- limitations, negative findings, and the next decision
+
+{{< agent-prompt >}}
+In [camp or project path], answer [research question] for the decision [decision to inform]. Use sources dated through [cutoff date] and save the source list, citations, scripts, and generated outputs in [approved paths].
+
+Do not invent missing values. Record conflicting evidence, sampling limits, and any step that could not be reproduced. Produce a concise findings memo and a review checklist. Stop before publishing the memo or changing the decision record.
+{{< /agent-prompt >}}
+
+## Review the method, not only the result
+
+The reviewer checks whether the sources answer the stated question, whether the script actually produced the tables, whether dates and versions are recorded, and whether the conclusion outruns the evidence. A failed or inconclusive run is still useful when the reason is captured. The [Agent Workflows]({{< ref "/guides/agent-workflows" >}}) guide explains the file-based handoff, while [Loops & Orchestration]({{< ref "/guides/loops-and-orchestration" >}}) covers choosing a workflow, festival, or work-item queue.
+
+## External tools and permission boundaries
+
+Browsers, databases, APIs, credentials, rate limits, data licensing, and scheduled execution belong to the tools and operators that provide them. Festival does not fetch data on a timer, guarantee deterministic outputs, or grant access to private systems. The agent can run approved scripts against supplied or explicitly authorized inputs. A human approves source use, sensitive-data handling, interpretation, and publication. Keep personal and confidential data to the minimum needed for the question.

--- a/docs/use-cases/support-escalation.md
+++ b/docs/use-cases/support-escalation.md
@@ -1,0 +1,36 @@
+---
+title: "Support Escalation to a Reproducible Fix"
+linkTitle: "Support Escalation"
+description: "Move a difficult support case from intake to a reproducible bug, reviewed fix, or approved customer response."
+weight: 42
+---
+
+# Support Escalation to a Reproducible Fix
+
+A hard support case needs more than a reply draft. The team needs to know what the customer saw, whether the behavior can be reproduced, which version is affected, and what can safely be promised next.
+
+## The handoff
+
+Keep the support system as the intake and customer-facing record. When a case needs engineering work, create a Festival plan with a redacted case summary, reproduction inputs, affected versions, and the desired outcome. The agent can turn that material into a short chain of evidence:
+
+| Stage | Result to review |
+| --- | --- |
+| Triage | Reproduction question, scope, and missing facts |
+| Reproduce | A fixture, test case, or documented inability to reproduce |
+| Diagnose | Evidence, suspected change, and competing explanations |
+| Fix or explain | Patch and checks, workaround, or a clear reason no fix is proposed |
+| Respond | A customer-safe draft with known limits and next action |
+
+{{< agent-prompt >}}
+In [camp or project path], investigate support case [redacted case ID] using the supplied reproduction details in [approved paths].
+
+Determine whether the behavior can be reproduced without customer credentials or production data. If it can, propose the smallest fix and verification checks. If it cannot, document what was tried and what evidence is missing. Draft an accurate reply for human approval. Do not send the reply, change customer data, promise a date, or expand the scope without asking.
+{{< /agent-prompt >}}
+
+## What the team reviews
+
+The support lead reviews the redaction and the customer wording. The engineer reviews the reproduction, test coverage, compatibility impact, and rollback or workaround. The product owner decides whether the issue becomes a backlog item, a festival, or a documented limitation. If the team uses GitHub Issues, Linear, or Jira, keep that system for prioritization and discussion, then link the resulting work back to the execution plan. [Using Festival with your issue tracker]({{< ref "/compare/festival-vs-issue-trackers" >}}) describes that division.
+
+## Keep the boundary clear
+
+The agent works from approved files, fixtures, and repositories. It can inspect code, run local tests, and prepare a patch or reply draft. It does not own the helpdesk, CRM, outbound messaging, refunds, account changes, or production access. Those systems, credentials, customer identity checks, and notification policies remain external responsibilities. A human approves any customer-facing statement and any action that affects a live account. Use the [Quick Start]({{< ref "/getting-started/quickstart" >}}) to establish the review points before handing over the case.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -2,11 +2,12 @@ baseURL: https://docs.fest.build
 title: Festival
 theme: festival
 contentDir: docs
+enableRobotsTXT: true
 
 googleAnalytics: G-BBJ8SY37X5
 
 params:
-  description: "Mission-based AI workspace management for developers using AI coding tools"
+  description: "Plan, run, and review long-running agent work with Festival. Keep projects, decisions, workflows, and progress together in files you own."
   repo: "https://github.com/Obedience-Corp/festival"
 
 markup:
@@ -27,50 +28,34 @@ menu:
     - name: Getting Started
       identifier: getting-started
       weight: 10
-    - name: Installation
-      parent: getting-started
-      url: /getting-started/installation/
-      weight: 11
     - name: Quick Start
       parent: getting-started
       url: /getting-started/quickstart/
-      weight: 12
-    - name: Shell Setup
+      weight: 11
+    - name: Why Festival
       parent: getting-started
-      url: /getting-started/shell-setup/
+      url: /methodology/why-festival/
+      weight: 12
+    - name: Installation
+      parent: getting-started
+      url: /getting-started/installation/
       weight: 13
+    - name: Installer & Plugins
+      parent: getting-started
+      url: /getting-started/festival-manager/
+      weight: 14
     - name: Set up with your agent
       parent: getting-started
       url: /getting-started/agents/
-      weight: 14
-    - name: Claude Code
-      parent: getting-started
-      url: /getting-started/agents/claude-code/
       weight: 15
-    - name: Codex
+    - name: Everyday Development
       parent: getting-started
-      url: /getting-started/agents/codex/
+      url: /guides/everyday-development/
       weight: 16
-    - name: Cursor
+    - name: Shell Setup
       parent: getting-started
-      url: /getting-started/agents/cursor/
+      url: /getting-started/shell-setup/
       weight: 17
-    - name: Gemini CLI
-      parent: getting-started
-      url: /getting-started/agents/gemini/
-      weight: 18
-    - name: Hermes Agent
-      parent: getting-started
-      url: /getting-started/agents/hermes/
-      weight: 19
-    - name: opencode
-      parent: getting-started
-      url: /getting-started/agents/opencode/
-      weight: 20
-    - name: Other agents
-      parent: getting-started
-      url: /getting-started/agents/other-agents/
-      weight: 21
     - name: Videos
       parent: getting-started
       url: /videos/
@@ -82,10 +67,6 @@ menu:
 
     - name: Methodology
       identifier: methodology
-      weight: 20
-    - name: Why Festival
-      parent: methodology
-      url: /methodology/why-festival/
       weight: 20
     - name: Overview
       parent: methodology
@@ -142,7 +123,11 @@ menu:
 
     - name: Use Cases
       identifier: use-cases
-      weight: 35
+      weight: 18
+    - name: Find Your Use Case
+      parent: use-cases
+      url: /use-cases/
+      weight: 30
     - name: AI Agent Project Management
       parent: use-cases
       url: /use-cases/ai-agent-project-management/
@@ -159,11 +144,27 @@ menu:
       parent: use-cases
       url: /use-cases/ai-agent-handoff/
       weight: 38
+    - name: Incident Investigation
+      parent: use-cases
+      url: /use-cases/incident-investigation/
+      weight: 39
+    - name: Research & Analysis
+      parent: use-cases
+      url: /use-cases/research-and-analysis/
+      weight: 40
+    - name: Support Escalation
+      parent: use-cases
+      url: /use-cases/support-escalation/
+      weight: 41
+    - name: Infrastructure & Recovery
+      parent: use-cases
+      url: /use-cases/infrastructure-changes/
+      weight: 42
 
     - name: Compare
       identifier: compare
       weight: 39
-    - name: Festival vs Issue Trackers
+    - name: Festival & Issue Trackers
       parent: compare
       url: /compare/festival-vs-issue-trackers/
       weight: 39

--- a/scripts/test_docs_discovery.mjs
+++ b/scripts/test_docs_discovery.mjs
@@ -1,0 +1,259 @@
+// Run after a production Hugo and Pagefind build:
+// DOCS_SITE_DIR=/path/to/build node --test scripts/test_docs_discovery.mjs
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import test from 'node:test';
+
+const site = resolve(process.env.DOCS_SITE_DIR || 'public');
+const origin = 'https://docs.fest.build';
+
+const newRoutes = [
+  '/getting-started/festival-manager/',
+  '/guides/everyday-development/',
+  '/use-cases/incident-investigation/',
+  '/use-cases/research-and-analysis/',
+  '/use-cases/support-escalation/',
+  '/use-cases/infrastructure-changes/',
+];
+const useCaseRoutes = newRoutes.filter((route) => route.startsWith('/use-cases/'));
+const changedAuthoredRoutes = [
+  ...newRoutes,
+  '/use-cases/ai-agent-project-management/',
+  '/use-cases/long-running-ai-coding-sessions/',
+  '/use-cases/claude-code-project-management/',
+  '/use-cases/ai-agent-handoff/',
+  '/methodology/why-festival/',
+  '/methodology/overview/',
+  '/guides/agent-workflows/',
+  '/compare/festival-vs-issue-trackers/',
+];
+const agentHubRoute = '/getting-started/agents/';
+const cliRoute = '/cli-reference/fest/fest_next/';
+const socialImageURL = 'https://fest.build/opengraph-image';
+
+function outputPath(route) {
+  const relative = route.replace(/^\/+/, '');
+  if (!relative) return resolve(site, 'index.html');
+  return resolve(site, relative, 'index.html');
+}
+
+function page(route) {
+  const path = outputPath(route);
+  assert.ok(existsSync(path), `missing built page: ${route}`);
+  return readFileSync(path, 'utf8');
+}
+
+function firstMatch(html, pattern, label) {
+  const match = html.match(pattern);
+  assert.ok(match, `missing ${label}`);
+  return match[1];
+}
+
+function attribute(html, name, value) {
+  return firstMatch(
+    html,
+    new RegExp(`<meta\\s+${name}="${value}"\\s+content="([^"]*)"`, 'i'),
+    `${name}=${value}`,
+  );
+}
+
+function pageMetadata(html, route) {
+  const title = firstMatch(html, /<title>([\s\S]*?)<\/title>/i, `title for ${route}`);
+  const description = attribute(html, 'name', 'description');
+  const canonical = firstMatch(
+    html,
+    /<link\s+rel="canonical"\s+href="([^"]+)"/i,
+    `canonical for ${route}`,
+  );
+  const ogTitle = attribute(html, 'property', 'og:title');
+  const ogDescription = attribute(html, 'property', 'og:description');
+  const ogURL = attribute(html, 'property', 'og:url');
+  const ogImage = attribute(html, 'property', 'og:image');
+  return { title, description, canonical, ogTitle, ogDescription, ogURL, ogImage };
+}
+
+function typeIncludes(value, expected) {
+  return Array.isArray(value) ? value.includes(expected) : value === expected;
+}
+
+function jsonldGraph(html, route) {
+  const scripts = [...html.matchAll(
+    /<script\s+type="application\/ld\+json">([\s\S]*?)<\/script>/gi,
+  )];
+  assert.ok(scripts.length > 0, `missing JSON-LD for ${route}`);
+
+  const schemas = scripts.map((match) => {
+    try {
+      return JSON.parse(match[1]);
+    } catch (error) {
+      assert.fail(`invalid JSON-LD for ${route}: ${error.message}`);
+    }
+  });
+  return schemas.flatMap((schema) => (
+    Array.isArray(schema['@graph']) ? schema['@graph'] : [schema]
+  ));
+}
+
+function assertBreadcrumbs(html, route) {
+  const graph = jsonldGraph(html, route);
+  const breadcrumb = graph.find((schema) => typeIncludes(schema['@type'], 'BreadcrumbList'));
+  assert.ok(breadcrumb, `missing BreadcrumbList for ${route}`);
+  assert.ok(Array.isArray(breadcrumb.itemListElement), `breadcrumb items missing for ${route}`);
+  assert.ok(breadcrumb.itemListElement.length > 0, `breadcrumb list empty for ${route}`);
+
+  breadcrumb.itemListElement.forEach((item, index) => {
+    assert.equal(item.position, index + 1, `breadcrumb position ${index + 1} invalid for ${route}`);
+    assert.ok(item.name, `breadcrumb name ${index + 1} missing for ${route}`);
+    assert.match(item.item, /^https:\/\/docs\.fest\.build\//, `breadcrumb URL ${index + 1} invalid for ${route}`);
+  });
+}
+
+function assertLocalReferences(html, route) {
+  const pageURL = new URL(`${origin}${route}`);
+  for (const match of html.matchAll(/\s(?:href|src)="([^"]+)"/gi)) {
+    const reference = match[1].replaceAll('&amp;', '&');
+    if (reference.startsWith('data:') || reference.startsWith('javascript:')) continue;
+
+    let url;
+    try {
+      url = new URL(reference, pageURL);
+    } catch {
+      assert.fail(`invalid URL in ${route}: ${reference}`);
+    }
+    if (url.origin !== origin || !['http:', 'https:'].includes(url.protocol)) continue;
+
+    const pathname = decodeURIComponent(url.pathname);
+    let target = resolve(site, pathname.replace(/^\/+/, ''));
+    if (pathname.endsWith('/')) target = resolve(target, 'index.html');
+    assert.ok(existsSync(target), `missing local reference from ${route}: ${reference}`);
+
+    if (url.hash && statSync(target).isFile() && target.endsWith('.html')) {
+      const targetHTML = readFileSync(target, 'utf8');
+      const fragment = decodeURIComponent(url.hash.slice(1));
+      assert.match(
+        targetHTML,
+        new RegExp(`(?:id|name)="${fragment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"`),
+        `missing anchor from ${route}: ${reference}`,
+      );
+    }
+  }
+}
+
+test('production build contains the six new guide and use-case routes', () => {
+  for (const route of newRoutes) page(route);
+});
+
+test('new authored pages have unique metadata and self-canonical HTTPS URLs', () => {
+  const metadata = changedAuthoredRoutes.map((route) => pageMetadata(page(route), route));
+  const titles = new Set();
+  const descriptions = new Set();
+
+  metadata.forEach((meta, index) => {
+    const route = changedAuthoredRoutes[index];
+    assert.ok(meta.title.trim(), `empty title for ${route}`);
+    assert.ok(meta.description.trim(), `empty description for ${route}`);
+    titles.add(meta.title);
+    descriptions.add(meta.description);
+    assert.equal(meta.canonical, `${origin}${route}`);
+    assert.equal(meta.ogTitle, meta.title, `OG title mismatch for ${route}`);
+    assert.equal(meta.ogDescription, meta.description, `OG description mismatch for ${route}`);
+    assert.equal(meta.ogURL, meta.canonical, `OG URL mismatch for ${route}`);
+    assert.equal(meta.ogImage, socialImageURL, `OG image mismatch for ${route}`);
+    assert.doesNotMatch(page(route), /<meta\s+name="robots"\s+content="noindex, nofollow"/i);
+  });
+
+  assert.equal(titles.size, changedAuthoredRoutes.length, 'changed authored pages must have unique titles');
+  assert.equal(descriptions.size, changedAuthoredRoutes.length, 'changed authored pages must have unique descriptions');
+});
+
+test('authored pages and a generated CLI page have one H1 and valid breadcrumb JSON-LD', () => {
+  for (const route of [...changedAuthoredRoutes, cliRoute]) {
+    const html = page(route);
+    assert.equal((html.match(/<h1\b[^>]*>/gi) || []).length, 1, `expected one H1 for ${route}`);
+    assertBreadcrumbs(html, route);
+  }
+
+  // The home page has valid JSON-LD but no breadcrumb list because it is the root.
+  const home = page('/');
+  assert.equal((home.match(/<h1\b[^>]*>/gi) || []).length, 1, 'expected one H1 for home');
+  assert.ok(jsonldGraph(home, '/').length > 0, 'missing JSON-LD for home');
+});
+
+test('use-case pages include the generated Quick Start CTA', () => {
+  for (const route of useCaseRoutes) {
+    const html = page(route);
+    const cta = firstMatch(
+      html,
+      /(<aside[^>]+aria-label="Try Festival"[\s\S]*?<\/aside>)/i,
+      `CTA aside for ${route}`,
+    );
+    assert.match(cta, /href="\/getting-started\/quickstart\/"/i, `missing Quick Start CTA link for ${route}`);
+  }
+});
+
+test('documentation menu exposes new routes and the agent hub exposes deep setup guides', () => {
+  const menuHTML = page(newRoutes[0]);
+  for (const route of newRoutes) assert.match(menuHTML, new RegExp(route.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+
+  const agentHub = page(agentHubRoute);
+  const agentHubURL = new URL(`${origin}${agentHubRoute}`);
+  const agentLinks = [...agentHub.matchAll(/\s(?:href)="([^"]+)"/gi)].map((match) => match[1]);
+  for (const slug of ['claude-code', 'codex', 'cursor', 'gemini', 'hermes', 'opencode', 'other-agents']) {
+    const expectedPath = new URL(`${slug}/`, agentHubURL).pathname;
+    assert.ok(
+      agentLinks.some((href) => new URL(href, agentHubURL).pathname === expectedPath),
+      `missing deep agent link: ${slug}`,
+    );
+  }
+});
+
+test('curated hubs do not append duplicate automatic child lists', () => {
+  for (const route of ['/getting-started/', '/use-cases/', agentHubRoute]) {
+    assert.doesNotMatch(page(route), /<div style="margin-bottom: 0\.5rem;">/i, `automatic child list leaked into ${route}`);
+  }
+});
+
+test('Pagefind indexes main content and not the body element', () => {
+  for (const route of ['/', ...newRoutes, cliRoute]) {
+    const html = page(route);
+    assert.equal((html.match(/<main\b[^>]*data-pagefind-body[^>]*>/gi) || []).length, 1, `missing Pagefind main marker for ${route}`);
+    assert.doesNotMatch(html, /<body\b[^>]*data-pagefind-body/i, `Pagefind marker moved to body for ${route}`);
+  }
+});
+
+test('production robots and sitemap permit crawling', () => {
+  const robots = readFileSync(resolve(site, 'robots.txt'), 'utf8');
+  assert.match(robots, /^User-agent:\s*\*\s*$/m);
+  assert.match(robots, /^Allow:\s*\/\s*$/m);
+  assert.match(robots, /^Sitemap:\s*https:\/\/docs\.fest\.build\/sitemap\.xml\s*$/m);
+  const sitemap = readFileSync(resolve(site, 'sitemap.xml'), 'utf8');
+  assert.match(sitemap, /<urlset[\s>]/i);
+  assert.match(sitemap, /<loc>https:\/\/docs\.fest\.build\//i);
+  for (const route of newRoutes) {
+    const expected = `${origin}${route}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    assert.match(sitemap, new RegExp(`<loc>${expected}</loc>`));
+  }
+});
+
+test('touched pages have resolvable local links, assets, and anchors', () => {
+  const routes = [
+    '/',
+    '/getting-started/',
+    agentHubRoute,
+    '/use-cases/',
+    ...changedAuthoredRoutes,
+    cliRoute,
+  ];
+  for (const route of routes) assertLocalReferences(page(route), route);
+});
+
+test('local preview disables indexing and production analytics', { skip: !process.env.DOCS_PREVIEW_DIR }, () => {
+  const preview = resolve(process.env.DOCS_PREVIEW_DIR);
+  for (const route of ['/', '/use-cases/', '/getting-started/festival-manager/']) {
+    const html = readFileSync(resolve(preview, route.replace(/^\/+/, ''), 'index.html'), 'utf8');
+    assert.match(html, /<meta name="robots" content="noindex, nofollow">/);
+    assert.doesNotMatch(html, /googletagmanager\.com|gtag\('config'/);
+  }
+  assert.match(readFileSync(resolve(preview, 'robots.txt'), 'utf8'), /^Disallow:\s*\/\s*$/m);
+});

--- a/themes/festival/assets/css/main.css
+++ b/themes/festival/assets/css/main.css
@@ -128,6 +128,56 @@ a:hover {
 }
 
 /* Layout */
+.skip-link {
+  position: fixed;
+  top: 0.5rem;
+  left: 1rem;
+  z-index: 200;
+  padding: 0.65rem 1rem;
+  border-radius: 6px;
+  background: #f2721c;
+  color: #17100a !important;
+  transform: translateY(-180%);
+}
+
+.skip-link:focus { transform: translateY(0); }
+
+:where(a, button, summary, input):focus-visible {
+  outline: 2px solid #f2721c;
+  outline-offset: 3px;
+}
+
+.doc-breadcrumbs {
+  margin: 0 0 1.3rem;
+  font-size: 0.8rem;
+  color: var(--festival-500);
+}
+
+.doc-breadcrumbs ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.6rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.doc-breadcrumbs li { margin: 0; }
+.doc-breadcrumbs li + li::before { content: "/"; margin-right: 0.6rem; }
+
+.doc-next-step {
+  margin-top: 2.5rem;
+  padding: 1.5rem;
+  border: 1px solid var(--festival-200);
+  border-radius: 12px;
+  background: var(--surface-raised);
+}
+
+[data-theme="dark"] .doc-next-step { border-color: var(--festival-800); }
+.doc-next-step__title { font-weight: 600; }
+.doc-next-step p { margin: 0 0 0.75rem; }
+.doc-next-step .btn { margin-top: 0.25rem; white-space: normal; }
+
 .site-header {
   position: fixed;
   top: 0;
@@ -432,6 +482,12 @@ a:hover {
 
 [data-theme="dark"] .doc-index__item strong {
   color: var(--festival-100);
+}
+
+[data-theme="dark"] .doc-index__item span,
+[data-theme="dark"] .doc-index__featured p,
+[data-theme="dark"] .doc-index__intro p {
+  color: var(--festival-400);
 }
 
 [data-theme="dark"] .doc-index__item:hover {
@@ -1566,6 +1622,12 @@ summary {
   opacity: 0.7;
 }
 
+.home-install__note a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
 .home-install .home-section__heading,
 .home-install .home-section__lede {
   color: inherit;
@@ -1745,6 +1807,19 @@ summary {
   max-height: 70vh;
   overflow-y: auto;
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+
+.search-close {
+  display: block;
+  margin: 0 0 0.75rem auto;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid var(--festival-400);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
 }
 
 [data-theme="dark"] .search-modal {

--- a/themes/festival/layouts/_default/baseof.html
+++ b/themes/festival/layouts/_default/baseof.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
-  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Site.Params.description }}{{ end }}">
+  {{ partial "seo.html" . }}
   {{ $css := resources.Get "css/main.css" | minify | fingerprint }}
   <link rel="stylesheet" href="{{ $css.RelPermalink }}">
   <link href="{{ "pagefind/pagefind-ui.css" | relURL }}" rel="stylesheet">
-  {{ template "_internal/google_analytics.html" . }}
+  {{ if eq hugo.Environment "production" }}{{ template "_internal/google_analytics.html" . }}{{ end }}
 </head>
 <body class="{{ if .IsHome }}site-body--home{{ else }}site-body--docs{{ end }}">
+  <a class="skip-link" href="#main-content">Skip to content</a>
   {{ partial "header.html" . }}
 
   <div class="sidebar-overlay" onclick="toggleSidebar()"></div>
@@ -20,7 +20,7 @@
       {{ partial "sidebar.html" . }}
     {{ end }}
 
-    <main class="content-area{{ if .IsHome }} content-area--home{{ else if .TableOfContents }} content-area--with-toc{{ end }}">
+    <main id="main-content" tabindex="-1" data-pagefind-body class="content-area{{ if .IsHome }} content-area--home{{ else if .TableOfContents }} content-area--with-toc{{ end }}">
       <div class="content">
         {{ block "main" . }}{{ end }}
       </div>
@@ -148,12 +148,37 @@
   });
 
   // Mobile sidebar
-  function toggleSidebar() {
+  function setSidebarOpen(open) {
     var sidebar = document.querySelector('.sidebar');
     var overlay = document.querySelector('.sidebar-overlay');
-    if (sidebar) sidebar.classList.toggle('open');
-    if (overlay) overlay.classList.toggle('open');
+    var button = document.querySelector('.sidebar-toggle');
+    if (!sidebar) return;
+    sidebar.classList.toggle('open', open);
+    sidebar.inert = window.matchMedia('(max-width: 768px)').matches && !open;
+    if (overlay) overlay.classList.toggle('open', open);
+    if (button) button.setAttribute('aria-expanded', String(open));
   }
+
+  function toggleSidebar() {
+    var sidebar = document.querySelector('.sidebar');
+    if (sidebar) setSidebarOpen(!sidebar.classList.contains('open'));
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    setSidebarOpen(false);
+    var sidebar = document.querySelector('.sidebar');
+    if (!sidebar) return;
+    sidebar.querySelectorAll('a').forEach(function(link) {
+      link.addEventListener('click', function() { setSidebarOpen(false); });
+    });
+    window.matchMedia('(max-width: 768px)').addEventListener('change', function() { setSidebarOpen(false); });
+    document.addEventListener('keydown', function(event) {
+      if (event.key === 'Escape' && sidebar.classList.contains('open')) {
+        setSidebarOpen(false);
+        document.querySelector('.sidebar-toggle').focus();
+      }
+    });
+  });
 
   function syncHeaderState() {
     var header = document.querySelector('.site-header--home');
@@ -300,15 +325,32 @@
       showImages: false
     });
 
+    var searchOpener = null;
+
     function openSearch() {
+      if (overlay.classList.contains('open')) return;
+      searchOpener = document.activeElement;
       overlay.classList.add('open');
       var input = overlay.querySelector('.pagefind-ui__search-input');
       if (input) setTimeout(function() { input.focus(); }, 50);
     }
 
     function closeSearch() {
+      if (!overlay.classList.contains('open')) return;
       overlay.classList.remove('open');
+      if (searchOpener && searchOpener.isConnected) searchOpener.focus();
     }
+
+    overlay.querySelector('.search-close').addEventListener('click', closeSearch);
+
+    overlay.addEventListener('keydown', function(e) {
+      if (e.key !== 'Tab') return;
+      var controls = Array.from(overlay.querySelectorAll('a[href], button, input, [tabindex="0"]')).filter(function(el) { return !el.disabled && el.getClientRects().length; });
+      var first = controls[0];
+      var last = controls[controls.length - 1];
+      if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+      else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+    });
 
     document.querySelectorAll('.search-trigger').forEach(function(btn) {
       btn.addEventListener('click', openSearch);
@@ -329,7 +371,8 @@
   </script>
 
   <div id="search-overlay" class="search-overlay">
-    <div class="search-modal">
+    <div class="search-modal" role="dialog" aria-modal="true" aria-label="Search documentation">
+      <button type="button" class="search-close">Close search</button>
       <div id="search-container"></div>
     </div>
   </div>

--- a/themes/festival/layouts/_default/list.html
+++ b/themes/festival/layouts/_default/list.html
@@ -1,6 +1,7 @@
 {{ define "main" }}
   {{ $isCliLeaf := and (strings.HasPrefix .RelPermalink "/cli-reference/") (ne .RelPermalink "/cli-reference/") }}
   <article>
+    {{ partial "breadcrumbs.html" . }}
     <h1>{{ .Title }}</h1>
     {{ .Content }}
 
@@ -28,7 +29,7 @@
           </div>
         </section>
       {{ end }}
-    {{ else }}
+    {{ else if not .Params.hideChildList }}
       {{ range .Pages }}
         <div style="margin-bottom: 0.5rem;">
           <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>

--- a/themes/festival/layouts/_default/single.html
+++ b/themes/festival/layouts/_default/single.html
@@ -1,5 +1,3 @@
 {{ define "main" }}
-  <article>
-    {{ .Content }}
-  </article>
+  {{ partial "doc-article.html" . }}
 {{ end }}

--- a/themes/festival/layouts/index.html
+++ b/themes/festival/layouts/index.html
@@ -21,7 +21,7 @@
       <div class="home-hero__stats">
         <div class="home-stat">
           <div class="home-stat__value">Multi-project</div>
-          <div class="home-stat__label">Build anything at any scale</div>
+          <div class="home-stat__label">Related repos and work in one camp</div>
         </div>
         <div class="home-stat">
           <div class="home-stat__value">Loops</div>
@@ -53,15 +53,15 @@
   <section class="home-section" id="how-it-works">
     <div class="home-section__intro">
       <h2 class="home-section__heading home-section__heading--centered">How it works</h2>
-      <p class="home-section__lede">Toolsuite made for human AI collaboration at any scale.</p>
+      <p class="home-section__lede">Create a camp, hand off a goal, and review the work as it progresses.</p>
     </div>
 
     <div class="howto">
       <div class="howto__row">
         <div class="howto__copy">
           <div class="howto__meta"><span class="howto__num">01</span><span class="howto__label">Set up</span></div>
-          <h3>Create your workspace</h3>
-          <p>One command scaffolds a campaign that holds every project, plan, and doc in one place. Add your repositories, create your first festival, and the workspace is ready. That is the whole setup.</p>
+          <h3>Create a camp for your work</h3>
+          <p>A camp holds the projects, plans, and context for one part of your life: a job, a side project, or a hobby. Create the camp, add your repositories, and give your agent a place to keep the work.</p>
           {{ with site.GetPage "/getting-started/quickstart" }}
             <a href="{{ .RelPermalink }}#create-a-camp" class="howto__link">Create your camp &rarr;</a>
           {{ end }}
@@ -81,7 +81,7 @@
         <div class="howto__copy">
           <div class="howto__meta"><span class="howto__num">02</span><span class="howto__label">Delegate</span></div>
           <h3>Describe the work to your agent</h3>
-          <p>Open your agent of choice, Claude Code, Codex, or Grok, and describe what you want in a sentence. It creates the design, scaffolds a festival, and plans the whole thing out into phases, sequences, and tasks. You do not touch the <code>fest</code> CLI.</p>
+          <p>Open your agent of choice, such as Claude Code, Codex, or Grok build. Describe the outcome and ask it to prepare a Festival plan. Review the scope and checkpoints before execution. Your agent handles the <code>fest</code> commands.</p>
           {{ with site.GetPage "/getting-started/quickstart" }}
             <a href="{{ .RelPermalink }}#hand-off-a-goal" class="howto__link">Try your first handoff &rarr;</a>
           {{ end }}
@@ -122,8 +122,8 @@
           <div class="howto__meta"><span class="howto__num">04</span><span class="howto__label">Track</span></div>
           <h3>Track everything in one place</h3>
           <p>Every festival, intent, design, and project across the campaign in one dashboard. Run many in parallel with different agents, and switch between them without losing the thread.</p>
-          {{ with site.GetPage "/getting-started/quickstart" }}
-            <a href="{{ .RelPermalink }}" class="howto__link">Quick start &rarr;</a>
+          {{ with site.GetPage "/guides/everyday-development" }}
+            <a href="{{ .RelPermalink }}" class="howto__link">Navigate your daily work &rarr;</a>
           {{ end }}
         </div>
         <div class="howto__visual">
@@ -154,7 +154,7 @@
           </div>
           <img src="/images/demos/cgo-navigation.gif" class="terminal-demo__gif" alt="cgo jumping between projects, festivals, and design directories, plus csw to switch campaigns" loading="lazy">
         </div>
-        <figcaption class="demo-gallery__caption">Jump anywhere in the workspace</figcaption>
+        <figcaption class="demo-gallery__caption"><a href="/guides/everyday-development/">Navigate projects with cgo</a></figcaption>
       </figure>
 
       <figure class="demo-gallery__item">
@@ -249,31 +249,29 @@
 
   <section class="home-section home-section--problem">
     <div class="home-section__intro">
-      <h2 class="home-section__heading home-section__heading--centered">Festival is for AI-assisted work that has to stay coherent for months or years</h2>
+      <h2 class="home-section__heading home-section__heading--centered">An operating environment for the life of the work</h2>
       <p class="home-section__lede">
-        Not one prompt. Not one chat. Not one coding session. Long-running work has changing
-        goals, decisions, artifacts, reviews, next actions, and context. AI can generate pieces
-        of the work, but it does not preserve the structure needed to finish the whole thing.
-        Festival keeps that structure intact.
+        Goals evolve over months and years. Keep the plans, decisions, research, and progress
+        with the work itself, so agents and people can return to it, understand it, and continue.
       </p>
     </div>
 
     <div class="cards cards--problem">
       <div class="card">
-        <div class="card__title">Ambitious builds fall apart without a plan</div>
-        <div class="card__description">Festival breaks complex goals into phases, sequences, and tasks. Every step is structured and scoped for AI execution.</div>
+        <div class="card__title">A goal becomes a plan</div>
+        <div class="card__description">Phases, sequences, and tasks turn a goal into a graph of work, with dependencies and checks attached.</div>
       </div>
       <div class="card">
-        <div class="card__title">Multi-project coordination is chaos</div>
-        <div class="card__description">Campaigns give you one workspace for all your repos, docs, and plans. cgo navigates instantly. Nothing bleeds between projects.</div>
+        <div class="card__title">Context stays with the camp</div>
+        <div class="card__description">Related repositories, research, and decisions share a home. Separate camps keep different parts of your life distinct.</div>
       </div>
       <div class="card">
-        <div class="card__title">Agents lose context between sessions</div>
-        <div class="card__description">All state lives in the filesystem. fest next gives any agent the full picture, any time, no re-explaining.</div>
+        <div class="card__title">Sessions can pick up the work</div>
+        <div class="card__description">Saved plans and progress give the next agent a starting point. fest next provides the next step and its planning context.</div>
       </div>
       <div class="card">
-        <div class="card__title">Scaling past one feature at a time</div>
-        <div class="card__description">Run multiple festivals in parallel across projects. Track progress, enforce quality gates, and ship at scale.</div>
+        <div class="card__title">You have room for other work</div>
+        <div class="card__description">Let agents execute approved work in separate festivals and worktrees. Return for decisions, review, and the results.</div>
       </div>
     </div>
   </section>
@@ -290,7 +288,6 @@
       <a href="/getting-started/agents/hermes/">Hermes</a>
       <a href="/getting-started/agents/other-agents/#aider">Aider</a>
       <a href="/getting-started/agents/cursor/">Cursor Agents</a>
-      <a href="/getting-started/agents/gemini/">Gemini CLI</a>
       <a href="/getting-started/agents/other-agents/#custom-tooling">Custom tooling</a>
     </div>
     <p class="home-tools__note">Any agent that can run shell commands and read files.</p>
@@ -298,40 +295,40 @@
 
   <section class="home-section home-section--next-steps">
     <div class="home-section__intro">
-      <h2 class="home-section__heading home-section__heading--centered">Use Festival where AI work loses context</h2>
+      <h2 class="home-section__heading home-section__heading--centered">Start with work you need to finish</h2>
       <p class="home-section__lede">
-        Start with the workflow problem you are trying to solve, then move into the installation
-        and command reference once the fit is clear.
+        A cross-repo feature, an investigation, a recurring analysis, or a difficult support
+        case. See what the agent can prepare and what you should review.
       </p>
     </div>
 
     <div class="cards">
       {{ with site.GetPage "/use-cases/ai-agent-project-management" }}
         <a href="{{ .RelPermalink }}" class="card">
-          <div class="card__title">AI agent project management</div>
-          <div class="card__description">Give agents goals, phases, tasks, status, and verification they can read from the workspace.</div>
+          <div class="card__title">Deliver a cross-repo change</div>
+          <div class="card__description">Keep the API, client, tests, and release checks connected to the same goal.</div>
           <span class="card__arrow">Read the use case &rarr;</span>
         </a>
       {{ end }}
-      {{ with site.GetPage "/use-cases/long-running-ai-coding-sessions" }}
+      {{ with site.GetPage "/use-cases/incident-investigation" }}
         <a href="{{ .RelPermalink }}" class="card">
-          <div class="card__title">Long-running AI coding sessions</div>
-          <div class="card__description">Keep multi-day or multi-week implementation work coherent across context windows and interruptions.</div>
+          <div class="card__title">Investigate an incident</div>
+          <div class="card__description">Build a timeline, test explanations, and prepare a postmortem with evidence.</div>
           <span class="card__arrow">Read the use case &rarr;</span>
         </a>
       {{ end }}
-      {{ with site.GetPage "/use-cases/ai-agent-handoff" }}
+      {{ with site.GetPage "/use-cases/research-and-analysis" }}
         <a href="{{ .RelPermalink }}" class="card">
-          <div class="card__title">AI agent handoff</div>
-          <div class="card__description">Let a new agent, model, or human reviewer resume from the actual next step.</div>
+          <div class="card__title">Make research repeatable</div>
+          <div class="card__description">Keep sources, scripts, assumptions, and findings together for the next review.</div>
           <span class="card__arrow">Read the use case &rarr;</span>
         </a>
       {{ end }}
-      {{ with site.GetPage "/compare/festival-vs-issue-trackers" }}
+      {{ with site.GetPage "/use-cases" }}
         <a href="{{ .RelPermalink }}" class="card">
-          <div class="card__title">Festival vs issue trackers</div>
-          <div class="card__description">Use backlog tools for team coordination and Festival for executable AI work plans.</div>
-          <span class="card__arrow">Compare the workflow &rarr;</span>
+          <div class="card__title">Find your use case</div>
+          <div class="card__description">Explore support, infrastructure, long-running work, and handoffs between agents.</div>
+          <span class="card__arrow">Browse the use cases &rarr;</span>
         </a>
       {{ end }}
     </div>
@@ -339,7 +336,7 @@
 
   <section class="home-section home-section--install">
     <div class="home-install home-install--center">
-      <h2 class="home-section__heading">Structure the ambition. Let AI ship it.</h2>
+      <h2 class="home-section__heading">Give your next goal a place to run.</h2>
       <div class="home-install__terminals">
         <div class="home-install__terminal">
           <span class="home-install__prompt">$</span>
@@ -358,7 +355,7 @@
           <a href="{{ .RelPermalink }}" class="btn btn--ghost-light">Quick Start Guide</a>
         {{ end }}
       </div>
-      <p class="home-install__note">Free to use. Works in 30 seconds.</p>
+      <p class="home-install__note">Free to use. Manage the suite and discover plugins with the <a href="/getting-started/festival-manager/">festival installer</a>.</p>
     </div>
   </section>
 </div>

--- a/themes/festival/layouts/page/single.html
+++ b/themes/festival/layouts/page/single.html
@@ -1,5 +1,3 @@
 {{ define "main" }}
-  <article>
-    {{ .Content }}
-  </article>
+  {{ partial "doc-article.html" . }}
 {{ end }}

--- a/themes/festival/layouts/partials/breadcrumbs.html
+++ b/themes/festival/layouts/partials/breadcrumbs.html
@@ -1,0 +1,8 @@
+<nav class="doc-breadcrumbs" aria-label="Breadcrumb" data-pagefind-ignore>
+  <ol>
+    {{ range .Ancestors.Reverse }}
+      <li><a href="{{ .RelPermalink }}">{{ if .IsHome }}Docs{{ else }}{{ .LinkTitle }}{{ end }}</a></li>
+    {{ end }}
+    <li aria-current="page">{{ .LinkTitle }}</li>
+  </ol>
+</nav>

--- a/themes/festival/layouts/partials/doc-article.html
+++ b/themes/festival/layouts/partials/doc-article.html
@@ -1,0 +1,12 @@
+<article>
+  {{ partial "breadcrumbs.html" . }}
+  {{ if not (findRE `<h1[\s>]` .Content) }}<h1>{{ .Title }}</h1>{{ end }}
+  {{ .Content }}
+  {{ if eq .Section "use-cases" }}
+  <aside class="doc-next-step" aria-label="Try Festival" data-pagefind-ignore>
+    <p class="doc-next-step__title">Try it with a goal from your own work</p>
+    <p>Create a camp, hand the goal to your agent, and review the plan before it starts.</p>
+    <a class="btn btn--primary" href="{{ (site.GetPage "/getting-started/quickstart").RelPermalink }}">Follow the Quick Start &rarr;</a>
+  </aside>
+  {{ end }}
+</article>

--- a/themes/festival/layouts/partials/header.html
+++ b/themes/festival/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <header class="site-header{{ if .IsHome }} site-header--home{{ end }}">
-  <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation">☰</button>
+  {{ if not .IsHome }}<button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle navigation" aria-controls="docs-navigation" aria-expanded="false">☰</button>{{ end }}
   <a href="{{ site.Home.RelPermalink }}" class="site-header__logo">
     <svg width="24" height="24" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
       <path style="fill:#F2721C" d="M434.512,310.732c-0.576-8.797-10.02-14.111-17.838-10.034c-6.798,3.547-28.117,12.749-44.912,12.749c-12.919,0-21.522-4.273-21.522-25.127c0-57.17,76.778-102.84,8.317-188.418c-7.853-9.813-23.683-2.694-21.581,9.677c0.043,0.258,4.034,26.153-8.07,40.489c-5.678,6.723-14.283,9.992-26.305,9.992c-41.638,0-38.739-104.87,13.766-137.424c11.674-7.237,4.206-25.335-9.134-22.295c-3.364,0.76-82.898,19.608-125.445,102.855c-31.593,61.81-14.482,104.442-1.988,135.572c11.166,27.819,16.261,40.516-8.747,57.83c-9.419,6.523-16.71,5.847-16.71,5.847c-23.391,0-45.548-34.384-52.105-47.617c-5.326-10.821-21.537-8.126-23.075,3.838c-0.66,5.144-15.433,126.793,49.127,200.177c35.57,40.429,85.057,54.811,139.297,53.008c50.141-1.68,90.152-18.638,118.923-50.402C439.86,402.546,434.755,314.451,434.512,310.732z"/>
@@ -15,6 +15,9 @@
   <nav class="site-header__nav">
     {{ with site.GetPage "/getting-started/quickstart" }}
       <a href="{{ .RelPermalink }}" class="site-header__link">Docs</a>
+    {{ end }}
+    {{ with site.GetPage "/use-cases" }}
+      <a href="{{ .RelPermalink }}" class="site-header__link site-header__link--desktop">Use Cases</a>
     {{ end }}
     {{ with site.GetPage "/getting-started/installation" }}
       <a href="{{ .RelPermalink }}" class="site-header__link site-header__link--desktop">Install</a>

--- a/themes/festival/layouts/partials/seo.html
+++ b/themes/festival/layouts/partials/seo.html
@@ -1,0 +1,34 @@
+{{- $title := printf "%s | Festival Docs" .Title -}}
+{{- if .IsHome }}{{ $title = "Festival Docs | Plan, run, and review agent work" }}{{ end -}}
+{{- $description := .Description -}}
+{{- if not $description -}}
+  {{- $description = .Summary | plainify | htmlUnescape | replaceRE `\s+` " " | strings.TrimSpace | truncate 160 -}}
+{{- end -}}
+{{- if not $description }}{{ $description = .Site.Params.description }}{{ end -}}
+<title>{{ $title }}</title>
+<meta name="description" content="{{ $description }}">
+<link rel="canonical" href="{{ .Permalink }}">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Festival Docs">
+<meta property="og:title" content="{{ $title }}">
+<meta property="og:description" content="{{ $description }}">
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:image" content="https://fest.build/opengraph-image">
+<meta property="og:image:alt" content="Festival flame logo. AI can generate the pieces. Festival keeps the work coherent.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ $title }}">
+<meta name="twitter:description" content="{{ $description }}">
+<meta name="twitter:image" content="https://fest.build/opengraph-image">
+{{ if ne hugo.Environment "production" }}<meta name="robots" content="noindex, nofollow">{{ end }}
+{{- $schema := slice (dict "@type" "WebPage" "@id" .Permalink "url" .Permalink "name" $title "description" $description "isPartOf" (dict "@type" "WebSite" "name" "Festival Docs" "url" site.Home.Permalink)) -}}
+{{- if not .IsHome -}}
+  {{- $items := slice -}}
+  {{- range .Ancestors.Reverse -}}
+    {{- $name := .LinkTitle -}}
+    {{- if .IsHome }}{{ $name = "Docs" }}{{ end -}}
+    {{- $items = $items | append (dict "@type" "ListItem" "position" (add (len $items) 1) "name" $name "item" .Permalink) -}}
+  {{- end -}}
+  {{- $items = $items | append (dict "@type" "ListItem" "position" (add (len $items) 1) "name" .LinkTitle "item" .Permalink) -}}
+  {{- $schema = $schema | append (dict "@type" "BreadcrumbList" "itemListElement" $items) -}}
+{{- end -}}
+<script type="application/ld+json">{{ dict "@context" "https://schema.org" "@graph" $schema | jsonify | safeJS }}</script>

--- a/themes/festival/layouts/partials/sidebar.html
+++ b/themes/festival/layouts/partials/sidebar.html
@@ -2,7 +2,7 @@
 {{ with .CurrentSection }}
   {{ $sidebarScope = .RelPermalink }}
 {{ end }}
-<nav class="sidebar" data-sidebar-scope="{{ $sidebarScope }}">
+<nav id="docs-navigation" class="sidebar" aria-label="Documentation" data-sidebar-scope="{{ $sidebarScope }}">
   {{ $currentURL := .RelPermalink }}
   {{ range .Site.Menus.docs }}
     {{ if .HasChildren }}
@@ -10,9 +10,9 @@
         <div class="sidebar__section-title">{{ .Name }}</div>
         {{ range .Children }}
           {{ $href := .URL | relURL }}
-          {{ $isActive := or (eq $currentURL $href) (and (ne $href "/" ) (strings.HasPrefix $currentURL $href)) }}
+          {{ $isActive := eq $currentURL $href }}
           <a href="{{ $href }}"
-             class="sidebar__link{{ if $isActive }} sidebar__link--active{{ end }}">
+             class="sidebar__link{{ if $isActive }} sidebar__link--active{{ end }}"{{ if $isActive }} aria-current="page"{{ end }}>
             {{ .Name }}
           </a>
         {{ end }}

--- a/themes/festival/layouts/robots.txt
+++ b/themes/festival/layouts/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+{{ if eq hugo.Environment "production" -}}
+Allow: /
+Sitemap: {{ "sitemap.xml" | absURL }}
+{{ else -}}
+Disallow: /
+{{ end -}}


### PR DESCRIPTION
## Summary

Follow-up to merged #178. Help developers recognize where Festival fits, then reach the agent-first Quick Start.

- Add everyday development guidance for `cgo`, camp switching, worktrees, and the post-merge `camp fresh` cycle.
- Explain the `festival` installer, suite updates, launchpad, executable CLI plugins, and their distinction from agent integrations.
- Add incident investigation, research/analysis, support escalation, and infrastructure/recovery use cases with example goals and review boundaries.
- Rewrite overlapping existing use cases and Why Festival around autonomous handoffs, durable work context, and reviewable outcomes. Explain how Festival complements an issue tracker through user-owned scripts and tools.
- Preserve existing URLs, flame branding, gradient, landing composition, and recordings. Improve entry-point links without replacing the landing page.
- Add self-canonicals, page-specific descriptions, social metadata, breadcrumb JSON-LD, and article-focused Pagefind indexing. Remove duplicate hub lists and add missing article H1s.
- Improve mobile navigation state, focus handling, search dismissal, and dark card contrast. Disable analytics/indexing in development previews; production analytics remains unchanged.

## Verification

- Production and development Hugo builds passed (520 build entries).
- Pagefind 1.5.2 indexed 503 HTML pages.
- All 17 onboarding/discovery regression checks passed, including links/fragments, metadata, schemas, menus, recordings, and preview isolation.
- PinchTab desktop/mobile review: use-case cards, incident prompt wrapping, suite/developer guides, sidebar keyboard and inert state, search results and focus return, Quick Start reduced-motion posters, and browser errors.
- No horizontal overflow on checked routes at 390, 1440, and 1920px. Full-monitor check at 1920px was DOM-based because some browser captures clipped the surface; complete visual capture was checked at 1440px.
- `git diff --check` passed.

Run against separately built production and development output:

```bash
DOCS_SITE_DIR=/path/to/production \
DOCS_PREVIEW_DIR=/path/to/development \
node --test scripts/test_docs_onboarding.mjs scripts/test_docs_discovery.mjs
```

## Notes

- Social cards reuse `https://fest.build/opengraph-image`, served by the separate frontend deployment. Verified HTTP 200, image/png, and the current flame/brand copy.
- The use cases describe work done by an agent with approved external tools. They do not claim native monitoring, scheduling, tracker synchronization, or unattended production authority.
- Removed unsupported speed/completeness claims. No conversion or ranking result is claimed.
- No generated CLI references, global installs, live systems, new tracking, or deployment configuration were changed. This PR does not publish or merge the site.
